### PR TITLE
Minor return value fix for erlcloud_as:set_desired_capacity

### DIFF
--- a/src/erlcloud_as.erl
+++ b/src/erlcloud_as.erl
@@ -155,7 +155,7 @@ set_desired_capacity(GroupName, Capacity, HonorCooldown, Config) ->
     case as_query(Config, "SetDesiredCapacity", Params, ?API_VERSION) of
         {ok, Doc} ->
             [RequestId] = xmerl_xpath:string(?SET_SCALE_REQUEST_ID_PATH, Doc),
-            erlcloud_xml:get_text(RequestId);
+            {ok, erlcloud_xml:get_text(RequestId)};
         {error, Reason} ->
             {error, Reason}
     end.


### PR DESCRIPTION
Return values did not actually match spec correctly, see commit message for details.
