### PR TITLE
Fix requests made in the China region

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -107,7 +107,17 @@ aws_request2_no_update(Method, Protocol, Host, Port, Path, Params, #aws_config{}
 
 aws_region_from_host(Host) ->
     case string:tokens(Host, ".") of
-        [_, Value, _, _] ->
+        %% the aws endpoint can vary depending on the region
+        %% we need to account for that:
+        %%  us-west-2: s3.us-west-2.amazonaws.com
+        %%  cn-north-1 (AWS China): s3.cn-north-1.amazonaws.com.cn
+        %% it's assumed that the first element is the aws service (s3, ec2, etc),
+        %% the second is the region identifier, the rest is ignored
+        %% the exception (of course) is the dynamodb streams which follows a different
+        %% format
+        ["streams", "dynamodb", Value | _Rest] ->
+            Value;
+        [_, Value, _, _ | _Rest] ->
             Value;
         _ ->
             "us-east-1"

--- a/src/erlcloud_ddb_streams.erl
+++ b/src/erlcloud_ddb_streams.erl
@@ -895,13 +895,7 @@ headers(Config, Operation, Body) ->
     Headers = [{"host", Config#aws_config.ddb_streams_host},
                {"x-amz-target", Operation},
                {"content-type", "application/x-amz-json-1.0"}],
-    Region =
-        case string:tokens(Config#aws_config.ddb_streams_host, ".") of
-            [_, _, Value, _, _] ->
-                Value;
-            _ ->
-                "us-east-1"
-        end,
+    Region = erlcloud_aws:aws_region_from_host(Config#aws_config.ddb_streams_host),
     erlcloud_aws:sign_v4_headers(Config, Headers, Body, Region, "dynamodb").
 
 uri(#aws_config{ddb_streams_scheme = Scheme, ddb_streams_host = Host} = Config) ->


### PR DESCRIPTION
AWS China endpoints all have a .cn suffix, account
for that when parsing endpoints to extract the region.