### PR TITLE
Support multiple lhttpc pools.

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -1,3 +1,11 @@
+-record(lhttpc_config, {
+          pools=1::pos_integer(),
+          pool_prefix="lhttpc_man_erlcloud"::string(),
+          pool_connection_timeout=30000::non_neg_integer(),
+          pool_max_size=50::pos_integer()
+}).
+-type(httpc_config() :: #lhttpc_config{}).
+
 -record(aws_config, {
           as_host="autoscaling.amazonaws.com"::string(),
           ec2_host="ec2.amazonaws.com"::string(),
@@ -32,6 +40,7 @@
           security_token=undefined::string()|undefined,
           timeout=10000::timeout(),
           cloudtrail_raw_result=false::boolean(),
+          httpc_config=#lhttpc_config{}::httpc_config(),
 
           %% Default to not retry failures (for backwards compatability).
           %% Recommended to be set to default_retry to provide recommended retry behavior.

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -9,7 +9,29 @@
 
 -module(erlcloud_httpc).
 
+-include("include/erlcloud_aws.hrl").
+
 -export([request/6]).
 
-request(URL, Method, Hdrs, Body, Timeout, _Config) ->
-    lhttpc:request(URL, Method, Hdrs, Body, Timeout, []).
+
+-define(LHTTPC_POOLID_PADDING, 2).
+
+request(URL, Method, Hdrs, Body, Timeout, #aws_config{ httpc_config=(#lhttpc_config{}=LHttpcConfig) }) ->
+    #lhttpc_config{
+            pools=Pools, pool_prefix=PPrefix, pool_connection_timeout=PConnTimeout, pool_max_size=PMaxSize
+        } = LHttpcConfig,
+
+    PIndex = erlang:phash2({URL, Method, Hdrs, Body, Timeout}, Pools),
+    PSuffix = case PIndex >= (?LHTTPC_POOLID_PADDING * 10) of
+        true  -> integer_to_list(PIndex);
+        false ->
+            FormatStr = lists:flatten(["~", integer_to_list(?LHTTPC_POOLID_PADDING), "..0B"]),
+            lists:flatten( io_lib:format(FormatStr, [PIndex]) )
+    end,
+    PoolId = list_to_atom(PPrefix ++ PSuffix),
+
+    LHttpcConfigParams = [{pool, PoolId},
+                          {pool_ensure, true},
+                          {pool_connection_timeout, PConnTimeout},
+                          {pool_max_size, PMaxSize}],
+    lhttpc:request(URL, Method, Hdrs, Body, Timeout, LHttpcConfigParams).


### PR DESCRIPTION
When reaching very high query rates (thousands per second) with DynamoDB, lhttpc_manager (which keeps track of open connections) starts getting clogged (even with a big pool_max_size) and becomes a bottleneck. Splitting the requests over multiple managers solves this problem.
