### PR TITLE
use aws config timeout instead of hardwired one

### DIFF
--- a/src/erlcloud_kinesis_impl.erl
+++ b/src/erlcloud_kinesis_impl.erl
@@ -102,7 +102,7 @@ request_and_retry(Config, Headers, Body, {attempt, Attempt}) ->
     case erlcloud_httpc:request(
            url(Config), post,
            [{<<"content-type">>, <<"application/x-amz-json-1.1">>} | Headers],
-           Body, 1000, Config) of
+           Body, Config#aws_config.timeout, Config) of
 
         {ok, {{200, _}, _, RespBody}} ->
             %% TODO check crc


### PR DESCRIPTION
1000 is an insufficient timeout for Europe->US West 2 requests, funny enough, is enough for Europe -> US East 1
