### PR TITLE
fix signature calculation on empty params

### DIFF
--- a/src/erlcloud_http.erl
+++ b/src/erlcloud_http.erl
@@ -3,7 +3,7 @@
 
 make_query_string(Params) ->
     string:join([case Value of
-                     [] -> [Key];
+                     [] -> [Key, "="];
                      _ -> [Key, "=", url_encode(value_to_string(Value))]
                  end
                  || {Key, Value} <- Params, Value =/= none, Value =/= undefined], "&").


### PR DESCRIPTION
when generating a http query string on params with empty lists (ie. queue name prefix on list_queues) the equal sign was not being added next to the key name leaving the empty value (ie. QueueNamePrefix = ). This leads to a signature calculation mismatch since amazon performs the calculation of their side using the equal sign.

fixes issue #113 
