### PR TITLE
Add ability to configure a proxy for S3 requests

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -16,6 +16,7 @@
           ddb_retry=fun erlcloud_ddb1:retry/2::erlcloud_ddb1:retry_fun(),
           access_key_id::string()|undefined|false,
           secret_access_key::string()|undefined|false,
-          security_token=undefined::string()|undefined
+          security_token=undefined::string()|undefined,
+          http_options=[]::proplists:proplist()
          }).
 -type(aws_config() :: #aws_config{}).


### PR DESCRIPTION
Add an `http_options` field to the `aws_config` record. This list of
options is set for the http client prior to making a request and may
include proxy information. Expose versions of the `new` and `configure`
functions in the `erlcloud_s3` module that allow the proxy host and port
to be set.
