### PR TITLE
s3_request should return {aws_error, Reason} in error state

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -862,8 +862,8 @@ s3_request(Config, Method, Host, Path, Subreasource, Params, POSTData, Headers) 
     case s3_request2(Config, Method, Host, Path, Subreasource, Params, POSTData, Headers) of
         {ok, Result} ->
             Result;
-        {error, Reason} ->
-            erlang:error({aws_error, Reason})
+        {error, Reason} -> 
+          {aws_error, Reason}
     end.
 
 %% s3_request2 returns {ok, Body} or {error, Reason} instead of throwing as s3_request does


### PR DESCRIPTION
On unstable connections a put_object call sometimes timeout. In my tests this crashes the server on `{Headers, _Body} = s3_request(Config, put, BucketName, [$/|Key], "", [],POSTData, RequestHeaders),` [erlcloud_s3.erl, line 607] . s3_request on error state triggers a crash. I think returning a tuple: `{aws_error, Reason}` and leave the handling to the calling service would better handle the situation. This way the calling service can respond to the initial request instead of just crashing.
