### PR TITLE
Sqs long poll

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -19,8 +19,8 @@
          set_queue_attributes/2, set_queue_attributes/3
         ]).
 
--include("erlcloud.hrl").
--include("erlcloud_aws.hrl").
+-include_lib("erlcloud/include/erlcloud.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
 
 -define(API_VERSION, "2012-11-05").
 


### PR DESCRIPTION
Implement SQS Long Polling so we can specify a poll interval of up to 20 seconds (current API max) and reduce our SQS operations costs.
