### PR TITLE
Fix `rebar3 edoc` command

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -2229,13 +2229,13 @@ update_table(Table, Opts) ->
 %% ===Example===
 %%
 %% Update table "Thread" to have 10 units of read and write capacity.
-%% Update secondary index <<"SubjectIdx">> to have 10 units of read write capacity 
-%% `
+%% Update secondary index `<<"SubjectIdx">>' to have 10 units of read write capacity
+%% ```
 %% erlcloud_ddb2:update_table(
 %%   <<"Thread">>,
 %%   [{provisioned_throughput, {10, 10}},
 %%    {global_secondary_index_updates, [{<<"SubjectIdx">>, 10, 10}]}])
-%% '
+%% '''
 %% @end
 %%------------------------------------------------------------------------------
 -spec update_table(table_name(), update_table_opts(), aws_config()) -> update_table_return();

--- a/src/erlcloud_ddb_impl.erl
+++ b/src/erlcloud_ddb_impl.erl
@@ -38,7 +38,7 @@
 %%
 %% Here is an example retry function that provides logging and an updated error reason:
 %%
-%% `
+%% ```
 %% retry(Error) ->
 %%     RequestId = erlcloud_ddb_impl:request_id_from_error(Error),
 %%     {_, Operation} = lists:keyfind("x-amz-target", 1, Error#ddb2_error.request_headers),
@@ -50,7 +50,7 @@
 %%                   Error#ddb2_error.request_body]),
 %%     Error2 = erlcloud_ddb_impl:error_reason2(Error),
 %%     erlcloud_ddb_impl:retry(Error2).
-%% `
+%% '''
 %%
 %% @end
 

--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -142,12 +142,11 @@ create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, Attribut
     create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, Attributes, new_config(AccessKeyID, SecretAccessKey)).
 
 
--spec(create_topic/1 :: (string()) -> Arn::string()).
--spec(create_topic/2 :: (string(), aws_config()) -> Arn::string()).
-
+-spec create_topic/1 :: (string()) -> string().
 create_topic(TopicName) ->
     create_topic(TopicName, default_config()).
 
+-spec create_topic/2 :: (string(), aws_config()) -> string().
 create_topic(TopicName, Config)
     when is_record(Config, aws_config) ->
         Doc = sns_xml_request(Config, "CreateTopic", [{"Name", TopicName}]),
@@ -206,11 +205,10 @@ delete_endpoint(EndpointArn, AccessKeyID, SecretAccessKey) ->
 
 
 -spec delete_topic/1 :: (string()) -> ok.
--spec delete_topic/2 :: (string(), aws_config()) -> ok.
-
 delete_topic(TopicArn) ->
     delete_topic(TopicArn, default_config()).
 
+-spec delete_topic/2 :: (string(), aws_config()) -> ok.
 delete_topic(TopicArn, Config)
     when is_record(Config, aws_config) ->
         sns_simple_request(Config, "DeleteTopic", [{"TopicArn", TopicArn}]).
@@ -240,10 +238,9 @@ get_endpoint_attributes(EndpointArn, AccessKeyID, SecretAccessKey) ->
 
 
 -spec set_endpoint_attributes/2 :: (string(), [{sns_endpoint_attribute(), string()}]) -> string().
--spec set_endpoint_attributes/3 :: (string(), [{sns_endpoint_attribute(), string()}], aws_config()) -> string().
-
 set_endpoint_attributes(EndpointArn, Attributes) ->
     set_endpoint_attributes(EndpointArn, Attributes, default_config()).
+-spec set_endpoint_attributes/3 :: (string(), [{sns_endpoint_attribute(), string()}], aws_config()) -> string().
 set_endpoint_attributes(EndpointArn, Attributes, Config) ->
     Doc = sns_xml_request(Config, "SetEndpointAttributes", [{"EndpointArn", EndpointArn} |
                                                             encode_attributes(Attributes)]),
@@ -252,14 +249,12 @@ set_endpoint_attributes(EndpointArn, Attributes, Config) ->
 
 
 -spec list_endpoints_by_platform_application/1 :: (string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
--spec list_endpoints_by_platform_application/2 :: (string(), undefined|string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
--spec list_endpoints_by_platform_application/3 :: (string(), undefined|string(), aws_config()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
--spec list_endpoints_by_platform_application/4 :: (string(), undefined|string(), string(), string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
-
 list_endpoints_by_platform_application(PlatformApplicationArn) ->
     list_endpoints_by_platform_application(PlatformApplicationArn, undefined).
+-spec list_endpoints_by_platform_application/2 :: (string(), undefined|string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
 list_endpoints_by_platform_application(PlatformApplicationArn, NextToken) ->
     list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, default_config()).
+-spec list_endpoints_by_platform_application/3 :: (string(), undefined|string(), aws_config()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
 list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, Config) ->
     Params =
         case NextToken of
@@ -275,21 +270,21 @@ list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, Config
              {next_token, "ListEndpointsByPlatformApplicationResult/NextToken", text}],
             Doc),
     Decoded.
+-spec list_endpoints_by_platform_application/4 :: (string(), undefined|string(), string(), string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
 list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, AccessKeyID, SecretAccessKey) ->
     list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, new_config(AccessKeyID, SecretAccessKey)).
 
 -spec list_topics/0 :: () -> [{topics, [[{arn, string()}]]} | {next_token, string()}].
--spec list_topics/1 :: (undefined | string() | aws_config()) -> [{topics, [[{arn, string()}]]} | {next_token, string()}].
--spec list_topics/2 :: (undefined | string(), aws_config()) ->  [{topics, [[{arn, string()}]]} | {next_token, string()}].
-
 list_topics() ->
     list_topics(default_config()).
 
+-spec list_topics/1 :: (undefined | string() | aws_config()) -> [{topics, [[{arn, string()}]]} | {next_token, string()}].
 list_topics(Config) when is_record(Config, aws_config) ->
     list_topics(undefined, Config);
 list_topics(NextToken) ->
     list_topics(NextToken, default_config()).
 
+-spec list_topics/2 :: (undefined | string(), aws_config()) ->  [{topics, [[{arn, string()}]]} | {next_token, string()}].
 list_topics(NextToken, Config) ->
     Params =
         case NextToken of
@@ -307,10 +302,10 @@ list_topics(NextToken, Config) ->
     Decoded.
 
 -spec list_topics_all/0 :: () -> [[{arn, string()}]].
--spec list_topics_all/1 :: (aws_config()) -> [[{arn, string()}]].
 list_topics_all() ->
     list_topics_all(default_config()).
 
+-spec list_topics_all/1 :: (aws_config()) -> [[{arn, string()}]].
 list_topics_all(Config) ->
     list_all(fun list_topics/2, topics, Config, undefined, []).
 


### PR DESCRIPTION
I've published the result to https://hexdocs.pm/erlcloud/ so the Hex package now shows docs available.

Are there still plans to do a big merge in from the AlertLogic fork? I'd like to do some clean-up and improvement of the edocs, but I can just maintain these docs as-is in a separate branch (closing this PR) if that's better.