### PR TITLE
Fix eunit tests

### DIFF
--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -11,7 +11,7 @@ request_test_() ->
 
 start() ->
     meck:new(httpc, [unstick]),
-    meck:expect(httpc, request, fun(_) -> {ok, {{0, 200, 0}, 0, ok}} end),
+    meck:expect(httpc, request, fun(_,_,_,_) -> {ok, {{0, 200, 0}, 0, ok}} end),
     ok.
 
 stop(_) ->
@@ -36,7 +36,7 @@ request_prot_host_port_int_test(_) ->
 % Internal functions
 % ==================
 
-get_url_from_history([{_, {httpc, request, [Url]}, _}]) ->
+get_url_from_history([{_, {httpc, request, [_, {Url, _}, _, _]}, _}]) ->
     Url.
 
 test_url(ExpScheme, ExpHost, ExpPort, ExpPath, Url) ->

--- a/test/erlcloud_ec2_tests.erl
+++ b/test/erlcloud_ec2_tests.erl
@@ -90,7 +90,7 @@ validate_params(Body, Expected) ->
 %% Validates the query body and responds with the provided response.
 -spec input_expect(string(), [expected_param()]) -> fun().
 input_expect(Response, Expected) ->
-    fun(post, {_Url, [] = _Headers, _ContentType, Body}, [], []) -> 
+    fun(post, {_Url, [] = _Headers, _ContentType, Body}, _, []) -> 
             validate_params(Body, Expected),
             {ok, {{0, 200, 0}, 0, Response}} 
     end.
@@ -124,7 +124,7 @@ input_tests(Response, Tests) ->
 %% returns the mock of the httpc function output tests expect to be called.
 -spec output_expect(string()) -> fun().
 output_expect(Response) ->
-    fun(post, {_Url, [] = _Headers, _ContentType, _Body}, [], []) -> 
+    fun(post, {_Url, [] = _Headers, _ContentType, _Body}, _, []) -> 
             {ok, {{0, 200, 0}, 0, Response}} 
     end.
 


### PR DESCRIPTION
Commit 4aab1499c0a07b2013a10a5e34c43785fb8dcc72 changed the signature
of httpc calls. This updates the tests to expect the new signature.
