### PR TITLE
Metadata should use head not get

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -431,7 +431,7 @@ get_object_metadata(BucketName, Key, Options, Config) ->
                       undefined -> "";
                       Version   -> ["versionId=", Version]
                   end,
-    {Headers, _Body} = s3_request(Config, get, BucketName, [$/|Key], Subresource, [], <<>>, RequestHeaders),
+    {Headers, _Body} = s3_request(Config, head, BucketName, [$/|Key], Subresource, [], <<>>, RequestHeaders),
     [{last_modified, proplists:get_value("last-modified", Headers)},
      {etag, proplists:get_value("etag", Headers)},
      {content_length, proplists:get_value("content-length", Headers)},
@@ -767,6 +767,7 @@ s3_request2_no_update(Config, Method, Host, Path, Subresource, Params, POSTData,
                                ]),
     Response = case Method of
                    get -> httpc:request(Method, {RequestURI, RequestHeaders}, [], []);
+                   head -> httpc:request(Method, {RequestURI, RequestHeaders}, [], []);
                    delete -> httpc:request(Method, {RequestURI, RequestHeaders}, [], []);
                    _ -> httpc:request(Method, {RequestURI, RequestHeaders, ContentType, Body}, [], [])
                end,


### PR DESCRIPTION
S3 metadata currently uses the get method, to retrieve the metadata, this is a slightly problematic with bigger objects since all the data needs to be retrieved and transferred.

Regarding to the Amazon S3 documentation [1] the HEAD method should be used to get a objects metadata. This patch addresses this inconsistency.

[1] http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html
