### PR TITLE
 store s3 user-defined metadata

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -437,7 +437,7 @@ get_object_metadata(BucketName, Key, Options, Config) ->
      {version_id, proplists:get_value("x-amz-version-id", Headers, "false")}|extract_metadata(Headers)].
 
 extract_metadata(Headers) ->
-    [{Key, Value} || {["x-amz-meta-"|Key], Value} <- Headers].
+    [{Key, Value} || {Key = "x-amz-meta-" ++ _, Value} <- Headers].
 
 -spec get_object_torrent(string(), string()) -> proplist().
 


### PR DESCRIPTION
Request 

``` erlang
> erlcloud_s3:put_object("bucket", "key", "value", [{meta, [{"meta-key", "value"}]}]).
```

creates header pair `erlang {["x-amz-meta-",109,101,116,97,45,107,101,121],"value"}` instead of `erlang {{"x-amz-meta-meta-key"},"value"}`
