### PR TITLE
Return the HMAC - there is no crypto:sha/2

### DIFF
--- a/src/erlcloud_util.erl
+++ b/src/erlcloud_util.erl
@@ -11,7 +11,7 @@ sha_mac(K, S) ->
 sha256_mac(K, S) ->
 	case erlang:function_exported(crypto, hmac, 3) of
 		true  -> crypto:hmac(sha256, K, S);
-		false -> crypto:sha256(K, S)
+		false -> crypto:hmac_final(crypto:hmac_update(crypto:hmac_init(sha256, K), S))
 	end.
 
 sha256(V) ->


### PR DESCRIPTION
This function need to return the HMAC for the v2 signatures to work.  

There is no sha256/2 in crypto in any version that I checked from R15B03-1 through R16B03-1.
