### PR TITLE
Support CommonPrefixes in S3 list operations

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -309,8 +309,13 @@ list_objects(BucketName, Options, Config)
                   {delimiter, "Delimiter", text},
                   {max_keys, "MaxKeys", integer},
                   {is_truncated, "IsTruncated", boolean},
+                  {common_prefixes, "CommonPrefixes", fun extract_prefixes/1},
                   {contents, "Contents", fun extract_contents/1}],
     erlcloud_xml:decode(Attributes, Doc).
+
+extract_prefixes(Nodes) ->
+    Attributes = [{prefix, "Prefix", text}],
+    [erlcloud_xml:decode(Attributes, Node) || Node <- Nodes].
 
 extract_contents(Nodes) ->
     Attributes = [{key, "Key", text},


### PR DESCRIPTION
This commit adds support for reading the CommonPrefixes key from S3 responses.

See the S3 API docs for more information about CommonPrefixes and how they work:

http://docs.aws.amazon.com/AmazonS3/latest/API/SOAPListBucket.html

Fixes #94
