### PR TITLE
Update for R16 crypto changes.

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,11 @@
+case erlang:system_info(otp_release) =< "R15B01" of
+    true  ->
+        HashDefine = [{d,old_hash}],
+        case lists:keysearch(erl_opts, 1, CONFIG) of
+            {value, {erl_opts, Opts}} ->
+                lists:keyreplace(erl_opts,1,CONFIG,{erl_opts,Opts++HashDefine});
+            false ->
+                CONFIG ++ [{erl_opts, HashDefine}]
+        end;
+    false -> CONFIG
+end.

--- a/src/erlcloud_mturk.erl
+++ b/src/erlcloud_mturk.erl
@@ -1599,7 +1599,7 @@ mturk_xml_request(Config, Operation, Params) ->
 mturk_request(Config, Operation, Params) ->
     Timestamp = erlcloud_aws:format_timestamp(erlang:universaltime()),
     StringToSign = [?API_SERVICE, Operation, Timestamp],
-    Signature = base64:encode(crypto:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
+    Signature = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
 
     QParams = [{"Operation", Operation}, {"Version", ?API_VERSION},
                {"Service", ?API_SERVICE}, {"Timestamp", Timestamp},

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -582,7 +582,7 @@ sign_get(Expire_time, BucketName, Key, Config)
     Datetime = (Mega * 1000000) + Sec,
     Expires = integer_to_list(Expire_time + Datetime),
     To_sign = lists:flatten(["GET\n\n\n", Expires, "\n/", BucketName, "/", Key]),
-    Sig = base64:encode(crypto:sha_mac(Config#aws_config.secret_access_key, To_sign)),
+    Sig = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, To_sign)),
     {Sig, Expires}.
 
 -spec make_link(integer(), string(), string()) -> {integer(), string(), string()}.
@@ -736,7 +736,7 @@ s3_request2(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) 
 s3_request2_no_update(Config, Method, Host, Path, Subresource, Params, POSTData, Headers0) ->
     {ContentMD5, ContentType, Body} =
         case POSTData of
-            {PD, CT} -> {base64:encode(crypto:md5(PD)), CT, PD}; PD -> {"", "", PD}
+            {PD, CT} -> {base64:encode(erlcloud_util:md5(PD)), CT, PD}; PD -> {"", "", PD}
         end,
     Headers = case Config#aws_config.security_token of
                   undefined -> Headers0;
@@ -784,7 +784,7 @@ make_authorization(Config, Method, ContentMD5, ContentType, Date, AmzHeaders,
                     case Host of "" -> ""; _ -> [$/, Host] end,
                     Resource, case Subresource of "" -> ""; _ -> [$?, Subresource] end
                    ],
-    Signature = base64:encode(crypto:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
+    Signature = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
     ["AWS ", Config#aws_config.access_key_id, $:, Signature].
 
 default_config() -> erlcloud_aws:default_config().

--- a/src/erlcloud_util.erl
+++ b/src/erlcloud_util.erl
@@ -1,0 +1,26 @@
+-module(erlcloud_util).
+-export([sha_mac/2, sha256_mac/2,
+         md5/1, sha256/1]).
+
+-ifndef(old_hash).
+sha_mac(K, S) ->
+    crypto:hmac(sha, K, S).
+sha256_mac(K, S) ->
+    crypto:hmac(sha256, K, S).
+
+sha256(V) ->
+    crypto:hash(sha256, V).
+md5(V) ->
+    crypto:hash(md5, V).
+-else.
+sha_mac(K, S) ->
+    crypto:sha_mac(K, S).
+sha256(K, S) ->
+    crypto:sha256(K, S).
+
+sha256(V) ->
+    crypto:sha256(V).
+md5(V) ->
+    crypto:md5(V).
+-endif.
+


### PR DESCRIPTION
R16 introduces a new crypto interface, old functions are deprecated. This isn't breaking change but it is not too uncommon to compile with warnings_as_errors which turns those warnings into errors and can break a compile.

The fix is to run a rebar script (this one is from riak_core).
