### PR TITLE
fix crash on erlcloud_ec2:describe_instance_attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ _build
 ebin/*.beam
 ebin/*.app
 .eunit/
+rebar
+*.sublime-*
 deps/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 REBAR=$(shell which rebar || echo ./rebar)
 
+all: get-deps compile
+
 get-deps:
 	@$(REBAR) get-deps
-
-all: compile
 
 clean:
 	@$(REBAR) clean


### PR DESCRIPTION
fix crash on erlcloud_ec2:describe_instance_attribute if attribute is not defined.
