### PR TITLE
erlcloud_s3:make_link to use Config#aws_config.s3_scheme for url-protocol

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -601,7 +601,7 @@ make_link(Expire_time, BucketName, Key) ->
 
 make_link(Expire_time, BucketName, Key, Config) ->
     {Sig, Expires} = sign_get(Expire_time, BucketName, erlcloud_http:url_encode_loose(Key), Config),
-    Host = lists:flatten(["http://", BucketName, ".", Config#aws_config.s3_host, port_spec(Config)]),
+    Host = lists:flatten([Config#aws_config.s3_scheme, BucketName, ".", Config#aws_config.s3_host, port_spec(Config)]),
     URI = lists:flatten(["/", Key, "?AWSAccessKeyId=", erlcloud_http:url_encode(Config#aws_config.access_key_id), "&Signature=", erlcloud_http:url_encode(Sig), "&Expires=", Expires]),
     {list_to_integer(Expires),
      binary_to_list(erlang:iolist_to_binary(Host)),


### PR DESCRIPTION
Noticed that "http://" was hard coded into the make_link function and this was causing our page to complain about loading insecure content when using SSL. I've updated the method to instead load the s3_scheme from the erlcoud_aws.hrl file where it is defaulted to "https://" I was going to change the .hrl to be "http://" for backwards compatibility reasons but noticed that the method just below make_link (make_get_url) correctly uses the Config file so it just makes sense to default it to "https://"
