### PR TITLE
Bugfixes: (1) Use 'NextToken' attribute in API call and (2) include the ...

### DIFF
--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -198,8 +198,10 @@ list_domains(FirstToken, MaxDomains, Config)
   when is_list(FirstToken),
        is_integer(MaxDomains) orelse MaxDomains =:= none ->
     {Doc, Result} = sdb_request(Config, "ListDomains",
-                                [{"MaxNumberOfDomains", MaxDomains}, {"FirstToken", FirstToken}]),
-    [{domains, erlcloud_xml:get_list("/ListDomainsResponse/ListDomainsResult/DomainName", Doc)}|Result].
+                                [{"MaxNumberOfDomains", MaxDomains}, {"NextToken", FirstToken}]),
+
+    [{domains, erlcloud_xml:get_list("/ListDomainsResponse/ListDomainsResult/DomainName", Doc)},
+     {next_token, erlcloud_xml:get_text("/ListDomainsResponse/ListDomainsResult/NextToken", Doc)}|Result].
 
 -spec put_attributes/3 :: (string(), string(), sdb_attributes()) -> proplist().
 put_attributes(DomainName, ItemName, Attributes) ->


### PR DESCRIPTION
...next token in the result so that it can be used in follow-up calls to list_domains/1 for situations where there are more than 100 domains.
