### PR TITLE
Adding Mixfile to support Elixir builds

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,37 @@
+defmodule Erlcloud.Mixfile do
+use Mix.Project
+
+    def project do
+        [
+            app: :erlcloud,
+            version: "0.13.1",
+            description: "Cloud Computing library for Erlang (Amazon EC2, S3, SQS, SimpleDB, Mechanical Turk, ELB)",
+            deps: deps,
+            language: :erlang
+        ]
+    end
+
+    def application do
+        [applications:
+            [
+                :kernel,
+                :stdlib,
+                :kernel,
+                :crypto,
+                :public_key,
+                :ssl,
+                :xmerl,
+                :inets,
+                :jsx,
+                :lhttpc
+            ],
+        ]
+    end
+
+    def deps do
+        [
+            {:jsx, "2.8.0"},
+            {:lhttpc, "1.4.0"},
+        ]
+    end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,7 @@ use Mix.Project
         [
             {:jsx, "2.8.0"},
             {:lhttpc, "1.4.0"},
+            {:meck, "0.8.4", only: :test},
         ]
     end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"jsx": {:hex, :jsx, "2.8.0"},
-  "lhttpc": {:hex, :lhttpc, "1.4.0"}}
+  "lhttpc": {:hex, :lhttpc, "1.4.0"},
+  "meck": {:hex, :meck, "0.8.4"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"jsx": {:hex, :jsx, "2.8.0"},
+  "lhttpc": {:hex, :lhttpc, "1.4.0"}}


### PR DESCRIPTION
From issue #267, builds using mix after v0.13 were failing due to dependency resolution issues.  This adds a simple Mixfile that allows erlcloud builds in Elixir along with its dependencies.

Tested locally, as a dependency to my application via a mix dependency of: `{:erlcloud, "~> 0.13", path: "/path/to/dir"}` and it downloaded dependencies, compiled and executed as expected.

Can tweak with feedback, let me know!
