### PR TITLE
Add support for aws cli credentials profiles

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -41,6 +41,8 @@
           access_key_id::string()|undefined|false,
           secret_access_key::string()|undefined|false,
           security_token=undefined::string()|undefined,
+          %% epoch seconds when temporary credentials will expire
+          expiration :: pos_integer(),
           %% Network request timeout; if not specifed, the default timeout will be used:
           %% ddb: 1s for initial call, 10s for subsequence;
           %% s3:delete_objects_batch/{2,3}, cloudtrail: 1s;

--- a/rebar.config
+++ b/rebar.config
@@ -17,8 +17,18 @@
 
 {deps, [
         {jsx, "2.8.0"},
-        {lhttpc, "1.4.0"}
+        {lhttpc, "1.4.0"},
+        {eini, ".*",
+         {git, "https://github.com/accense/eini.git",
+          {tag, "1.2.1"}}}
        ]}.
+
+{overrides,
+ [
+  %% do not pull in the covertool plugin or repo, cause it fetches rebar and
+  %% breaks rebar3!
+  {override, eini, [{plugins, []},{deps, []}]}
+ ]}.
 
 {profiles, [
             {test, [{deps, [{meck, "0.8.4"}]}]}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -19,7 +19,7 @@ case erlang:function_exported(rebar3, main, 1) of
         [{deps, [{meck, ".*",{git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}},
                  {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
                  %% {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.2.0"}}},
-                 {eini, ".*", {git, "https://github.com/accense/eini.git", {branch, "master"}}},
+                 {eini, ".*", {git, "https://github.com/accense/eini.git", {tag, "1.2.1"}}},
                  {lhttpc, ".*", {git, "git://github.com/talko/lhttpc", {tag, "1.4.0"}}}]}
          | lists:keydelete(deps, 1, Config1)]
 end.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -19,6 +19,7 @@ case erlang:function_exported(rebar3, main, 1) of
         [{deps, [{meck, ".*",{git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}},
                  {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
                  %% {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.2.0"}}},
+                 {eini, ".*", {git, "https://github.com/accense/eini.git", {branch, "master"}}},
                  {lhttpc, ".*", {git, "git://github.com/talko/lhttpc", {tag, "1.4.0"}}}]}
          | lists:keydelete(deps, 1, Config1)]
 end.

--- a/src/erlcloud_sts.erl
+++ b/src/erlcloud_sts.erl
@@ -4,11 +4,16 @@
 -include_lib("erlcloud/include/erlcloud.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([assume_role/4, assume_role/5,
          get_federation_token/3,
          get_federation_token/4]).
 
 -define(API_VERSION, "2011-06-15").
+-define(UTC_TO_GREGORIAN, 62167219200).
 
 
 assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds) ->
@@ -44,12 +49,13 @@ assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds, ExternalId)
             {expiration       , "AssumeRoleResult/Credentials/Expiration"     , time}
         ],
         Xml),
-
+    ExpireTS = expiration_tosecs( proplists:get_value(expiration, Creds) ),
     AssumedConfig =
         AwsConfig#aws_config {
             access_key_id     = proplists:get_value(access_key_id, Creds),
             secret_access_key = proplists:get_value(secret_access_key, Creds),
-            security_token    = proplists:get_value(session_token, Creds)
+            security_token    = proplists:get_value(session_token, Creds),
+            expiration        = ExpireTS
         },
 
     {AssumedConfig, Creds}.
@@ -82,16 +88,18 @@ get_federation_token(AwsConfig, DurationSeconds, Name, Policy)
                {access_key_id       , "GetFederationTokenResult/Credentials/AccessKeyId", text},
                {secret_access_key   , "GetFederationTokenResult/Credentials/SecretAccessKey", text},
                {session_token       , "GetFederationTokenResult/Credentials/SessionToken"   , text},
+               {expiration          , "GetFederationTokenResult/Credentials/Expiration", text},
                {federated_user_arn  , "GetFederationTokenResult/FederatedUser/Arn", text},
                {federated_user_id   , "GetFederationTokenResult/FederatedUser/FederatedUserId", text}
               ],
               Xml),
-
+    ExpireTS = expiration_tosecs( proplists:get_value(expiration, Creds) ),
     FederatedConfig =
         AwsConfig#aws_config {
           access_key_id     = proplists:get_value(access_key_id, Creds),
           secret_access_key = proplists:get_value(secret_access_key, Creds),
-          security_token    = proplists:get_value(session_token, Creds)
+          security_token    = proplists:get_value(session_token, Creds),
+          expiration        = ExpireTS
          },
 
     {FederatedConfig, Creds}.
@@ -107,3 +115,32 @@ sts_query(AwsConfig, Action, Params, ApiVersion) ->
         [{"Action", Action}, {"Version", ApiVersion} | Params],
         AwsConfig
     ).
+
+
+expiration_tosecs( Timestamp ) ->
+    {ok, [Year,Month,Day,Hour,Min,Sec,_Ms],[]} =
+        io_lib:fread( "~4d-~2d-~2dT~2d:~2d:~2d.~3dZ", Timestamp ),
+    GregorianSeconds = calendar:datetime_to_gregorian_seconds(
+                         {{Year,Month,Day},{Hour,Min,Sec}} ),
+    (GregorianSeconds - ?UTC_TO_GREGORIAN).
+
+    
+
+-ifdef(TEST).
+
+expiration_tosecs_test() ->
+    Timestamp = "2011-07-15T23:28:33.359Z",
+    ?assertEqual( 1310772513, expiration_tosecs( Timestamp ) ).
+
+
+-endif.
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Allow config credentials to be sourced from the `~/.aws/credentials`
and support both `source_profile` and `role_arn` specifications.