### PR TITLE
Add support for non-standard DynamoDB and S3 endpoints

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -83,7 +83,8 @@
 -include("erlcloud_ddb2.hrl").
 
 %%% Library initialization.
--export([configure/2, configure/3, new/2, new/3]).
+-export([configure/2, configure/3, configure/4, configure/5,
+         new/2, new/3, new/4, new/5]).
 
 %%% DynamoDB API
 -export([batch_get_item/1, batch_get_item/2, batch_get_item/3,
@@ -211,6 +212,21 @@ new(AccessKeyID, SecretAccessKey, Host) ->
                 secret_access_key=SecretAccessKey,
                 ddb_host=Host}.
 
+-spec(new/4 :: (string(), string(), string(), non_neg_integer()) -> aws_config()).
+new(AccessKeyID, SecretAccessKey, Host, Port) ->
+    #aws_config{access_key_id=AccessKeyID,
+                secret_access_key=SecretAccessKey,
+                ddb_host=Host,
+                ddb_port=Port}.
+
+-spec(new/5 :: (string(), string(), string(), non_neg_integer(), string()) -> aws_config()).
+new(AccessKeyID, SecretAccessKey, Host, Port, Scheme) ->
+    #aws_config{access_key_id=AccessKeyID,
+                secret_access_key=SecretAccessKey,
+                ddb_host=Host,
+                ddb_port=Port,
+                ddb_scheme=Scheme}.
+
 -spec(configure/2 :: (string(), string()) -> ok).
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
@@ -219,6 +235,16 @@ configure(AccessKeyID, SecretAccessKey) ->
 -spec(configure/3 :: (string(), string(), string()) -> ok).
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
+    ok.
+
+-spec(configure/4 :: (string(), string(), string(), non_neg_integer()) -> ok).
+configure(AccessKeyID, SecretAccessKey, Host, Port) ->
+    put(aws_config, new(AccessKeyID, SecretAccessKey, Host, Port)),
+    ok.
+
+-spec(configure/5 :: (string(), string(), string(), non_neg_integer(), string()) -> ok).
+configure(AccessKeyID, SecretAccessKey, Host, Port, Scheme) ->
+    put(aws_config, new(AccessKeyID, SecretAccessKey, Host, Port, Scheme)),
     ok.
 
 default_config() -> erlcloud_aws:default_config().

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -3,7 +3,7 @@
 -module(erlcloud_s3).
 -export([new/2, new/3, new/4, new/5,
          configure/2, configure/3, configure/4, configure/5,
-         create_bucket/1, create_bucket/2, create_bucket/3,
+         create_bucket/1, create_bucket/2, create_bucket/3, create_bucket/4,
          delete_bucket/1, delete_bucket/2,
          get_bucket_attribute/2, get_bucket_attribute/3,
          list_buckets/0, list_buckets/1,

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1,7 +1,8 @@
 %% Amazon Simple Storage Service (S3)
 
 -module(erlcloud_s3).
--export([new/2, new/3, new/4, configure/2, configure/3, configure/4,
+-export([new/2, new/3, new/4, new/5,
+         configure/2, configure/3, configure/4, configure/5,
          create_bucket/1, create_bucket/2, create_bucket/3,
          delete_bucket/1, delete_bucket/2,
          get_bucket_attribute/2, get_bucket_attribute/3,
@@ -68,6 +69,17 @@ new(AccessKeyID, SecretAccessKey, Host, Port) ->
        s3_port=Port
       }.
 
+-spec new(string(), string(), string(), non_neg_integer(), string()) -> aws_config().
+
+new(AccessKeyID, SecretAccessKey, Host, Port, Scheme) ->
+    #aws_config{
+       access_key_id=AccessKeyID,
+       secret_access_key=SecretAccessKey,
+       s3_host=Host,
+       s3_port=Port,
+       s3_scheme=Scheme
+      }.
+
 -spec configure(string(), string()) -> ok.
 
 configure(AccessKeyID, SecretAccessKey) ->
@@ -84,6 +96,12 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
 
 configure(AccessKeyID, SecretAccessKey, Host, Port) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host, Port)),
+    ok.
+
+-spec configure(string(), string(), string(), non_neg_integer(), string()) -> ok.
+
+configure(AccessKeyID, SecretAccessKey, Host, Port, Scheme) ->
+    put(aws_config, new(AccessKeyID, SecretAccessKey, Host, Port, Scheme)),
     ok.
 
 -type s3_bucket_attribute_name() :: acl


### PR DESCRIPTION
This PR makes switching from AWS DynamoDB and S3 to, for instance, DynamoDB local and FakeS3 a bit more seamless.