### PR TITLE
Add atom to dynamize_value

### DIFF
--- a/src/erlcloud_ddb.erl
+++ b/src/erlcloud_ddb.erl
@@ -279,6 +279,8 @@ dynamize_value({s, Value}) when is_binary(Value) ->
     {<<"S">>, Value};
 dynamize_value({s, Value}) when is_list(Value) ->
     {<<"S">>, list_to_binary(Value)};
+dynamize_value({s, Value}) when is_atom(Value) ->
+    {<<"S">>, atom_to_binary(Value, utf8)};
 dynamize_value({n, Value}) when is_number(Value) ->
     {<<"N">>, dynamize_number(Value)};
 dynamize_value({b, Value}) when is_binary(Value) orelse is_list(Value) ->

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -286,6 +286,8 @@ dynamize_value({s, Value}) when is_binary(Value) ->
     {<<"S">>, Value};
 dynamize_value({s, Value}) when is_list(Value) ->
     {<<"S">>, list_to_binary(Value)};
+dynamize_value({s, Value}) when is_atom(Value) ->
+    {<<"S">>, atom_to_binary(Value, utf8)};
 dynamize_value({n, Value}) when is_number(Value) ->
     {<<"N">>, dynamize_number(Value)};
 dynamize_value({b, Value}) when is_binary(Value) orelse is_list(Value) ->
@@ -304,6 +306,8 @@ dynamize_value(Value) when is_list(Value) ->
     dynamize_value({s, Value});
 dynamize_value(Value) when is_number(Value) ->
     dynamize_value({n, Value});
+dynamize_value(Value) when is_atom(Value) ->
+    dynamize_value({s, atom_to_binary(Value, utf8)});
 dynamize_value(Value) ->
     error({erlcloud_ddb, {invalid_attr_value, Value}}).
 


### PR DESCRIPTION
I had an issue with a jsx:decode(Body) where Body was a Json reply from an Api.  The resulting proplist included an atom. I wanted to store the result in ddb w/o any additional parsing. So I added this.  
