### PR TITLE
Allow both lhttpc and httpc(inets)

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -32,6 +32,7 @@
           security_token=undefined::string()|undefined,
           timeout=10000::timeout(),
           cloudtrail_raw_result=false::boolean(),
+          http_client=lhttpc::erlcloud_httpc:request_fun(),
 
           %% Default to not retry failures (for backwards compatability).
           %% Recommended to be set to default_retry to provide recommended retry behavior.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -234,7 +234,7 @@ port_to_str(Port) when is_list(Port) ->
     Port.
 
 -spec http_body({ok, tuple()} | {error, term()}) 
-               -> {ok, string() | binary()} | {error, tuple()}.
+               -> {ok, binary()} | {error, tuple()}.
 %% Extract the body and do error handling on the return of a httpc:request call.
 http_body(Return) ->
     case http_headers_body(Return) of
@@ -246,7 +246,7 @@ http_body(Return) ->
 
 -type headers() :: [{string(), string()}].
 -spec http_headers_body({ok, tuple()} | {error, term()}) 
-                       -> {ok, {headers(), string() | binary()}} | {error, tuple()}.
+                       -> {ok, {headers(), binary()}} | {error, tuple()}.
 %% Extract the headers and body and do error handling on the return of a httpc:request call.
 http_headers_body({ok, {{OKStatus, _StatusLine}, Headers, Body}}) 
   when OKStatus >= 200, OKStatus =< 299 ->

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -9,7 +9,56 @@
 
 -module(erlcloud_httpc).
 
+-include("erlcloud_aws.hrl").
+
 -export([request/6]).
 
-request(URL, Method, Hdrs, Body, Timeout, _Config) ->
+-type request_fun() :: 
+    lhttpc | httpc |
+    {module(), atom()} |
+    fun((string(),
+         head | get | put | post | trace | options | delete,
+         list({binary(), binary()}),
+         binary(), pos_integer(), #aws_config{}) ->
+        {ok, {{pos_integer(), string()},
+              list({string(), string()}), binary()}} |
+        {error, any()}).
+-export_type([request_fun/0]).
+
+request(URL, Method, Hdrs, Body, Timeout,
+        #aws_config{http_client = lhttpc} = Config) ->
+    request_lhttpc(URL, Method, Hdrs, Body, Timeout, Config);
+request(URL, Method, Hdrs, Body, Timeout,
+        #aws_config{http_client = httpc} = Config) ->
+    request_httpc(URL, Method, Hdrs, Body, Timeout, Config);
+request(URL, Method, Hdrs, Body, Timeout,
+        #aws_config{http_client = {M, F}} = Config)
+    when is_atom(M), is_atom(F) ->
+    M:F(URL, Method, Hdrs, Body, Timeout, Config);
+request(URL, Method, Hdrs, Body, Timeout,
+        #aws_config{http_client = F} = Config)
+    when is_function(F, 6) ->
+    F(URL, Method, Hdrs, Body, Timeout, Config).
+
+request_lhttpc(URL, Method, Hdrs, Body, Timeout, _Config) ->
     lhttpc:request(URL, Method, Hdrs, Body, Timeout, []).
+
+request_httpc(URL, Method, Hdrs, <<>>, Timeout, _Config) ->
+    HdrsStr = [{binary_to_list(K), binary_to_list(V)} || {K, V} <- Hdrs],
+    response_httpc(httpc:request(Method, {URL, HdrsStr},
+                                 [{timeout, Timeout}],
+                                 [{body_format, binary}]));
+request_httpc(URL, Method, Hdrs, Body, Timeout, _Config) ->
+    {value,
+     {_, ContentType}, HdrsRest} = lists:keytake(<<"content-type">>, 1, Hdrs),
+    HdrsStr = [{binary_to_list(K), binary_to_list(V)} || {K, V} <- HdrsRest],
+    response_httpc(httpc:request(Method,
+                                 {URL, HdrsStr,
+                                  binary_to_list(ContentType), Body},
+                                 [{timeout, Timeout}],
+                                 [{body_format, binary}])).
+
+response_httpc({ok, {{_HTTPVer, Status, StatusLine}, Headers, Body}}) ->
+    {ok, {{Status, StatusLine}, Headers, Body}};
+response_httpc({error, _} = Error) ->
+    Error.


### PR DESCRIPTION
The old erlcloud errors due to httpc are available if the erlcloud application env `http_client` setting is changed to httpc, otherwise the current source code remains the same (continuing to use lhttpc with the default setting in the .app file).

To address #130 
