### PR TITLE
Added support for create_topic, delete_topic, set_topic_attributes, subs...

### DIFF
--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -198,8 +198,8 @@ delete_endpoint(EndpointArn, AccessKeyID, SecretAccessKey) ->
 
 
 
--spec(delete_topic/1 :: (string()) -> proplist()).
--spec(delete_topic/2 :: (string(), aws_config()) -> proplist()).
+-spec delete_topic/1 :: (string()) -> ok.
+-spec delete_topic/2 :: (string(), aws_config()) -> ok.
 
 delete_topic(TopicArn) ->
     delete_topic(TopicArn, default_config()).


### PR DESCRIPTION
...cribe apis

I have followed the style of the erlcloud_sns.erl module, but I have to say that the way that erlcloud_sns returns results is different from the rest of the erlcloud library where most APIs return {ok, Result} | {error, Reason} tuple, the erlcloud_sns exists the process.... 
While I don't object to exiting the process I want consistency...
Would you like me to modify erlcloud_sns to be consistent with the rest of the APIs?
