### PR TITLE
Add a universal way to config timeout

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -38,7 +38,11 @@
           access_key_id::string()|undefined|false,
           secret_access_key::string()|undefined|false,
           security_token=undefined::string()|undefined,
-          timeout=10000::timeout(),
+          %% Network request timeout; if not specifed, the default timeout will be used:
+          %% ddb: 1s for initial call, 10s for subsequence;
+          %% s3:delete_objects_batch/{2,3}, cloudtrail: 1s;
+          %% other services: 10s.
+          timeout=undefined::timeout()|undefined,
           cloudtrail_raw_result=false::boolean(),
           http_client=lhttpc::erlcloud_httpc:request_fun(), %% If using hackney, ensure that it is started.
           hackney_pool=default::atom(), %% The name of the http request pool hackney should use.
@@ -50,6 +54,8 @@
           retry=fun erlcloud_retry:no_retry/1::erlcloud_retry:retry_fun()
          }).
 -type(aws_config() :: #aws_config{}).
+
+-define(DEFAULT_TIMEOUT, 10000).
 
 -record(aws_request,
         {

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -163,7 +163,7 @@ request_impl(Method, _Protocol, _Host, _Port, _Path, Operation, Params, Body, #a
                 erlcloud_httpc:request(
                      url(Config), Method, 
                      [{<<"content-type">>, <<"application/x-amz-json-1.1">>} | Headers],
-                     Body, 1000, Config)) of
+                     Body, timeout(Config), Config)) of
        {ok, {_RespHeader, RespBody}} ->
             case Config#aws_config.cloudtrail_raw_result of
                 true -> {ok, RespBody};
@@ -193,3 +193,7 @@ port_spec(#aws_config{cloudtrail_port=Port}) ->
     [":", erlang:integer_to_list(Port)].
 
 
+timeout(#aws_config{timeout = undefined}) ->
+    1000;
+timeout(#aws_config{timeout = Timeout}) ->
+    Timeout.

--- a/src/erlcloud_ddb_impl.erl
+++ b/src/erlcloud_ddb_impl.erl
@@ -110,14 +110,16 @@ backoff(Attempt) ->
     timer:sleep(random:uniform((1 bsl (Attempt - 1)) * 100)).
 
 %% HTTPC timeout for a request
-timeout(1, _) ->
+timeout(1, #aws_config{timeout = undefined}) ->
     %% Shorter timeout on first request. This is to avoid long (5s) failover when first DDB
     %% endpoint doesn't respond
     1000;
-timeout(_, Config) ->
+timeout(_, #aws_config{timeout = undefined}) ->
     %% Longer timeout on subsequent requsets - results in less timeouts when system is
     %% under heavy load
-    Config#aws_config.timeout.
+    ?DEFAULT_TIMEOUT;
+timeout(_, #aws_config{timeout = Timeout}) ->
+    Timeout.
 
 -type attempt() :: {attempt, pos_integer()} | {error, term()}.
 

--- a/src/erlcloud_kinesis_impl.erl
+++ b/src/erlcloud_kinesis_impl.erl
@@ -102,7 +102,7 @@ request_and_retry(Config, Headers, Body, {attempt, Attempt}) ->
     case erlcloud_httpc:request(
            url(Config), post,
            [{<<"content-type">>, <<"application/x-amz-json-1.1">>} | Headers],
-           Body, Config#aws_config.timeout, Config) of
+           Body, timeout(Config), Config) of
 
         {ok, {{200, _}, _, RespBody}} ->
             %% TODO check crc
@@ -166,3 +166,7 @@ port_spec(#aws_config{kinesis_port=80}) ->
 port_spec(#aws_config{kinesis_port=Port}) ->
     [":", erlang:integer_to_list(Port)].
 
+timeout(#aws_config{timeout = undefined}) ->
+    ?DEFAULT_TIMEOUT;
+timeout(#aws_config{timeout = Timeout}) ->
+    Timeout.

--- a/src/erlcloud_mturk.erl
+++ b/src/erlcloud_mturk.erl
@@ -1613,7 +1613,7 @@ mturk_request(Config, Operation, Params) ->
                  post,
                  [{<<"content-type">>, <<"application/x-www-form-urlencoded">>}],
                  list_to_binary(erlcloud_http:make_query_string(QParams)),
-                 Config#aws_config.timeout, Config),
+                 timeout(Config), Config),
 
     case Response of
         {ok, {{200, _StatusLine}, _Headers, Body}} ->
@@ -1623,3 +1623,8 @@ mturk_request(Config, Operation, Params) ->
         {error, Error} ->
             erlang:error({aws_error, {socket_error, Error}})
     end.
+
+timeout(#aws_config{timeout = undefined}) ->
+    ?DEFAULT_TIMEOUT;
+timeout(#aws_config{timeout = Timeout}) ->
+    Timeout.

--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -74,7 +74,7 @@ request_and_retry(Config, ResultFun, {retry, Request}) ->
       } = Request,
     Request2 = Request#aws_request{attempt = Attempt + 1},
     RetryFun = Config#aws_config.retry,
-    case erlcloud_httpc:request(URI, Method, Headers, Body, Config#aws_config.timeout, Config) of
+    case erlcloud_httpc:request(URI, Method, Headers, Body, timeout(Config), Config) of
         {ok, {{Status, StatusLine}, ResponseHeaders, ResponseBody}} ->
             Request3 = Request2#aws_request{
                          response_type = if Status >= 200, Status < 300 -> ok; true -> error end,
@@ -97,3 +97,8 @@ request_and_retry(Config, ResultFun, {retry, Request}) ->
                          httpc_error_reason = Reason},
             request_and_retry(Config, ResultFun, RetryFun(Request4))
     end.
+
+timeout(#aws_config{timeout = undefined}) ->
+    ?DEFAULT_TIMEOUT;
+timeout(#aws_config{timeout = Timeout}) ->
+    Timeout.

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -240,8 +240,13 @@ delete_objects_batch(Bucket, KeyList, Config) ->
                {"content-md5", binary_to_list(ContentMD5)},
                {"content-length", Len}],
     Result = erlcloud_httpc:request(
-        Url, "POST", Headers, Payload, 1000, Config),
+        Url, "POST", Headers, Payload, delete_objects_batch_timeout(Config), Config),
     erlcloud_aws:http_headers_body(Result).
+
+delete_objects_batch_timeout(#aws_config{timeout = undefined}) ->
+    1000;
+delete_objects_batch_timeout(#aws_config{timeout = Timeout}) ->
+    Timeout.
 
 % returns paths list from AWS S3 root directory, used as input to delete_objects_batch
 % example : 

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -272,8 +272,14 @@ receive_message(QueueName, AttributeNames, MaxNumberOfMessages,
        VisibilityTimeout =:= none,
        (WaitTimeSeconds >= 0 andalso WaitTimeSeconds =< 20) orelse
        WaitTimeSeconds =:= none ->
-    TotalTimeout = if (WaitTimeSeconds =/= none andalso WaitTimeSeconds >= 0) -> Config#aws_config.timeout + (WaitTimeSeconds * 1000) ;
-       true -> Config#aws_config.timeout
+    InitialTimeout = case Config#aws_config.timeout of
+        undefined -> ?DEFAULT_TIMEOUT;
+        _ -> Config#aws_config.timeout
+    end,
+    TotalTimeout = if
+       (WaitTimeSeconds =/= none andalso WaitTimeSeconds >= 0 andalso InitialTimeout =/= infinity) ->
+           InitialTimeout + (WaitTimeSeconds * 1000) ;
+       true -> InitialTimeout
     end,
     Doc = sqs_xml_request(Config#aws_config{timeout=TotalTimeout}, QueueName, "ReceiveMessage",
                           [


### PR DESCRIPTION
A compact and universal way to specify http request timeout.

Backwards compatibility won't be broken as long as users didn't specify the timeout explicitly.
Nevertheless, in case of specified, this change is what they actually needed.

Previous complete discusses are in #257.