### PR TITLE
Add UTF-8 support by using Erlang's unicode application

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -83,7 +83,7 @@ aws_request2(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Config0
                 httpc:request(Req);
             _ ->
                 httpc:request(Method,
-                              {lists:flatten(URL), [], "application/x-www-form-urlencoded",
+                              {lists:flatten(URL), [], "application/x-www-form-urlencoded; charset=utf-8",
                                list_to_binary(Query)}, [], [])
         end,
 

--- a/src/erlcloud_http.erl
+++ b/src/erlcloud_http.erl
@@ -8,7 +8,7 @@ make_query_string(Params) ->
 value_to_string(Integer) when is_integer(Integer) -> integer_to_list(Integer);
 value_to_string(Atom) when is_atom(Atom) -> atom_to_list(Atom);
 value_to_string(Binary) when is_binary(Binary) -> Binary;
-value_to_string(String) when is_list(String) -> String.
+value_to_string(String) when is_list(String) -> unicode:characters_to_binary(String).
 
 url_encode(Binary) when is_binary(Binary) ->
     url_encode(binary_to_list(Binary));


### PR DESCRIPTION
This patch fixes an error triggered when erlcloud encodes Unicode strings with multibyte characters (the example string here contains a fleuron, if for some reason you get a box instead):

```
(app@127.0.0.1)1> erlcloud_sdb:put_attributes("test_domain", "test", [{"test", "fleuron: ❦"}]).
** exception error: no function clause matching erlcloud_http:url_encode([10086],"02%A3%noruelf") (src/erlcloud_http.erl, line 17)
     in function  erlcloud_http:'-make_query_string/1-lc$^0/1-0-'/1 (src/erlcloud_http.erl, line 5)
     in call from erlcloud_http:'-make_query_string/1-lc$^0/1-0-'/1 (src/erlcloud_http.erl, line 6)
     in call from erlcloud_http:make_query_string/1 (src/erlcloud_http.erl, line 5)
     in call from erlcloud_aws:aws_request2/7 (src/erlcloud_aws.erl, line 62)
     in call from erlcloud_aws:aws_request/7 (src/erlcloud_aws.erl, line 38)
     in call from erlcloud_aws:aws_request_xml/5 (src/erlcloud_aws.erl, line 11)
     in call from erlcloud_sdb:sdb_request/3 (src/erlcloud_sdb.erl, line 258)
```

This patch resolves the error:

```
(app@127.0.0.1)1> erlcloud_sdb:put_attributes("test_domain", "test", [{"test", "fleuron: ❦"}]).
[{box_usage,2.19909e-5}]
```

The attribute is then stored and returned as a Erlang Unicode string, as expected:

```
(app@127.0.0.1)3> erlcloud_sdb:get_attributes("test_domain", "test").
[{attributes,[{"test",[102,108,101,117,114,111,110,58,32,10086]}]},
```

Unfortunately I wasn't able to get the test suite to run. Am I doing it wrong?

```
$ make eunit
==> meck (compile)
==> jsx (compile)
==> erlcloud (compile)
Compiled src/erlcloud_sdb.erl
Compiled src/erlcloud_xml.erl
Compiled src/erlcloud_sqs.erl
Compiled src/erlcloud_mon.erl
Compiled src/erlcloud_elb.erl
Compiled src/erlcloud_s3.erl
Compiled src/erlcloud_aws.erl
Compiled src/erlcloud_mturk.erl
Compiled src/erlcloud_ec2.erl
==> erlcloud (eunit)
Compiled src/erlcloud_xml.erl
Compiled src/erlcloud_sdb.erl
Compiled src/erlcloud_sqs.erl
Compiled src/erlcloud_mon.erl
Compiled src/erlcloud_elb.erl
Compiled src/erlcloud_s3.erl
Compiled src/erlcloud_ec2.erl
Compiled src/erlcloud_aws.erl
Compiled src/erlcloud_mturk.erl
undefined
*** instantiation of subtests failed ***
::{badmatch,{ok,{https,[],"host",443,"/",
                     "?AWSAccessKeyId=id&SignatureMethod=HmacSHA1&SignatureVersion=2&Timestamp=2013-01-28T17%3A42%3A58Z&Signature=KsJhlIBt3CLy86veVgF2P59sd3g%3D"}}}


undefined
*** context setup failed ***
::{already_started,<0.332.0>}


undefined
*** context setup failed ***
::{already_started,<0.332.0>}
```
