### PR TITLE
fix httpc timeout issue

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -16,6 +16,7 @@
           ddb_retry=fun erlcloud_ddb_impl:retry/2::erlcloud_ddb_impl:retry_fun(),
           access_key_id::string()|undefined|false,
           secret_access_key::string()|undefined|false,
-          security_token=undefined::string()|undefined
+          security_token=undefined::string()|undefined,
+          timeout=10000::timeout()
          }).
 -type(aws_config() :: #aws_config{}).

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -92,15 +92,18 @@ aws_request2_no_update(Method, Protocol, Host, Port, Path, Params, #aws_config{}
         _ -> URL = [UProtocol, Host, $:, port_to_str(Port), Path]
     end,
     
+    %% Note: httpc MUST be used with {timeout, timeout()} option
+    %%       Many timeout related failures is observed at prod env
+    %%       when library is used in 24/7 manner
     Response =
         case Method of
             get ->
                 Req = lists:flatten([URL, $?, Query]),
-                httpc:request(Req);
+                httpc:request(get, {Req, []}, [{timeout, Config#aws_config.timeout}], []);
             _ ->
                 httpc:request(Method,
                               {lists:flatten(URL), [], "application/x-www-form-urlencoded; charset=utf-8",
-                               list_to_binary(Query)}, [], [])
+                               list_to_binary(Query)}, [{timeout, Config#aws_config.timeout}], [])
         end,
     
     http_body(Response).


### PR DESCRIPTION
erlcloud is stall very often at production environment. I've traced issue, root cause is timeout issue at httpc. 
The commit attempts to fix it. 
