### PR TITLE
fix global default_timeout

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -55,8 +55,6 @@
          }).
 -type(aws_config() :: #aws_config{}).
 
--define(DEFAULT_TIMEOUT, 10000).
-
 -record(aws_request,
         {
           %% Provided by requesting service

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -163,7 +163,7 @@ request_impl(Method, _Protocol, _Host, _Port, _Path, Operation, Params, Body, #a
                 erlcloud_httpc:request(
                      url(Config), Method, 
                      [{<<"content-type">>, <<"application/x-amz-json-1.1">>} | Headers],
-                     Body, erlcloud_aws:get_timeout(Config), Config)) of
+                     Body, timeout(Config), Config)) of
        {ok, {_RespHeader, RespBody}} ->
             case Config#aws_config.cloudtrail_raw_result of
                 true -> {ok, RespBody};
@@ -192,3 +192,8 @@ port_spec(#aws_config{cloudtrail_port=80}) ->
 port_spec(#aws_config{cloudtrail_port=Port}) ->
     [":", erlang:integer_to_list(Port)].
 
+%CT have less default timeout
+timeout(#aws_config{timeout = undefined}) ->
+    1000;
+timeout(#aws_config{timeout = Timeout}) ->
+    Timeout.

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -163,7 +163,7 @@ request_impl(Method, _Protocol, _Host, _Port, _Path, Operation, Params, Body, #a
                 erlcloud_httpc:request(
                      url(Config), Method, 
                      [{<<"content-type">>, <<"application/x-amz-json-1.1">>} | Headers],
-                     Body, timeout(Config), Config)) of
+                     Body, erlcloud_aws:get_timeout(Config), Config)) of
        {ok, {_RespHeader, RespBody}} ->
             case Config#aws_config.cloudtrail_raw_result of
                 true -> {ok, RespBody};
@@ -192,8 +192,3 @@ port_spec(#aws_config{cloudtrail_port=80}) ->
 port_spec(#aws_config{cloudtrail_port=Port}) ->
     [":", erlang:integer_to_list(Port)].
 
-
-timeout(#aws_config{timeout = undefined}) ->
-    1000;
-timeout(#aws_config{timeout = Timeout}) ->
-    Timeout.

--- a/src/erlcloud_ddb_impl.erl
+++ b/src/erlcloud_ddb_impl.erl
@@ -114,12 +114,8 @@ timeout(1, #aws_config{timeout = undefined}) ->
     %% Shorter timeout on first request. This is to avoid long (5s) failover when first DDB
     %% endpoint doesn't respond
     1000;
-timeout(_, #aws_config{timeout = undefined}) ->
-    %% Longer timeout on subsequent requsets - results in less timeouts when system is
-    %% under heavy load
-    ?DEFAULT_TIMEOUT;
-timeout(_, #aws_config{timeout = Timeout}) ->
-    Timeout.
+timeout(_, #aws_config{} = Cfg) ->
+    erlcloud_aws:get_timeout(Cfg).
 
 -type attempt() :: {attempt, pos_integer()} | {error, term()}.
 

--- a/src/erlcloud_kinesis_impl.erl
+++ b/src/erlcloud_kinesis_impl.erl
@@ -102,7 +102,7 @@ request_and_retry(Config, Headers, Body, {attempt, Attempt}) ->
     case erlcloud_httpc:request(
            url(Config), post,
            [{<<"content-type">>, <<"application/x-amz-json-1.1">>} | Headers],
-           Body, timeout(Config), Config) of
+           Body, erlcloud_aws:get_timeout(Config), Config) of
 
         {ok, {{200, _}, _, RespBody}} ->
             %% TODO check crc
@@ -166,7 +166,3 @@ port_spec(#aws_config{kinesis_port=80}) ->
 port_spec(#aws_config{kinesis_port=Port}) ->
     [":", erlang:integer_to_list(Port)].
 
-timeout(#aws_config{timeout = undefined}) ->
-    ?DEFAULT_TIMEOUT;
-timeout(#aws_config{timeout = Timeout}) ->
-    Timeout.

--- a/src/erlcloud_mturk.erl
+++ b/src/erlcloud_mturk.erl
@@ -1613,7 +1613,7 @@ mturk_request(Config, Operation, Params) ->
                  post,
                  [{<<"content-type">>, <<"application/x-www-form-urlencoded">>}],
                  list_to_binary(erlcloud_http:make_query_string(QParams)),
-                 timeout(Config), Config),
+                 erlcloud_aws:get_timeout(Config), Config),
 
     case Response of
         {ok, {{200, _StatusLine}, _Headers, Body}} ->
@@ -1623,8 +1623,3 @@ mturk_request(Config, Operation, Params) ->
         {error, Error} ->
             erlang:error({aws_error, {socket_error, Error}})
     end.
-
-timeout(#aws_config{timeout = undefined}) ->
-    ?DEFAULT_TIMEOUT;
-timeout(#aws_config{timeout = Timeout}) ->
-    Timeout.

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -272,10 +272,7 @@ receive_message(QueueName, AttributeNames, MaxNumberOfMessages,
        VisibilityTimeout =:= none,
        (WaitTimeSeconds >= 0 andalso WaitTimeSeconds =< 20) orelse
        WaitTimeSeconds =:= none ->
-    InitialTimeout = case Config#aws_config.timeout of
-        undefined -> ?DEFAULT_TIMEOUT;
-        _ -> Config#aws_config.timeout
-    end,
+    InitialTimeout = erlcloud_aws:get_timeout(Config),
     TotalTimeout = if
        (WaitTimeSeconds =/= none andalso WaitTimeSeconds >= 0 andalso InitialTimeout =/= infinity) ->
            InitialTimeout + (WaitTimeSeconds * 1000) ;


### PR DESCRIPTION
Problem:
follow up on https://github.com/alertlogic/erlcloud/issues/99 and https://github.com/alertlogic/erlcloud/pull/100

Solution:
remove define. update how the library uses timeout.

@smilerlee @nalundgaard please review and merge before it hits other consumers of the library
