### PR TITLE
Fixes for Erlang/OTP 19.0

### DIFF
--- a/src/erlcloud_as.erl
+++ b/src/erlcloud_as.erl
@@ -1,7 +1,7 @@
 -module(erlcloud_as).
 
--include_lib("erlcloud/include/erlcloud_aws.hrl").
--include_lib("erlcloud/include/erlcloud_as.hrl").
+-include("erlcloud_aws.hrl").
+-include("erlcloud_as.hrl").
 
 %% AWS Autoscaling functions
 -export([describe_groups/0, describe_groups/1, describe_groups/2, describe_groups/4,

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -21,7 +21,7 @@
 ]).
 
 -include("erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud_aws.hrl").
 
 -define(ERLCLOUD_RETRY_TIMEOUT, 10000).
 

--- a/src/erlcloud_cloudformation.erl
+++ b/src/erlcloud_cloudformation.erl
@@ -1,7 +1,7 @@
 -module (erlcloud_cloudformation).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 
 -define(API_VERSION, "2010-05-15").
 

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -1,7 +1,7 @@
 -module(erlcloud_cloudtrail).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 
 %% EC2 API Functions
 -export([

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -27,14 +27,14 @@
 %%
 %% API
 %%
--spec(create_trail/3 :: (string(), string(), aws_config()) -> ct_return()).
+-spec create_trail(string(), string(), aws_config()) -> ct_return().
 create_trail(Trail, S3BucketName, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}, 
             {<<"S3BucketName">>, list_to_binary(S3BucketName)}
            ],
     ct_request("CreateTrail", Json, Config).
 
--spec(create_trail/4 :: (string(), string(), string(), aws_config()) -> ct_return()).
+-spec create_trail(string(), string(), string(), aws_config()) -> ct_return().
 create_trail(Trail, S3BucketName, SnsTopicName,  Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}, 
             {<<"S3BucketName">>, list_to_binary(S3BucketName)},
@@ -42,7 +42,7 @@ create_trail(Trail, S3BucketName, SnsTopicName,  Config) ->
            ],
     ct_request("CreateTrail", Json, Config).
 
--spec(create_trail/5 :: (string(), string(), string(), boolean(), aws_config()) -> ct_return()).
+-spec create_trail(string(), string(), string(), boolean(), aws_config()) -> ct_return().
 create_trail(Trail, S3BucketName, SnsTopicName, IncludeGlobalServiceEvents, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}, 
             {<<"S3BucketName">>, list_to_binary(S3BucketName)},
@@ -51,7 +51,7 @@ create_trail(Trail, S3BucketName, SnsTopicName, IncludeGlobalServiceEvents, Conf
            ],
     ct_request("CreateTrail", Json, Config).
 
--spec(create_trail/6 :: (string(), string(), string(), string(), boolean(), aws_config()) -> ct_return()).
+-spec create_trail(string(), string(), string(), string(), boolean(), aws_config()) -> ct_return().
 create_trail(Trail, S3BucketName, S3KeyPrefix, SnsTopicName, IncludeGlobalServiceEvents, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}, 
             {<<"S3BucketName">>, list_to_binary(S3BucketName)},
@@ -61,19 +61,19 @@ create_trail(Trail, S3BucketName, S3KeyPrefix, SnsTopicName, IncludeGlobalServic
            ],
     ct_request("CreateTrail", Json, Config).
 
--spec(delete_trail/1 :: ([string()] ) -> ct_return()).
+-spec delete_trail([string()]) -> ct_return().
 delete_trail(Trail) ->
     delete_trail(Trail, default_config()).
 
--spec(delete_trail/2 :: ([string()], aws_config()) -> ct_return()).
+-spec delete_trail([string()], aws_config()) -> ct_return().
 delete_trail(Trail, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}],
     ct_request("DeleteTrail", Json, Config).
 
--spec(describe_trails/0 :: () -> ct_return()).
+-spec describe_trails() -> ct_return().
 describe_trails() -> describe_trails([]).
 
--spec(describe_trails/1 :: ([string()] | aws_config()) -> ct_return()).
+-spec describe_trails([string()] | aws_config()) -> ct_return().
 describe_trails(Config) when is_record(Config, aws_config) ->
     describe_trails([], Config);
 
@@ -82,7 +82,7 @@ describe_trails(Config) when is_record(Config, aws_config) ->
 describe_trails(Trails) ->
     describe_trails(Trails, default_config()).
 
--spec(describe_trails/2 :: ([string()], aws_config()) -> ct_return()).
+-spec describe_trails([string()], aws_config()) -> ct_return().
 describe_trails([], Config) ->
     ct_request("DescribeTrails", [], Config);
 
@@ -91,34 +91,34 @@ describe_trails(Trails, Config) ->
     Json = [{<<"TrailNameList">>, [list_to_binary(T) || T <- Trails]}],
     ct_request("DescribeTrails", Json, Config).
 
--spec(get_trail_status/1 :: ([string()] ) -> ct_return()).
+-spec get_trail_status([string()] ) -> ct_return().
 get_trail_status(Trail) ->
     get_trail_status(Trail, default_config()).
 
--spec(get_trail_status/2 :: ([string()], aws_config()) -> ct_return()).
+-spec get_trail_status([string()], aws_config()) -> ct_return().
 get_trail_status(Trail, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}],
     ct_request("GetTrailStatus", Json, Config).
 
--spec(start_logging/1 :: ([string()] ) -> ct_return()).
+-spec start_logging([string()] ) -> ct_return().
 start_logging(Trail) ->
     start_logging(Trail, default_config()).
 
--spec(start_logging/2 :: ([string()], aws_config()) -> ct_return()).
+-spec start_logging([string()], aws_config()) -> ct_return().
 start_logging(Trail, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}],
     ct_request("StartLogging", Json, Config).
 
--spec(stop_logging/1 :: ([string()] ) -> ct_return()).
+-spec stop_logging([string()] ) -> ct_return().
 stop_logging(Trail) ->
     stop_logging(Trail, default_config()).
 
--spec(stop_logging/2 :: ([string()], aws_config()) -> ct_return()).
+-spec stop_logging([string()], aws_config()) -> ct_return().
 stop_logging(Trail, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}],
     ct_request("StopLogging", Json, Config).
 
--spec(update_trail/4 :: (string(), string(), string(), aws_config()) -> ct_return()).
+-spec update_trail(string(), string(), string(), aws_config()) -> ct_return().
 update_trail(Trail, S3BucketName, SnsTopicName, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}, 
             {<<"S3BucketName">>, list_to_binary(S3BucketName)},
@@ -126,7 +126,7 @@ update_trail(Trail, S3BucketName, SnsTopicName, Config) ->
            ],
     ct_request("UpdateTrail", Json, Config).
 
--spec(update_trail/5 :: (string(), string(), string(), boolean(), aws_config()) -> ct_return()).
+-spec update_trail(string(), string(), string(), boolean(), aws_config()) -> ct_return().
 update_trail(Trail, S3BucketName, SnsTopicName, IncludeGlobalServiceEvents, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}, 
             {<<"S3BucketName">>, list_to_binary(S3BucketName)},
@@ -136,7 +136,7 @@ update_trail(Trail, S3BucketName, SnsTopicName, IncludeGlobalServiceEvents, Conf
     ct_request("UpdateTrail", Json, Config).
 
 
--spec(update_trail/6 :: (string(), string(), string(), string(), boolean(), aws_config()) -> ct_return()).
+-spec update_trail(string(), string(), string(), string(), boolean(), aws_config()) -> ct_return().
 update_trail(Trail, S3BucketName, S3KeyPrefix, SnsTopicName, IncludeGlobalServiceEvents, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}, 
             {<<"S3BucketName">>, list_to_binary(S3BucketName)},

--- a/src/erlcloud_ddb.erl
+++ b/src/erlcloud_ddb.erl
@@ -176,23 +176,23 @@
 %%% Library initialization.
 %%%------------------------------------------------------------------------------
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 ddb_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -202,25 +202,25 @@
 %%% Library initialization.
 %%%------------------------------------------------------------------------------
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 ddb_host=Host}.
 
--spec(new/4 :: (string(), string(), string(), non_neg_integer()) -> aws_config()).
+-spec new(string(), string(), string(), non_neg_integer()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host, Port) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 ddb_host=Host,
                 ddb_port=Port}.
 
--spec(new/5 :: (string(), string(), string(), non_neg_integer(), string()) -> aws_config()).
+-spec new(string(), string(), string(), non_neg_integer(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host, Port, Scheme) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
@@ -228,22 +228,22 @@ new(AccessKeyID, SecretAccessKey, Host, Port, Scheme) ->
                 ddb_port=Port,
                 ddb_scheme=Scheme}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
--spec(configure/4 :: (string(), string(), string(), non_neg_integer()) -> ok).
+-spec configure(string(), string(), string(), non_neg_integer()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host, Port) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host, Port)),
     ok.
 
--spec(configure/5 :: (string(), string(), string(), non_neg_integer(), string()) -> ok).
+-spec configure(string(), string(), string(), non_neg_integer(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host, Port, Scheme) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host, Port, Scheme)),
     ok.

--- a/src/erlcloud_ddb_streams.erl
+++ b/src/erlcloud_ddb_streams.erl
@@ -90,25 +90,25 @@
 %%% Library initialization.
 %%%------------------------------------------------------------------------------
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 retry = fun erlcloud_retry:default_retry/1}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 ddb_streams_host=Host,
                 retry = fun erlcloud_retry:default_retry/1}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -166,9 +166,9 @@
 % -define(NEW_API_VERSION, "2013-10-15").
 % -define(NEW_API_VERSION, "2014-02-01").
 -define(NEW_API_VERSION, "2015-10-01").
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
--include_lib("erlcloud/include/erlcloud_ec2.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
+-include("erlcloud_ec2.hrl").
 
 -type filter_list() :: [{string(),[string()]}].
 

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -170,41 +170,41 @@
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 -include_lib("erlcloud/include/erlcloud_ec2.hrl").
 
--type(filter_list() :: [{string(),[string()]}]).
+-type filter_list() :: [{string(),[string()]}].
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 ec2_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
 %%
 %%
--spec(allocate_address/0 :: () -> {ok, string()} | {error, any()}).
+-spec allocate_address() -> {ok, string()} | {error, any()}.
 allocate_address() -> allocate_address(none, default_config()).
 
--spec(allocate_address/1 :: (aws_config()) -> {ok, string()} | {error, any()}).
+-spec allocate_address(aws_config()) -> {ok, string()} | {error, any()}.
 allocate_address(Config) when is_record(Config, aws_config) ->
     allocate_address(none, Config);
 allocate_address(Domain) when is_atom(Domain) ->
     allocate_address(Domain, default_config()).
 
--spec(allocate_address/2 :: (none | vpc, aws_config()) -> {ok, string()} | {ok, {string() | string()}} | {error, any()}).
+-spec allocate_address(none | vpc, aws_config()) -> {ok, string()} | {ok, {string() | string()}} | {error, any()}.
 allocate_address(Domain, Config) ->
     Params = case Domain of
                  vpc -> [{"Domain", "vpc"}];
@@ -225,11 +225,11 @@ allocate_address(Domain, Config) ->
 
 %%
 %%
--spec(associate_address/2 :: (string(), string()) -> ok | {error, any()}).
+-spec associate_address(string(), string()) -> ok | {error, any()}.
 associate_address(PublicIP, InstanceID) ->
     associate_address(PublicIP, InstanceID, default_config()).
 
--spec(associate_address/3 :: (string(), string(), string() | aws_config()) -> ok | {error, any()}).
+-spec associate_address(string(), string(), string() | aws_config()) -> ok | {error, any()}.
 associate_address(PublicIP, InstanceID, Config)
   when is_list(PublicIP), is_list(InstanceID), is_record(Config, aws_config) ->
     associate_address(PublicIP, InstanceID, none, Config);
@@ -237,7 +237,7 @@ associate_address(PublicIP, InstanceID, AllocationID)
   when is_list(PublicIP), is_list(InstanceID), is_list(AllocationID) ->
     associate_address(PublicIP, InstanceID, AllocationID, default_config()).
 
--spec(associate_address/4 :: (string(), string(), string() | none, aws_config()) -> ok | {error, any()}).
+-spec associate_address(string(), string(), string() | none, aws_config()) -> ok | {error, any()}.
 associate_address(PublicIP, InstanceID, AllocationID, Config) ->
     AllocationParam = case AllocationID of
                           none -> [{ "PublicIp", PublicIP} ];
@@ -249,22 +249,22 @@ associate_address(PublicIP, InstanceID, AllocationID, Config) ->
 
 %%
 %%
--spec(associate_dhcp_options/2 :: (string(), string()) -> ok | {error, any()}).
+-spec associate_dhcp_options(string(), string()) -> ok | {error, any()}.
 associate_dhcp_options(OptionsID, VpcID) ->
     associate_dhcp_options(OptionsID, VpcID, default_config()).
 
--spec(associate_dhcp_options/3 :: (string(), string(), aws_config()) -> ok | {error, any()}).
+-spec associate_dhcp_options(string(), string(), aws_config()) -> ok | {error, any()}.
 associate_dhcp_options(OptionsID, VpcID, Config) ->
     ec2_simple_query2(Config, "AssociateDhcpOptions",
                      [{"DhcpOptionsId", OptionsID}, {"VpcId", VpcID}]).
 
 %%
 %%
--spec(associate_route_table/2 :: (string(), string()) -> {ok, string()} | {error, any()}).
+-spec associate_route_table(string(), string()) -> {ok, string()} | {error, any()}.
 associate_route_table(RouteTableID, SubnetID) ->
     associate_route_table(RouteTableID, SubnetID, default_config()).
 
--spec(associate_route_table/3 :: (string(), string(), aws_config()) -> {ok, string()} | {error, any()}).
+-spec associate_route_table(string(), string(), aws_config()) -> {ok, string()} | {error, any()}.
 associate_route_table(RouteTableID, SubnetID, Config) ->
     Params = [{"RouteTableId", RouteTableID}, {"SubnetId", SubnetID}],
     case ec2_query2(Config, "AssociateRouteTable", Params, ?NEW_API_VERSION) of
@@ -276,11 +276,11 @@ associate_route_table(RouteTableID, SubnetID, Config) ->
 
 %%
 %%
--spec(attach_internet_gateway/2 :: (string(), string()) -> {ok, proplist()} | {error, any()}).
+-spec attach_internet_gateway(string(), string()) -> {ok, proplist()} | {error, any()}.
 attach_internet_gateway(GatewayID, VpcID) ->
     attach_internet_gateway(GatewayID, VpcID, default_config()).
 
--spec(attach_internet_gateway/3 :: (string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec attach_internet_gateway(string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 attach_internet_gateway(GatewayID, VpcID, Config) ->
     ec2_simple_query2(Config, "AttachInternetGateway",
                      [{"InternetGatewayId", GatewayID},
@@ -289,11 +289,11 @@ attach_internet_gateway(GatewayID, VpcID, Config) ->
 
 %%
 %%
--spec(attach_volume/3 :: (string(), string(), string()) -> {ok, proplist()} | {error, any()}).
+-spec attach_volume(string(), string(), string()) -> {ok, proplist()} | {error, any()}.
 attach_volume(VolumeID, InstanceID, Device) ->
     attach_volume(VolumeID, InstanceID, Device, default_config()).
 
--spec(attach_volume/4 :: (string(), string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec attach_volume(string(), string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 attach_volume(VolumeID, InstanceID, Device, Config)
   when is_list(VolumeID), is_list(InstanceID), is_list(Device) ->
     case ec2_query2(Config, "AttachVolume", [{"InstanceId", InstanceID}, {"Device", Device}, {"VolumeId", VolumeID}]) of
@@ -317,11 +317,11 @@ extract_volume_status(Node) ->
 
 %%
 %%
--spec(authorize_security_group_ingress/2 :: (string(), ec2_ingress_spec()) -> ok | {error, any()}).
+-spec authorize_security_group_ingress(string(), ec2_ingress_spec()) -> ok | {error, any()}.
 authorize_security_group_ingress(GroupName, IngressSpec) ->
     authorize_security_group_ingress(GroupName, IngressSpec, default_config()).
 
--spec(authorize_security_group_ingress/3 :: (string(), ec2_ingress_spec() | [ vpc_ingress_spec() ], aws_config()) -> ok | {error, any()}).
+-spec authorize_security_group_ingress(string(), ec2_ingress_spec() | [ vpc_ingress_spec() ], aws_config()) -> ok | {error, any()}.
 authorize_security_group_ingress(GroupName, IngressSpec, Config)
   when is_list(GroupName), is_record(IngressSpec, ec2_ingress_spec) ->
     Params = [{"GroupName", GroupName}|ingress_spec_params(IngressSpec)],
@@ -377,13 +377,13 @@ vpc_ingress_details_to_params([H|T], Count, Prefix, Suffix, DetailCount, Res) ->
 
 %%
 %%
--spec(bundle_instance/6 :: (string(), string(), string(), string(), string(), string()) -> {ok, proplist()} | {error, any()}).
+-spec bundle_instance(string(), string(), string(), string(), string(), string()) -> {ok, proplist()} | {error, any()}.
 bundle_instance(InstanceID, Bucket, Prefix, AccessKeyID, UploadPolicy,
                 UploadPolicySignature) ->
     bundle_instance(InstanceID, Bucket, Prefix, AccessKeyID, UploadPolicy,
                     UploadPolicySignature, default_config()).
 
--spec(bundle_instance/7 :: (string(), string(), string(), string(), string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec bundle_instance(string(), string(), string(), string(), string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 bundle_instance(InstanceID, Bucket, Prefix, AccessKeyID, UploadPolicy,
                 UploadPolicySignature, Config) ->
     case ec2_query2(Config, "BundleInstance",
@@ -411,11 +411,11 @@ extract_bundle_task([Node]) ->
 
 %%
 %%
--spec(cancel_bundle_task/1 :: (string()) -> {ok, proplist()} | {error, any()}).
+-spec cancel_bundle_task(string()) -> {ok, proplist()} | {error, any()}.
 cancel_bundle_task(BundleID) ->
     cancel_bundle_task(BundleID, default_config()).
 
--spec(cancel_bundle_task/2 :: (string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec cancel_bundle_task(string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 cancel_bundle_task(BundleID, Config)
   when is_list(BundleID) ->
     case ec2_query2(Config, "CancelBundleTask", [{"BundleId", BundleID}]) of
@@ -427,11 +427,11 @@ cancel_bundle_task(BundleID, Config)
 
 %%
 %%
--spec(cancel_spot_instance_requests/1 :: ([string()]) -> {ok, [proplist()]} | {error, any()}).
+-spec cancel_spot_instance_requests([string()]) -> {ok, [proplist()]} | {error, any()}.
 cancel_spot_instance_requests(SpotInstanceRequestIDs) ->
     cancel_spot_instance_requests(SpotInstanceRequestIDs, default_config()).
 
--spec(cancel_spot_instance_requests/2 :: ([string()], aws_config()) -> {ok, [proplist()]} | {error, any()}).
+-spec cancel_spot_instance_requests([string()], aws_config()) -> {ok, [proplist()]} | {error, any()}.
 cancel_spot_instance_requests(SpotInstanceRequestIDs, Config)
   when is_list(SpotInstanceRequestIDs) ->
     case ec2_query2(Config, "CancelSpotInstanceRequests",
@@ -451,11 +451,11 @@ extract_spot_instance_state(Node) ->
 
 %%
 %%
--spec(confirm_product_instance/2 :: (string(), string()) -> {ok, proplist()} | {error, any()}).
+-spec confirm_product_instance(string(), string()) -> {ok, proplist()} | {error, any()}.
 confirm_product_instance(ProductCode, InstanceID) ->
     confirm_product_instance(ProductCode, InstanceID, default_config()).
 
--spec(confirm_product_instance/3 :: (string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec confirm_product_instance(string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 confirm_product_instance(ProductCode, InstanceID, Config)
   when is_list(ProductCode), is_list(InstanceID) ->
     Params = [{"ProductCode", ProductCode}, {"InstanceId", InstanceID}],
@@ -471,10 +471,10 @@ confirm_product_instance(ProductCode, InstanceID, Config)
 
 %%
 %%
--spec(create_key_pair/1 :: (string()) -> {ok, proplist()} | {error, any()}).
+-spec create_key_pair(string()) -> {ok, proplist()} | {error, any()}.
 create_key_pair(KeyName) -> create_key_pair(KeyName, default_config()).
 
--spec(create_key_pair/2 :: (string(), aws_config()) -> proplist()).
+-spec create_key_pair(string(), aws_config()) -> proplist().
 create_key_pair(KeyName, Config)
   when is_list(KeyName) ->
     case ec2_query2(Config, "CreateKeyPair", [{"KeyName", KeyName}]) of
@@ -490,24 +490,24 @@ create_key_pair(KeyName, Config)
 
 %%
 %%
--spec(create_image/2 :: (string(), string()) -> {ok, proplist()} | {error, any()}).
+-spec create_image(string(), string()) -> {ok, proplist()} | {error, any()}.
 create_image(InstanceID, Name) -> create_image(InstanceID, Name, default_config()).
 
--spec(create_image/3 :: (string(), string(), string() | aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_image(string(), string(), string() | aws_config()) -> {ok, proplist()} | {error, any()}.
 create_image(InstanceID, Name, Config)
   when is_record(Config, aws_config) ->
     create_image(InstanceID, Name, none, Config);
 create_image(InstanceID, Name, Description) ->
     create_image(InstanceID, Name, Description, default_config()).
 
--spec(create_image/4 :: (string(), string(), string() | none, boolean() | aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_image(string(), string(), string() | none, boolean() | aws_config()) -> {ok, proplist()} | {error, any()}.
 create_image(InstanceID, Name, Description, Config)
   when is_record(Config, aws_config) ->
     create_image(InstanceID, Name, Description, false, Config);
 create_image(InstanceID, Name, Description, NoReboot) ->
     create_image(InstanceID, Name, Description, NoReboot, default_config()).
 
--spec(create_image/5 :: (string(), string(), string() | none, boolean(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_image(string(), string(), string() | none, boolean(), aws_config()) -> {ok, proplist()} | {error, any()}.
 create_image(InstanceID, Name, Description, NoReboot, Config)
   when is_list(InstanceID), is_list(Name),
        is_list(Description) orelse Description =:= none,
@@ -523,11 +523,11 @@ create_image(InstanceID, Name, Description, NoReboot, Config)
 
 %%
 %%
--spec(create_internet_gateway/0 :: () -> {ok, proplist()} | {error, any()}).
+-spec create_internet_gateway() -> {ok, proplist()} | {error, any()}.
 create_internet_gateway() ->
     create_internet_gateway(default_config()).
 
--spec(create_internet_gateway/1 :: (aws_config()) -> proplist()).
+-spec create_internet_gateway(aws_config()) -> proplist().
 create_internet_gateway(Config) ->
     case ec2_query2(Config, "CreateInternetGateway", [], ?NEW_API_VERSION) of
         {ok, Doc} ->
@@ -539,11 +539,11 @@ create_internet_gateway(Config) ->
 
 %%
 %%
--spec(create_network_acl/1 :: (string()) -> {ok, proplist()} | {error, any()}).
+-spec create_network_acl(string()) -> {ok, proplist()} | {error, any()}.
 create_network_acl(VpcID) ->
     create_network_acl(VpcID, default_config()).
 
--spec(create_network_acl/2 :: (string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_network_acl(string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 create_network_acl(VpcID, Config) ->
     case ec2_query2(Config, "CreateNetworkAcl", [{"VpcId", VpcID}], ?NEW_API_VERSION) of
         {ok, Doc} ->
@@ -591,11 +591,11 @@ extract_port_range([Node]) ->
 
 %%
 %%
--spec(create_network_acl_entry/1 :: (ec2_network_acl_spec()) -> ok | {error, any()}).
+-spec create_network_acl_entry(ec2_network_acl_spec()) -> ok | {error, any()}.
 create_network_acl_entry(Spec) ->
     create_network_acl_entry(Spec, default_config()).
 
--spec(create_network_acl_entry/2 :: (ec2_network_acl_spec(), aws_config()) -> ok | {error, any()}).
+-spec create_network_acl_entry(ec2_network_acl_spec(), aws_config()) -> ok | {error, any()}.
 create_network_acl_entry(Spec, Config) ->
     Params = network_acl_spec_to_params(Spec),
     ec2_simple_query2(Config, "CreateNetworkAclEntry", Params, ?NEW_API_VERSION).
@@ -614,11 +614,11 @@ network_acl_spec_to_params(Spec) ->
 
 %%
 %%
--spec(create_route/4 :: (string(), string(), gateway_id | instance_id | network_interface_id, string()) -> ok | {error, any()}).
+-spec create_route(string(), string(), gateway_id | instance_id | network_interface_id, string()) -> ok | {error, any()}.
 create_route(RouteTableID, DestCidrBl, Attachment, Val) ->
     create_route(RouteTableID, DestCidrBl, Attachment, Val, default_config()).
 
--spec(create_route/5 :: (string(), string(), gateway_id | instance_id | network_interface_id, string(), aws_config()) -> ok | {error, any()}).
+-spec create_route(string(), string(), gateway_id | instance_id | network_interface_id, string(), aws_config()) -> ok | {error, any()}.
 create_route(RouteTableID, DestCidrBl, Attachment, Val, Config) ->
     ASpec= case Attachment of
                gateway_id -> {"GatewayId", Val};
@@ -633,11 +633,11 @@ create_route(RouteTableID, DestCidrBl, Attachment, Val, Config) ->
 
 %%
 %%
--spec(create_route_table/1 :: (string()) -> {ok, [proplist()]} | {error, any()}).
+-spec create_route_table(string()) -> {ok, [proplist()]} | {error, any()}.
 create_route_table(VpcID) ->
     create_route_table(VpcID, default_config()).
 
--spec(create_route_table/2 :: (string(), aws_config()) -> {ok, [proplist()]} | {error, any()}).
+-spec create_route_table(string(), aws_config()) -> {ok, [proplist()]} | {error, any()}.
 create_route_table(VpcID, Config) ->
     case ec2_query2(Config, "CreateRouteTable", [{"VpcId", VpcID}], ?NEW_API_VERSION) of
         {ok, Doc} ->
@@ -650,17 +650,17 @@ create_route_table(VpcID, Config) ->
 
 %%
 %%
--spec(create_subnet/2 :: (string(), string()) -> {ok, proplist()} | {error, any()}).
+-spec create_subnet(string(), string()) -> {ok, proplist()} | {error, any()}.
 create_subnet(VpcID, CIDR) when is_list(VpcID), is_list(CIDR) ->
     create_subnet(VpcID, CIDR, none, default_config()).
 
--spec(create_subnet/3 :: (string(), string(), string() | aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_subnet(string(), string(), string() | aws_config()) -> {ok, proplist()} | {error, any()}.
 create_subnet(VpcID, CIDR, Config) when is_record(Config, aws_config) ->
     create_subnet(VpcID, CIDR, none, Config);
 create_subnet(VpcID, CIDR, Zone) when is_list(Zone) ->
     create_subnet(VpcID, CIDR, Zone, default_config()).
 
--spec(create_subnet/4 :: (string(), string(), string() | none, aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_subnet(string(), string(), string() | none, aws_config()) -> {ok, proplist()} | {error, any()}.
 create_subnet(VpcID, CIDR, Zone, Config) when
       is_list(VpcID), is_list(CIDR), is_list(Zone) orelse Zone =:= none ->
     Params = [{"VpcId", VpcID}, {"CidrBlock", CIDR},
@@ -675,18 +675,18 @@ create_subnet(VpcID, CIDR, Zone, Config) when
 
 %%
 %%
--spec(create_security_group/2 :: (string(), string()) -> ok | {error, any()}).
+-spec create_security_group(string(), string()) -> ok | {error, any()}.
 create_security_group(GroupName, GroupDescription) ->
     create_security_group(GroupName, GroupDescription, none, default_config()).
 
--spec(create_security_group/3 :: (string(), string(), aws_config() | string() | none) -> ok | {error, any()}).
+-spec create_security_group(string(), string(), aws_config() | string() | none) -> ok | {error, any()}.
 create_security_group(GroupName, GroupDescription, Config)
   when is_record(Config, aws_config) ->
     create_security_group(GroupName, GroupDescription, none, Config);
 create_security_group(GroupName, GroupDescription, VpcID) ->
     create_security_group(GroupName, GroupDescription, VpcID, default_config()).
 
--spec(create_security_group/4 :: (string(), string(), string() | none, aws_config()) -> ok | {error, any()}).
+-spec create_security_group(string(), string(), string() | none, aws_config()) -> ok | {error, any()}.
 create_security_group(GroupName, GroupDescription, VpcID, Config)
   when is_list(GroupName), is_list(GroupDescription) ->
     case ec2_query2(Config, "CreateSecurityGroup",
@@ -703,18 +703,18 @@ create_security_group(GroupName, GroupDescription, VpcID, Config)
 
 %%
 %%
--spec(create_snapshot/1 :: (string()) -> {ok, proplist()} | {error, any()}).
+-spec create_snapshot(string()) -> {ok, proplist()} | {error, any()}.
 create_snapshot(VolumeID) ->
     create_snapshot(VolumeID, "", default_config()).
 
--spec(create_snapshot/2 :: (string(), string()) -> proplist() ; (string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_snapshot(string(), string()) -> proplist() ; (string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 create_snapshot(VolumeID, Config)
   when is_record(Config, aws_config) ->
     create_snapshot(VolumeID, "", Config);
 create_snapshot(VolumeID, Description) ->
     create_snapshot(VolumeID, Description, default_config()).
 
--spec(create_snapshot/3 :: (string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_snapshot(string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 create_snapshot(VolumeID, Description, Config)
   when is_list(VolumeID), is_list(Description) ->
     case ec2_query2(Config, "CreateSnapshot", [{"VolumeId", VolumeID}, {"Description", Description}]) of
@@ -735,18 +735,18 @@ create_snapshot(VolumeID, Description, Config)
 
 %%
 %%
--spec(create_spot_datafeed_subscription/1 :: (string()) -> {ok, proplist()} | {error, any()}).
+-spec create_spot_datafeed_subscription(string()) -> {ok, proplist()} | {error, any()}.
 create_spot_datafeed_subscription(Bucket) ->
     create_spot_datafeed_subscription(Bucket, none).
 
--spec(create_spot_datafeed_subscription/2 :: (string(), string() | none | aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_spot_datafeed_subscription(string(), string() | none | aws_config()) -> {ok, proplist()} | {error, any()}.
 create_spot_datafeed_subscription(Bucket, Config)
   when is_record(Config, aws_config) ->
     create_spot_datafeed_subscription(Bucket, none, Config);
 create_spot_datafeed_subscription(Bucket, Prefix) ->
     create_spot_datafeed_subscription(Bucket, Prefix, default_config()).
 
--spec(create_spot_datafeed_subscription/3 :: (string(), string() | none, aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_spot_datafeed_subscription(string(), string() | none, aws_config()) -> {ok, proplist()} | {error, any()}.
 create_spot_datafeed_subscription(Bucket, Prefix, Config)
   when is_list(Bucket),
        is_list(Prefix) orelse Prefix =:= none ->
@@ -770,15 +770,15 @@ extract_spot_datafeed_subscription([Node]) ->
 
 %%
 %%
--spec(create_volume/3 :: (ec2_volume_size(), string(), string()) -> {ok, proplist()} | {error, any()}).
+-spec create_volume(ec2_volume_size(), string(), string()) -> {ok, proplist()} | {error, any()}.
 create_volume(Size, SnapshotID, AvailabilityZone) ->
     create_volume(Size, SnapshotID, AvailabilityZone,"standard", default_config()).
 
--spec(create_volume/4 :: (ec2_volume_size(), string(), string(), string()) -> {ok, proplist()} | {error, any()}).
+-spec create_volume(ec2_volume_size(), string(), string(), string()) -> {ok, proplist()} | {error, any()}.
 create_volume(Size, SnapshotID, AvailabilityZone, VolumeType) ->
     create_volume(Size, SnapshotID, AvailabilityZone,VolumeType, default_config()).
 
--spec(create_volume/5 :: (ec2_volume_size(), string(), string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_volume(ec2_volume_size(), string(), string(), string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 create_volume(Size, SnapshotID, AvailabilityZone, VolumeType, Config)
   when ((VolumeType == "standard" andalso Size >= 1 andalso Size =< 1024) orelse
         (VolumeType == "gp2" andalso Size >= 1 andalso Size =< 16384) orelse
@@ -808,17 +808,17 @@ create_volume(Size, SnapshotID, AvailabilityZone, VolumeType, Config)
 
 %%
 %%
--spec(create_vpc/1 :: (string()) -> {ok, proplist()} | {error, any()}).
+-spec create_vpc(string()) -> {ok, proplist()} | {error, any()}.
 create_vpc(CIDR) ->
     create_vpc(CIDR, none, default_config()).
 
--spec(create_vpc/2 :: (string(), string() | none | aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_vpc(string(), string() | none | aws_config()) -> {ok, proplist()} | {error, any()}.
 create_vpc(CIDR, InsTen) when is_list(InsTen) ->
     create_vpc(CIDR, InsTen, default_config());
 create_vpc(CIDR, Config) when is_record(Config, aws_config) ->
     create_vpc(CIDR, none, Config).
 
--spec(create_vpc/3 :: (string(), string() | none, aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec create_vpc(string(), string() | none, aws_config()) -> {ok, proplist()} | {error, any()}.
 create_vpc(CIDR, InsTen, Config) when
       is_list(CIDR), is_list(InsTen) orelse InsTen =:= none ->
     case ec2_query2(Config, "CreateVpc", [{"CidrBlock", CIDR}, {"instanceTenancy", InsTen}]) of
@@ -835,50 +835,50 @@ create_vpc(CIDR, InsTen, Config) when
 
 %%
 %%
--spec(delete_internet_gateway/1 :: (string()) -> ok | {error, any()}).
+-spec delete_internet_gateway(string()) -> ok | {error, any()}.
 delete_internet_gateway(GatewayID) ->
     delete_internet_gateway(GatewayID, default_config()).
 
--spec(delete_internet_gateway/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec delete_internet_gateway(string(), aws_config()) -> ok | {error, any()}.
 delete_internet_gateway(GatewayID, Config) ->
     ec2_simple_query2(Config, "DeleteInternetGateway",
                      [{"InternetGatewayId", GatewayID}], ?NEW_API_VERSION).
 
 %%
 %%
--spec(delete_key_pair/1 :: (string()) -> ok | {error, any()}).
+-spec delete_key_pair(string()) -> ok | {error, any()}.
 delete_key_pair(KeyName) -> delete_key_pair(KeyName, default_config()).
 
--spec(delete_key_pair/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec delete_key_pair(string(), aws_config()) -> ok | {error, any()}.
 delete_key_pair(KeyName, Config)
   when is_list(KeyName) ->
     ec2_simple_query2(Config, "DeleteKeyPair", [{"KeyName", KeyName}]).
 
 %%
 %%
--spec(delete_network_acl/1 :: (string()) -> ok | {error, any()}).
+-spec delete_network_acl(string()) -> ok | {error, any()}.
 delete_network_acl(NetworkAclId) ->
     delete_network_acl(NetworkAclId, default_config()).
 
--spec(delete_network_acl/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec delete_network_acl(string(), aws_config()) -> ok | {error, any()}.
 delete_network_acl(NetworkAclId, Config) ->
     ec2_simple_query2(Config, "DeleteNetworkAcl",
                      [{"NetworkAclId", NetworkAclId}], ?NEW_API_VERSION).
 
 %%
 %%
--spec(delete_network_acl_entry/2 :: (string(), string()) -> ok | {error, any()}).
+-spec delete_network_acl_entry(string(), string()) -> ok | {error, any()}.
 delete_network_acl_entry(NetworkAclID, RuleNumber) ->
     delete_network_acl_entry(NetworkAclID, RuleNumber, false, default_config()).
 
--spec(delete_network_acl_entry/3 :: (string(), string(), boolean() | aws_config()) -> ok | {error, any()}).
+-spec delete_network_acl_entry(string(), string(), boolean() | aws_config()) -> ok | {error, any()}.
 delete_network_acl_entry(NetworkAclID, RuleNumber, Config)
   when is_record(Config, aws_config) ->
     delete_network_acl_entry(NetworkAclID, RuleNumber, false, Config);
 delete_network_acl_entry(NetworkAclID, RuleNumber, Egress) ->
     delete_network_acl_entry(NetworkAclID, RuleNumber, Egress, default_config()).
 
--spec(delete_network_acl_entry/4 :: (string(), string(), boolean(), aws_config()) -> ok | {error, any()}).
+-spec delete_network_acl_entry(string(), string(), boolean(), aws_config()) -> ok | {error, any()}.
 delete_network_acl_entry(NetworkAclID, RuleNumber, Egress, Config) ->
     Params = [{"NetworkAclId", NetworkAclID},
               {"RuleNumber", RuleNumber},
@@ -887,11 +887,11 @@ delete_network_acl_entry(NetworkAclID, RuleNumber, Egress, Config) ->
 
 %%
 %%
--spec(delete_route/2 :: (string(), string()) -> ok | {error, any()}).
+-spec delete_route(string(), string()) -> ok | {error, any()}.
 delete_route(RouteTableID, DestCidrBlock) ->
     delete_route(RouteTableID, DestCidrBlock, default_config()).
 
--spec(delete_route/3 :: (string(), string(), aws_config()) -> ok | {error, any()}).
+-spec delete_route(string(), string(), aws_config()) -> ok | {error, any()}.
 delete_route(RouteTableID, DestCidrBlock, Config) ->
     Params = [{"RouteTableId", RouteTableID},
               {"DestinationCidrBlock", DestCidrBlock}],
@@ -899,22 +899,22 @@ delete_route(RouteTableID, DestCidrBlock, Config) ->
 
 %%
 %%
--spec(delete_route_table/1 :: (string()) -> ok | {error, any()}).
+-spec delete_route_table(string()) -> ok | {error, any()}.
 delete_route_table(RouteTableID) ->
     delete_route_table(RouteTableID, default_config()).
 
--spec(delete_route_table/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec delete_route_table(string(), aws_config()) -> ok | {error, any()}.
 delete_route_table(RouteTableID, Config) ->
     ec2_simple_query2(Config, "DeleteRouteTable",
                      [{"RouteTableId", RouteTableID}], ?NEW_API_VERSION).
 
 %%
 %%
--spec(delete_security_group/1 :: (string()) -> ok | {error, any()}).
+-spec delete_security_group(string()) -> ok | {error, any()}.
 delete_security_group(GroupName) ->
     delete_security_group(groupName, GroupName, default_config()).
 
--spec(delete_security_group/2 :: (groupId | groupName | string(), string() | aws_config()) -> ok | {error, any()}).
+-spec delete_security_group(groupId | groupName | string(), string() | aws_config()) -> ok | {error, any()}.
 delete_security_group(GroupName, Config)
   when is_list(GroupName), is_record(Config, aws_config) ->
     delete_security_group(groupName, GroupName, Config);
@@ -922,7 +922,7 @@ delete_security_group(Param, GroupName)
   when is_atom(Param), is_list(GroupName) ->
     delete_security_group(Param, GroupName, default_config()).
 
--spec(delete_security_group/3 :: (groupId | groupName, string(), aws_config()) -> ok | {error, any()}).
+-spec delete_security_group(groupId | groupName, string(), aws_config()) -> ok | {error, any()}.
 delete_security_group(Param, GroupName, Config) ->
     ParamStr = atom_to_list(Param),
     Key = [string:to_upper(hd(ParamStr)) | tl(ParamStr)],
@@ -930,75 +930,75 @@ delete_security_group(Param, GroupName, Config) ->
 
 %%
 %%
--spec(delete_snapshot/1 :: (string()) -> ok | {error, any()}).
+-spec delete_snapshot(string()) -> ok | {error, any()}.
 delete_snapshot(SnapshotID) -> delete_snapshot(SnapshotID, default_config()).
 
--spec(delete_snapshot/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec delete_snapshot(string(), aws_config()) -> ok | {error, any()}.
 delete_snapshot(SnapshotID, Config)
   when is_list(SnapshotID) ->
     ec2_simple_query2(Config, "DeleteSnapshot", [{"SnapshotId", SnapshotID}]).
 
 %%
 %%
--spec(delete_spot_datafeed_subscription/0 :: () -> ok | {error, any()}).
+-spec delete_spot_datafeed_subscription() -> ok | {error, any()}.
 delete_spot_datafeed_subscription() -> delete_spot_datafeed_subscription(default_config()).
 
--spec(delete_spot_datafeed_subscription/1 :: (aws_config()) -> ok | {error, any()}).
+-spec delete_spot_datafeed_subscription(aws_config()) -> ok | {error, any()}.
 delete_spot_datafeed_subscription(Config) ->
     ec2_simple_query2(Config, "DeleteSpotDatafeedSubscription", []).
 
 %%
 %%
--spec(delete_subnet/1 :: (string()) -> ok | {error, any()}).
+-spec delete_subnet(string()) -> ok | {error, any()}.
 delete_subnet(SubnetID) when is_list(SubnetID) ->
     delete_subnet(SubnetID, default_config()).
 
--spec(delete_subnet/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec delete_subnet(string(), aws_config()) -> ok | {error, any()}.
 delete_subnet(SubnetID, Config) when is_list(SubnetID) ->
     ec2_simple_query2(Config, "DeleteSubnet", [{"SubnetId", SubnetID}]).
 
 %%
 %%
--spec(delete_volume/1 :: (string()) -> ok | {error, any()}).
+-spec delete_volume(string()) -> ok | {error, any()}.
 delete_volume(VolumeID) -> delete_volume(VolumeID, default_config()).
 
--spec(delete_volume/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec delete_volume(string(), aws_config()) -> ok | {error, any()}.
 delete_volume(VolumeID, Config)
   when is_list(VolumeID) ->
     ec2_simple_query2(Config, "DeleteVolume", [{"VolumeId", VolumeID}]).
 
 %%
 %%
--spec(delete_vpc/1 :: (string()) -> ok | {error, any()}).
+-spec delete_vpc(string()) -> ok | {error, any()}.
 delete_vpc(ID) ->
     delete_vpc(ID, default_config()).
 
--spec(delete_vpc/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec delete_vpc(string(), aws_config()) -> ok | {error, any()}.
 delete_vpc(ID, Config) ->
     ec2_simple_query2(Config, "DeleteVpc", [{"VpcId", ID}]).
 
 %%
 %%
--spec(deregister_image/1 :: (string()) -> ok | {error, any()}).
+-spec deregister_image(string()) -> ok | {error, any()}.
 deregister_image(ImageID) -> deregister_image(ImageID, default_config()).
 
--spec(deregister_image/2 :: (string(), aws_config()) -> ok | {error, any()}).
+-spec deregister_image(string(), aws_config()) -> ok | {error, any()}.
 deregister_image(ImageID, Config)
   when is_list(ImageID) ->
     ec2_simple_query2(Config, "DeregisterImage", [{"ImageId", ImageID}]).
 
 %%
 %%
--spec(describe_addresses/0 :: () -> {ok, proplist()} | {error, any()}).
+-spec describe_addresses() -> {ok, proplist()} | {error, any()}.
 describe_addresses() -> describe_addresses([]).
 
--spec(describe_addresses/1 :: ([string()] | aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec describe_addresses([string()] | aws_config()) -> {ok, proplist()} | {error, any()}.
 describe_addresses(Config)
   when is_record(Config, aws_config) ->
     describe_addresses([], Config);
 describe_addresses(PublicIPs) -> describe_addresses(PublicIPs, default_config()).
 
--spec(describe_addresses/2 :: ([string()], aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec describe_addresses([string()], aws_config()) -> {ok, proplist()} | {error, any()}.
 describe_addresses(PublicIPs, Config)
   when is_list(PublicIPs) ->
     case ec2_query2(Config, "DescribeAddresses", erlcloud_aws:param_list(PublicIPs, "PublicIp")) of
@@ -1011,16 +1011,16 @@ describe_addresses(PublicIPs, Config)
 
 %%
 %%
--spec(describe_availability_zones/0 :: () -> proplist()).
+-spec describe_availability_zones() -> proplist().
 describe_availability_zones() -> describe_availability_zones([]).
--spec(describe_availability_zones/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_availability_zones([string()] | aws_config()) -> proplist().
 describe_availability_zones(Config)
   when is_record(Config, aws_config) ->
     describe_availability_zones([], Config);
 describe_availability_zones(ZoneNames) ->
     describe_availability_zones(ZoneNames, default_config()).
 
--spec(describe_availability_zones/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_availability_zones([string()], aws_config()) -> proplist().
 describe_availability_zones(ZoneNames, Config)
   when is_list(ZoneNames) ->
     case ec2_query2(Config, "DescribeAvailabilityZones", erlcloud_aws:param_list(ZoneNames, "ZoneName")) of
@@ -1037,18 +1037,18 @@ describe_availability_zones(ZoneNames, Config)
 
 %%
 %%
--spec(describe_bundle_tasks/0 :: () -> [proplist()]).
+-spec describe_bundle_tasks() -> [proplist()].
 describe_bundle_tasks() ->
     describe_bundle_tasks([]).
 
--spec(describe_bundle_tasks/1 :: ([string()] | aws_config()) -> [proplist()]).
+-spec describe_bundle_tasks([string()] | aws_config()) -> [proplist()].
 describe_bundle_tasks(Config)
   when is_record(Config, aws_config) ->
     describe_bundle_tasks([], Config);
 describe_bundle_tasks(BundleIDs) ->
     describe_bundle_tasks(BundleIDs, default_config()).
 
--spec(describe_bundle_tasks/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec describe_bundle_tasks([string()], aws_config()) -> [proplist()].
 describe_bundle_tasks(BundleIDs, Config) ->
     case ec2_query2(Config, "DescribeBundleTasks", erlcloud_aws:param_list(BundleIDs, "BundleId")) of
         {ok, Doc} ->
@@ -1059,17 +1059,17 @@ describe_bundle_tasks(BundleIDs, Config) ->
 
 %%
 %%
--spec(describe_dhcp_options/0 :: () -> proplist()).
+-spec describe_dhcp_options() -> proplist().
 describe_dhcp_options() ->
     describe_dhcp_options(none, default_config()).
 
--spec(describe_dhcp_options/1 :: (aws_config() | filter_list() | none) -> proplist()).
+-spec describe_dhcp_options(aws_config() | filter_list() | none) -> proplist().
 describe_dhcp_options(Config) when is_record(Config, aws_config) ->
     describe_dhcp_options(none, Config);
 describe_dhcp_options(Filter) when is_list(Filter) ->
     describe_dhcp_options(Filter, default_config()).
 
--spec(describe_dhcp_options/2 :: (none | filter_list(), aws_config()) -> proplist()).
+-spec describe_dhcp_options(none | filter_list(), aws_config()) -> proplist().
 describe_dhcp_options(Filter, Config) ->
     Params = list_to_ec2_filter(Filter),
     case ec2_query2(Config, "DescribeDhcpOptions", Params, ?NEW_API_VERSION) of
@@ -1091,11 +1091,11 @@ extract_dhcp_opt_kv(Node) ->
 
 %%
 %%
--spec(describe_image_attribute/2 :: (string(), atom()) -> proplist()).
+-spec describe_image_attribute(string(), atom()) -> proplist().
 describe_image_attribute(ImageID, Attribute) ->
     describe_image_attribute(ImageID, Attribute, default_config()).
 
--spec(describe_image_attribute/3 :: (string(), atom(), aws_config()) -> term()).
+-spec describe_image_attribute(string(), atom(), aws_config()) -> term().
 describe_image_attribute(ImageID, Attribute, Config)
   when is_list(ImageID), is_atom(Attribute) ->
     AttributeName = case Attribute of
@@ -1156,12 +1156,12 @@ extract_permissions([_|Nodes], Accum) ->
 %%    product_codes: []
 %% ]]
 %%
--spec(describe_images/0 :: () -> proplist()).
+-spec describe_images() -> proplist().
 describe_images() -> describe_images([], "self").
 
 %% Uses an config other than the one set for the current process.
 %% See describe_images/0 for return term
--spec(describe_images/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_images([string()] | aws_config()) -> proplist().
 describe_images(Config)
   when is_record(Config, aws_config) ->
     describe_images([], "self", none, Config);
@@ -1173,8 +1173,7 @@ describe_images(ImageIDs) ->
 
 %% Describes images with ImageIDs if owned by current user using an alternate Config.
 %% See describe_images/0 for return term
--spec(describe_images/2 :: ([string()], aws_config()) -> proplist() ;
-                           ([string()], string() | none) -> proplist()).
+-spec describe_images([string()], aws_config() | string() | none) -> proplist().
 describe_images(ImageIDs, Config)
   when is_record(Config, aws_config) ->
     describe_images(ImageIDs, none, none, Config);
@@ -1186,8 +1185,7 @@ describe_images(ImageIDs, Config)
 describe_images(ImageIDs, Owner) ->
     describe_images(ImageIDs, Owner, none, default_config()).
 
--spec(describe_images/3 :: ([string()], string() | none, aws_config()) -> proplist() ;
-                           ([string()], string() | none, string() | none) -> proplist()).
+-spec describe_images([string()], string() | none, aws_config() | string() | none) -> proplist().
 
 %% Describes images with ImageIDs if Owned by Owner (useful for corporate accounts) using an alternate Config.
 %% See describe_images/0 for return term
@@ -1202,7 +1200,7 @@ describe_images(ImageIDs, Owner, ExecutableBy) ->
 
 %% Describes images with ImageIDs if owned by Owner and executable by ExecutableBy using an alternate Config
 %% See describe_images/0 for return term
--spec(describe_images/4 :: ([string()], string() | none, string() | none, aws_config()) -> proplist  ()).
+-spec describe_images([string()], string() | none, string() | none, aws_config()) -> proplist().
 describe_images(ImageIDs, Owner, ExecutableBy, Config)
   when is_list(ImageIDs),
        is_list(Owner) orelse Owner =:= none,
@@ -1256,11 +1254,11 @@ extract_product_code(Node) ->
 
 %%
 %%
--spec(describe_instance_attribute/2 :: (string(), atom()) -> proplist()).
+-spec describe_instance_attribute(string(), atom()) -> proplist().
 describe_instance_attribute(InstanceID, Attribute) ->
     describe_instance_attribute(InstanceID, Attribute, default_config()).
 
--spec(describe_instance_attribute/3 :: (string(), atom(), aws_config()) -> term()).
+-spec describe_instance_attribute(string(), atom(), aws_config()) -> term().
 describe_instance_attribute(InstanceID, Attribute, Config)
   when is_list(InstanceID), is_atom(Attribute) ->
     AttributeName = case Attribute of
@@ -1301,24 +1299,24 @@ attribute_xpath(_, AttributeName) ->
 
 %%
 %%
--spec(describe_instances/0 :: () -> proplist()).
+-spec describe_instances() -> proplist().
 describe_instances() -> describe_instances([]).
 
--spec(describe_instances/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_instances([string()] | aws_config()) -> proplist().
 describe_instances(Config)
   when is_record(Config, aws_config) ->
     describe_instances([], Config);
 describe_instances(InstanceIDs) ->
     describe_instances(InstanceIDs, [], default_config()).
 
--spec(describe_instances/2 :: ([string()], filter_list() | aws_config()) -> proplist()).
+-spec describe_instances([string()], filter_list() | aws_config()) -> proplist().
 describe_instances(InstanceIDs, Config)
   when is_record(Config, aws_config) ->
     describe_instances(InstanceIDs, [], Config);
 describe_instances(InstanceIDs, Filter) ->
     describe_instances(InstanceIDs, Filter, default_config()).
 
--spec(describe_instances/3 :: ([string()], filter_list(), aws_config()) -> proplist()).
+-spec describe_instances([string()], filter_list(), aws_config()) -> proplist().
 describe_instances(InstanceIDs, Filter, Config)
   when is_list(InstanceIDs) ->
     Params = erlcloud_aws:param_list(InstanceIDs, "InstanceId") ++ list_to_ec2_filter(Filter),
@@ -1394,15 +1392,15 @@ extract_block_device_mapping_status(Node) ->
 
 %%
 %%
--spec(describe_instance_status/1 :: (string()) -> proplist()).
+-spec describe_instance_status(string()) -> proplist().
 describe_instance_status(InstanceID) ->
     describe_instance_status([{"InstanceId", InstanceID}], [], default_config()).
 
--spec(describe_instance_status/2 :: (proplist(), filter_list()) -> proplist()).
+-spec describe_instance_status(proplist(), filter_list()) -> proplist().
 describe_instance_status(Params, Filter) ->
     describe_instance_status(Params, Filter, default_config()).
 
--spec(describe_instance_status/3 :: (proplist(), filter_list(), aws_config()) -> proplist()).
+-spec describe_instance_status(proplist(), filter_list(), aws_config()) -> proplist().
 describe_instance_status(Params, Filter, Config) ->
     AllParams = Params ++ list_to_ec2_filter(Filter),
     case ec2_query2(Config, "DescribeInstanceStatus", AllParams, ?NEW_API_VERSION) of
@@ -1422,17 +1420,17 @@ extract_instance_status(Node) ->
 
 %%
 %%
--spec(describe_internet_gateways/0 :: () -> proplist()).
+-spec describe_internet_gateways() -> proplist().
 describe_internet_gateways() ->
     describe_internet_gateways(none, default_config()).
 
--spec(describe_internet_gateways/1 :: (filter_list | aws_config()) -> proplist()).
+-spec describe_internet_gateways(filter_list | aws_config()) -> proplist().
 describe_internet_gateways(Config) when is_record(Config, aws_config) ->
     describe_internet_gateways(none, Config);
 describe_internet_gateways(Filter) ->
     describe_internet_gateways(Filter, default_config()).
 
--spec(describe_internet_gateways/2 :: (none | filter_list(), aws_config()) -> [proplist()]).
+-spec describe_internet_gateways(none | filter_list(), aws_config()) -> [proplist()].
 describe_internet_gateways(Filter, Config) ->
     Params = list_to_ec2_filter(Filter),
     case ec2_query2(Config, "DescribeInternetGateways", Params, ?NEW_API_VERSION) of
@@ -1458,16 +1456,16 @@ extract_igw_attachments(Node) ->
 
 %%
 %%
--spec(describe_key_pairs/0 :: () -> proplist()).
+-spec describe_key_pairs() -> proplist().
 describe_key_pairs() -> describe_key_pairs([]).
 
--spec(describe_key_pairs/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_key_pairs([string()] | aws_config()) -> proplist().
 describe_key_pairs(Config)
   when is_record(Config, aws_config) ->
     describe_key_pairs([], Config);
 describe_key_pairs(KeyNames) -> describe_key_pairs(KeyNames, default_config()).
 
--spec(describe_key_pairs/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_key_pairs([string()], aws_config()) -> proplist().
 describe_key_pairs(KeyNames, Config)
   when is_list(KeyNames) ->
     case ec2_query2(Config, "DescribeKeyPairs", erlcloud_aws:param_list(KeyNames, "KeyName")) of
@@ -1485,17 +1483,17 @@ describe_key_pairs(KeyNames, Config)
 
 %%
 %%
--spec(describe_network_acls/0 :: () -> [proplist()]).
+-spec describe_network_acls() -> [proplist()].
 describe_network_acls() ->
     describe_network_acls(none, default_config()).
 
--spec(describe_network_acls/1 :: (filter_list() | aws_config()) -> [proplist()]).
+-spec describe_network_acls(filter_list() | aws_config()) -> [proplist()].
 describe_network_acls(Config) when is_record(Config, aws_config) ->
     describe_network_acls(none, Config);
 describe_network_acls(Filter) ->
     describe_network_acls(Filter, default_config()).
 
--spec(describe_network_acls/2 :: (filter_list(), aws_config()) -> [proplist()]).
+-spec describe_network_acls(filter_list(), aws_config()) -> [proplist()].
 describe_network_acls(Filter, Config) ->
     Params = list_to_ec2_filter(Filter),
     case ec2_query2(Config, "DescribeNetworkAcls", Params, ?NEW_API_VERSION) of
@@ -1508,16 +1506,16 @@ describe_network_acls(Filter, Config) ->
 
 %%
 %%
--spec(describe_regions/0 :: () -> proplist()).
+-spec describe_regions() -> proplist().
 describe_regions() -> describe_regions([]).
--spec(describe_regions/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_regions([string()] | aws_config()) -> proplist().
 describe_regions(Config)
   when is_record(Config, aws_config) ->
     describe_regions([], Config);
 describe_regions(RegionNames) ->
     describe_regions(RegionNames, default_config()).
 
--spec(describe_regions/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_regions([string()], aws_config()) -> proplist().
 describe_regions(RegionNames, Config)
   when is_list(RegionNames) ->
     case ec2_query2(Config, "DescribeRegions", erlcloud_aws:param_list(RegionNames, "RegionName")) of
@@ -1533,18 +1531,18 @@ describe_regions(RegionNames, Config)
 %
 % Network Interfaces API
 %
--spec(describe_network_interfaces/0 :: () -> [proplist()]).
+-spec describe_network_interfaces() -> [proplist()].
 describe_network_interfaces() ->
     describe_network_interfaces(none).
 
--spec(describe_network_interfaces/1 :: (list() | aws_config()) -> [proplist()]).
+-spec describe_network_interfaces(list() | aws_config()) -> [proplist()].
 describe_network_interfaces(Config)
     when is_record(Config, aws_config) ->
       describe_network_interfaces([], Config);
 describe_network_interfaces(NetworkInterfacesIds) ->
     describe_network_interfaces(NetworkInterfacesIds, default_config()).
 
--spec(describe_network_interfaces/2 :: (list(), aws_config()) -> [proplist()]).
+-spec describe_network_interfaces(list(), aws_config()) -> [proplist()].
 %%
 %%
 %% Example: describe_network_interfaces(["eni-1c111111", "eni-222e2222"], Config).
@@ -1552,7 +1550,7 @@ describe_network_interfaces(NetworkInterfacesIds, Config)
     when is_record(Config, aws_config) ->
         describe_network_interfaces_filtered(NetworkInterfacesIds, none, Config).
 
--spec(describe_network_interfaces_filtered/3 :: (list(), filter_list() | node, aws_config()) -> [proplist()]).
+-spec describe_network_interfaces_filtered(list(), filter_list() | node, aws_config()) -> [proplist()].
 %%
 %% Example: describe_network_interfaces_filtered([], [{"subnet-id", ["subnet-e11e11e1"]}], Config)
 %%
@@ -1568,7 +1566,7 @@ describe_network_interfaces_filtered(NetworkInterfacesIds, Filter, Config)
               Error
        end.
 
--spec(extract_network_interface/1 :: (Node::list()) -> proplist()).
+-spec extract_network_interface(Node::list()) -> proplist().
 extract_network_interface(Node) ->
     [
      {network_interface_id, get_text("networkInterfaceId", Node)},
@@ -1590,7 +1588,7 @@ extract_network_interface(Node) ->
             [extract_private_ip_address(Item) || Item <- xmerl_xpath:string("privateIpAddressesSet/item", Node)]}
     ].
 
--spec(extract_attachment/1 :: (Node::list()) -> proplist()).
+-spec extract_attachment(Node::list()) -> proplist().
 extract_attachment(Node) ->
     [
      {attachment_id, get_text("attachment/attachmentId", Node)},
@@ -1602,14 +1600,14 @@ extract_attachment(Node) ->
      {delete_on_termination, get_bool("attachment/deleteOnTermination", Node)}
     ].
 
--spec(extract_private_ip_address/1 :: (Node::list()) -> proplist()).
+-spec extract_private_ip_address(Node::list()) -> proplist().
 extract_private_ip_address(Node) ->
     [
      {private_ip_address, get_text("privateIpAddress", Node)},
      {primary, get_bool("primary", Node)}
     ].
 
--spec(extract_association/1 :: (Node::list()) -> proplist()).
+-spec extract_association(Node::list()) -> proplist().
 extract_association(Node) ->
     [
      {public_ip, get_text("association/publicIp", Node)},
@@ -1621,17 +1619,17 @@ extract_association(Node) ->
 
 %%
 %%
--spec(describe_reserved_instances/0 :: () -> proplist()).
+-spec describe_reserved_instances() -> proplist().
 describe_reserved_instances() -> describe_reserved_instances([]).
 
--spec(describe_reserved_instances/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_reserved_instances([string()] | aws_config()) -> proplist().
 describe_reserved_instances(Config)
   when is_record(Config, aws_config) ->
     describe_reserved_instances([], Config);
 describe_reserved_instances(ReservedInstanceIDs) ->
     describe_reserved_instances(ReservedInstanceIDs, default_config()).
 
--spec(describe_reserved_instances/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_reserved_instances([string()], aws_config()) -> proplist().
 describe_reserved_instances(ReservedInstanceIDs, Config)
   when is_list(ReservedInstanceIDs) ->
     case ec2_query2(Config, "DescribeReservedInstances", erlcloud_aws:param_list(ReservedInstanceIDs, "ReservedInstanceId")) of
@@ -1658,17 +1656,17 @@ extract_reserved_instance(Node) ->
 
 %%
 %%
--spec(describe_reserved_instances_offerings/0 :: () -> proplist()).
+-spec describe_reserved_instances_offerings() -> proplist().
 describe_reserved_instances_offerings() -> describe_reserved_instances_offerings([]).
 
--spec(describe_reserved_instances_offerings/1 :: ([{atom(), string()}] | aws_config()) -> proplist()).
+-spec describe_reserved_instances_offerings([{atom(), string()}] | aws_config()) -> proplist().
 describe_reserved_instances_offerings(Config)
   when is_record(Config, aws_config) ->
     describe_reserved_instances_offerings([], Config);
 describe_reserved_instances_offerings(Selector) ->
     describe_reserved_instances_offerings(Selector, default_config()).
 
--spec(describe_reserved_instances_offerings/2 :: ([{atom(), string()}], aws_config()) -> proplist()).
+-spec describe_reserved_instances_offerings([{atom(), string()}], aws_config()) -> proplist().
 describe_reserved_instances_offerings(Selector, Config)
   when is_list(Selector) ->
     InstanceTypes = [Value || {Key, Value} <- Selector, Key =:= instance_type],
@@ -1698,17 +1696,17 @@ extract_reserved_instances_offering(Node) ->
 
 %%
 %%
--spec(describe_route_tables/0 :: () -> [proplist()]).
+-spec describe_route_tables() -> [proplist()].
 describe_route_tables() ->
     describe_route_tables(none, default_config()).
 
--spec(describe_route_tables/1 :: (filter_list() | none | aws_config()) -> [proplist()]).
+-spec describe_route_tables(filter_list() | none | aws_config()) -> [proplist()].
 describe_route_tables(Config) when is_record(Config, aws_config) ->
     describe_route_tables(none, Config);
 describe_route_tables(Filter) ->
     describe_route_tables(Filter, default_config()).
 
--spec(describe_route_tables/2 :: (filter_list() | none, aws_config()) -> [proplist()]).
+-spec describe_route_tables(filter_list() | none, aws_config()) -> [proplist()].
 describe_route_tables(Filter, Config) ->
     Params = list_to_ec2_filter(Filter),
     case ec2_query2(Config, "DescribeRouteTables", Params, ?NEW_API_VERSION) of
@@ -1751,18 +1749,18 @@ extract_route_assn(Node) ->
 
 %%
 %%
--spec(describe_security_groups/0 :: () -> [proplist()]).
+-spec describe_security_groups() -> [proplist()].
 describe_security_groups() ->
     describe_security_groups([]).
 
--spec(describe_security_groups/1 :: ([string()] | aws_config()) -> [proplist()]).
+-spec describe_security_groups([string()] | aws_config()) -> [proplist()].
 describe_security_groups(Config)
   when is_record(Config, aws_config) ->
     describe_security_groups([], Config);
 describe_security_groups(GroupNames) ->
     describe_security_groups(GroupNames, default_config()).
 
--spec(describe_security_groups/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec describe_security_groups([string()], aws_config()) -> [proplist()].
 describe_security_groups(GroupNames, Config)
   when is_list(GroupNames) ->
     case ec2_query2(Config, "DescribeSecurityGroups", erlcloud_aws:param_list(GroupNames, "GroupName"), ?NEW_API_VERSION) of
@@ -1775,11 +1773,11 @@ describe_security_groups(GroupNames, Config)
 
 %%
 %%
--spec(describe_security_groups_filtered/1 :: (filter_list()) -> [proplist()]).
+-spec describe_security_groups_filtered(filter_list()) -> [proplist()].
 describe_security_groups_filtered(Filter) ->
     describe_security_groups_filtered(Filter, default_config()).
 
--spec(describe_security_groups_filtered/2 :: (filter_list(), aws_config()) -> [proplist()]).
+-spec describe_security_groups_filtered(filter_list(), aws_config()) -> [proplist()].
 describe_security_groups_filtered(Filter, Config)->
     Params = list_to_ec2_filter(Filter),
     case ec2_query2(Config, "DescribeSecurityGroups", Params, ?NEW_API_VERSION) of
@@ -1825,11 +1823,11 @@ extract_user_id_group_pair(Node) ->
     ].
 %%
 %%
--spec(describe_snapshot_attribute/2 :: (string(), atom()) -> proplist()).
+-spec describe_snapshot_attribute(string(), atom()) -> proplist().
 describe_snapshot_attribute(SnapshotID, Attribute) ->
     describe_snapshot_attribute(SnapshotID, Attribute, default_config()).
 
--spec(describe_snapshot_attribute/3 :: (string(), atom(), aws_config()) -> term()).
+-spec describe_snapshot_attribute(string(), atom(), aws_config()) -> term().
 describe_snapshot_attribute(SnapshotID, create_volume_permission, Config)
   when is_list(SnapshotID) ->
     case ec2_query2(Config, "DescribeSnapshotAttribute", [{"snapshotId", SnapshotID}, {"Attribute", "createVolumePermission"}]) of
@@ -1841,33 +1839,31 @@ describe_snapshot_attribute(SnapshotID, create_volume_permission, Config)
 
 %%
 %%
--spec(describe_snapshots/0 :: () -> [proplist()]).
+-spec describe_snapshots() -> [proplist()].
 describe_snapshots() -> describe_snapshots([], "self").
 
--spec(describe_snapshots/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_snapshots([string()] | aws_config()) -> proplist().
 describe_snapshots(Config)
   when is_record(Config, aws_config) ->
     describe_snapshots([], "self", Config);
 describe_snapshots(SnapshotIDs) ->
     describe_snapshots(SnapshotIDs, none, none, default_config()).
 
--spec(describe_snapshots/2 :: ([string()], aws_config()) -> [proplist()] ;
-                              ([string()], string() | none) -> [proplist()]).
+-spec describe_snapshots([string()], aws_config() | string() | none) -> [proplist()].
 describe_snapshots(SnapshotIDs, Config)
   when is_record(Config, aws_config) ->
     describe_snapshots(SnapshotIDs, none, none, Config);
 describe_snapshots(SnapshotIDs, Owner) ->
     describe_snapshots(SnapshotIDs, Owner, none, default_config()).
 
--spec(describe_snapshots/3 :: ([string()], string() | none, aws_config()) -> [proplist()] ;
-                              ([string()], string() | none, string() | none) -> [proplist()]).
+-spec describe_snapshots([string()], string() | none, aws_config() | string() | none) -> [proplist()].
 describe_snapshots(SnapshotIDs, Owner, Config)
   when is_record(Config, aws_config) ->
     describe_snapshots(SnapshotIDs, Owner, none, Config);
 describe_snapshots(SnapshotIDs, Owner, RestorableBy) ->
     describe_snapshots(SnapshotIDs, Owner, RestorableBy, default_config()).
 
--spec(describe_snapshots/4 :: ([string()], string() | none, string() | none, aws_config()) -> [proplist()]).
+-spec describe_snapshots([string()], string() | none, string() | none, aws_config()) -> [proplist()].
 describe_snapshots(SnapshotIDs, Owner, RestorableBy, Config)
   when is_list(SnapshotIDs),
        is_list(Owner) orelse Owner =:= none,
@@ -1895,11 +1891,11 @@ extract_snapshot(Node) ->
 
 %%
 %%
--spec(describe_spot_datafeed_subscription/0 :: () -> proplist()).
+-spec describe_spot_datafeed_subscription() -> proplist().
 describe_spot_datafeed_subscription() ->
     describe_spot_datafeed_subscription(default_config()).
 
--spec(describe_spot_datafeed_subscription/1 :: (aws_config()) -> proplist()).
+-spec describe_spot_datafeed_subscription(aws_config()) -> proplist().
 describe_spot_datafeed_subscription(Config) ->
     case ec2_query2(Config, "DescribeSpotDatafeedSubscription", []) of
         {ok, Doc} ->
@@ -1910,18 +1906,18 @@ describe_spot_datafeed_subscription(Config) ->
 
 %%
 %%
--spec(describe_spot_instance_requests/0 :: () -> [proplist()]).
+-spec describe_spot_instance_requests() -> [proplist()].
 describe_spot_instance_requests() ->
     describe_spot_instance_requests([]).
 
--spec(describe_spot_instance_requests/1 :: ([string()] | aws_config()) -> [proplist()]).
+-spec describe_spot_instance_requests([string()] | aws_config()) -> [proplist()].
 describe_spot_instance_requests(Config)
   when is_record(Config, aws_config) ->
     describe_spot_instance_requests([], Config);
 describe_spot_instance_requests(SpotInstanceRequestIDs) ->
     describe_spot_instance_requests(SpotInstanceRequestIDs, default_config()).
 
--spec(describe_spot_instance_requests/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec describe_spot_instance_requests([string()], aws_config()) -> [proplist()].
 describe_spot_instance_requests(SpotInstanceRequestIDs, Config)
   when is_list(SpotInstanceRequestIDs) ->
     case ec2_query2(Config, "DescribeSpotInstanceRequests", erlcloud_aws:param_list(SpotInstanceRequestIDs, "SpotInstanceRequestId"), ?NEW_API_VERSION) of
@@ -1971,32 +1967,32 @@ extract_launch_specification(Node) ->
 
 %%
 %%
--spec(describe_spot_price_history/0 :: () -> proplist()).
+-spec describe_spot_price_history() -> proplist().
 describe_spot_price_history() ->
     describe_spot_price_history(none).
 
--spec(describe_spot_price_history/1 :: (datetime() | none | aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none | aws_config()) -> proplist().
 describe_spot_price_history(Config)
   when is_record(Config, aws_config) ->
     describe_spot_price_history(none, Config);
 describe_spot_price_history(StartTime) ->
     describe_spot_price_history(StartTime, none).
 
--spec(describe_spot_price_history/2 :: (datetime() | none, datetime() | none | aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none, datetime() | none | aws_config()) -> proplist().
 describe_spot_price_history(StartTime, Config)
   when is_record(Config, aws_config) ->
     describe_spot_price_history(StartTime, none, Config);
 describe_spot_price_history(StartTime, EndTime) ->
     describe_spot_price_history(StartTime, EndTime, []).
 
--spec(describe_spot_price_history/3 :: (datetime() | none, datetime() | none, [string()] | aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none, datetime() | none, [string()] | aws_config()) -> proplist().
 describe_spot_price_history(StartTime, EndTime, Config)
   when is_record(Config, aws_config) ->
     describe_spot_price_history(StartTime, EndTime, [], Config);
 describe_spot_price_history(StartTime, EndTime, InstanceTypes) ->
     describe_spot_price_history(StartTime, EndTime, InstanceTypes, none).
 
--spec(describe_spot_price_history/4 :: (datetime() | none, datetime() | none, [string()], string() | none | aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none, datetime() | none, [string()], string() | none | aws_config()) -> proplist().
 describe_spot_price_history(StartTime, EndTime, InstanceTypes, Config)
   when is_record(Config, aws_config) ->
     describe_spot_price_history(StartTime, EndTime, InstanceTypes, none, Config);
@@ -2004,7 +2000,7 @@ describe_spot_price_history(StartTime, EndTime, InstanceTypes, ProductDescriptio
     describe_spot_price_history(StartTime, EndTime, InstanceTypes,
                                 ProductDescription, default_config()).
 
--spec(describe_spot_price_history/5 :: (datetime() | none, datetime() | none, [string()], string() | none, aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none, datetime() | none, [string()], string() | none, aws_config()) -> proplist().
 describe_spot_price_history(StartTime, EndTime, InstanceTypes,
                             ProductDescription, Config)
   when is_list(InstanceTypes),
@@ -2031,17 +2027,17 @@ extract_spot_price_history(Node) ->
 
 %%
 %%
--spec(describe_subnets/0 :: () -> proplist()).
+-spec describe_subnets() -> proplist().
 describe_subnets() ->
     describe_subnets(none, default_config()).
 
--spec(describe_subnets/1 :: ([none | filter_list() | string()] | aws_config()) -> proplist()).
+-spec describe_subnets([none | filter_list() | string()] | aws_config()) -> proplist().
 describe_subnets(Config) when is_record(Config, aws_config) ->
     describe_subnets(none, Config);
 describe_subnets(Filter) when is_list(Filter) ->
     describe_subnets(Filter, default_config()).
 
--spec(describe_subnets/2 :: (none | filter_list(), aws_config()) -> proplist()).
+-spec describe_subnets(none | filter_list(), aws_config()) -> proplist().
 describe_subnets(Filter, Config) ->
     Params = list_to_ec2_filter(Filter),
     case ec2_query2(Config, "DescribeSubnets", Params, ?NEW_API_VERSION) of
@@ -2066,17 +2062,17 @@ extract_subnet(Node) ->
 
 %%
 %%
--spec(describe_volumes/0 :: () -> {ok, proplist()} | {error, any()}).
+-spec describe_volumes() -> {ok, proplist()} | {error, any()}.
 describe_volumes() -> describe_volumes([]).
 
--spec(describe_volumes/1 :: ([string()] | aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec describe_volumes([string()] | aws_config()) -> {ok, proplist()} | {error, any()}.
 describe_volumes(Config)
   when is_record(Config, aws_config) ->
     describe_volumes([], Config);
 describe_volumes(VolumeIDs) ->
     describe_volumes(VolumeIDs, default_config()).
 
--spec(describe_volumes/2 :: ([string()], aws_config()) -> {ok, proplist()} | {error, any()}).
+-spec describe_volumes([string()], aws_config()) -> {ok, proplist()} | {error, any()}.
 describe_volumes(VolumeIDs, Config)
   when is_list(VolumeIDs) ->
     case ec2_query2(Config, "DescribeVolumes", erlcloud_aws:param_list(VolumeIDs, "VolumeId"), ?NEW_API_VERSION) of
@@ -2108,17 +2104,17 @@ extract_volume(Node) ->
 
 %%
 %%
--spec(describe_vpcs/0 :: () -> proplist()).
+-spec describe_vpcs() -> proplist().
 describe_vpcs() ->
     describe_vpcs(default_config()).
 
--spec(describe_vpcs/1 :: (filter_list() | aws_config()) -> proplist()).
+-spec describe_vpcs(filter_list() | aws_config()) -> proplist().
 describe_vpcs(Config) when is_record(Config, aws_config) ->
     describe_vpcs(none, Config);
 describe_vpcs(Filter) ->
     describe_vpcs(Filter, default_config()).
 
--spec(describe_vpcs/2 :: (filter_list() | none, aws_config()) -> proplist()).
+-spec describe_vpcs(filter_list() | none, aws_config()) -> proplist().
 describe_vpcs(Filter, Config) ->
     Params = list_to_ec2_filter(Filter),
     case ec2_query2(Config, "DescribeVpcs", Params, ?NEW_API_VERSION) of
@@ -2141,11 +2137,11 @@ extract_vpc(Node) ->
 
 %%
 %%
--spec(detach_internet_gateway/2 :: (string(), string()) -> ok).
+-spec detach_internet_gateway(string(), string()) -> ok.
 detach_internet_gateway(GatewayID, VpcID) ->
     detach_internet_gateway(GatewayID, VpcID, default_config()).
 
--spec(detach_internet_gateway/3 :: (string(), string(), aws_config()) -> ok).
+-spec detach_internet_gateway(string(), string(), aws_config()) -> ok.
 detach_internet_gateway(GatewayID, VpcID, Config) ->
     ec2_simple_query2(Config, "DetachInternetGateway",
                      [{"InternetGatewayId", GatewayID}, {"VpcId", VpcID}],
@@ -2153,10 +2149,10 @@ detach_internet_gateway(GatewayID, VpcID, Config) ->
 
 %%
 %%
--spec(detach_volume/1 :: (string()) -> proplist()).
+-spec detach_volume(string()) -> proplist().
 detach_volume(VolumeID) -> detach_volume(VolumeID, default_config()).
 
--spec(detach_volume/2 :: (string(), aws_config()) -> proplist()).
+-spec detach_volume(string(), aws_config()) -> proplist().
 detach_volume(VolumeID, Config)
   when is_list(VolumeID) ->
     Params = [{"VolumeId", VolumeID}],
@@ -2169,21 +2165,21 @@ detach_volume(VolumeID, Config)
 
 %%
 %%
--spec(disassociate_address/1 :: (string()) -> ok).
+-spec disassociate_address(string()) -> ok.
 disassociate_address(PublicIP) ->
     disassociate_address(PublicIP, default_config()).
 
--spec(disassociate_address/2 :: (string(), aws_config()) -> ok).
+-spec disassociate_address(string(), aws_config()) -> ok.
 disassociate_address(PublicIP, Config)
   when is_list(PublicIP) ->
     ec2_simple_query2(Config, "DisassociateAddress", [{"PublicIp", PublicIP}]).
 
 %%
 %%
--spec(get_console_output/1 :: (string()) -> proplist()).
+-spec get_console_output(string()) -> proplist().
 get_console_output(InstanceID) -> get_console_output(InstanceID, default_config()).
 
--spec(get_console_output/2 :: (string(), aws_config()) -> proplist()).
+-spec get_console_output(string(), aws_config()) -> proplist().
 get_console_output(InstanceID, Config)
   when is_list(InstanceID) ->
     case ec2_query2(Config, "GetConsoleOutput", [{"InstanceId", InstanceID}]) of
@@ -2199,10 +2195,10 @@ get_console_output(InstanceID, Config)
 
 %%
 %%
--spec(get_password_data/1 :: (string()) -> proplist()).
+-spec get_password_data(string()) -> proplist().
 get_password_data(InstanceID) -> get_password_data(InstanceID, default_config()).
 
--spec(get_password_data/2 :: (string(), aws_config()) -> proplist()).
+-spec get_password_data(string(), aws_config()) -> proplist().
 get_password_data(InstanceID, Config)
   when is_list(InstanceID) ->
     case ec2_query2(Config, "GetPasswordData", [{"InstanceId", InstanceID}]) of
@@ -2218,11 +2214,11 @@ get_password_data(InstanceID, Config)
 
 %%
 %%
--spec(modify_image_attribute/3 :: (string(), atom(), term()) -> ok).
+-spec modify_image_attribute(string(), atom(), term()) -> ok.
 modify_image_attribute(ImageID, Attribute, Value) ->
     modify_image_attribute(ImageID, Attribute, Value, default_config()).
 
--spec(modify_image_attribute/4 :: (string(), atom(), term(), aws_config()) -> ok).
+-spec modify_image_attribute(string(), atom(), term(), aws_config()) -> ok.
 modify_image_attribute(ImageID, Attribute, Value, Config) ->
     {AttributeName, OperationType, Values} = case {Attribute, Value} of
                                                  {launch_permission, {Operation, Permissions}}
@@ -2244,11 +2240,11 @@ modify_image_attribute(ImageID, Attribute, Value, Config) ->
 
 %%
 %%
--spec(modify_instance_attribute/3 :: (string(), atom(), term()) -> ok).
+-spec modify_instance_attribute(string(), atom(), term()) -> ok.
 modify_instance_attribute(InstanceID, Attribute, Value) ->
     modify_instance_attribute(InstanceID, Attribute, Value, default_config()).
 
--spec(modify_instance_attribute/4 :: (newstyle | string(), string()|atom(), string()|atom()|term(), string()|aws_config()) -> ok). %%FIXME
+-spec modify_instance_attribute(newstyle | string(), string()|atom(), string()|atom()|term(), string()|aws_config()) -> ok. %%FIXME
 modify_instance_attribute(newstyle, InstanceID, Attribute, Value) ->
     modify_instance_attribute(newstyle, InstanceID, Attribute, Value, default_config());
 modify_instance_attribute(InstanceID, Attribute, Value, Config) ->
@@ -2270,7 +2266,7 @@ modify_instance_attribute(InstanceID, Attribute, Value, Config) ->
     Params = [{"InstanceID", InstanceID}, {"Attribute", AttributeName}|AParams],
     ec2_simple_query2(Config, "ModifyInstanceAttribute", Params).
 
--spec(modify_instance_attribute/5 :: (newstyle, string(), string(), string(), aws_config()) -> ok).
+-spec modify_instance_attribute(newstyle, string(), string(), string(), aws_config()) -> ok.
 modify_instance_attribute(newstyle, InstanceID, Attribute, Value, Config) -> %%FIXME
     ec2_simple_query2(Config, "ModifyInstanceAttribute",
                      [{"InstanceId", InstanceID}, {Attribute, Value}], ?NEW_API_VERSION).
@@ -2282,11 +2278,11 @@ permission_list(Permissions) ->
 
 %%
 %%
--spec(modify_snapshot_attribute/3 :: (string(), atom(), term()) -> ok).
+-spec modify_snapshot_attribute(string(), atom(), term()) -> ok.
 modify_snapshot_attribute(SnapshotID, Attribute, Value) ->
     modify_snapshot_attribute(SnapshotID, Attribute, Value, default_config()).
 
--spec(modify_snapshot_attribute/4 :: (string(), atom(), term(), aws_config()) -> ok).
+-spec modify_snapshot_attribute(string(), atom(), term(), aws_config()) -> ok.
 modify_snapshot_attribute(SnapshotID, create_volume_permission,
                           {Operation, Permissions}, Config)
   when Operation =:= add orelse Operation =:= remove,
@@ -2300,11 +2296,11 @@ modify_snapshot_attribute(SnapshotID, create_volume_permission,
 
 %%
 %%
--spec(monitor_instances/1 :: ([string()]) -> proplist()).
+-spec monitor_instances([string()]) -> proplist().
 monitor_instances(InstanceIDs) ->
     monitor_instances(InstanceIDs, default_config()).
 
--spec(monitor_instances/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec monitor_instances([string()], aws_config()) -> [proplist()].
 monitor_instances(InstanceIDs, Config) ->
     case ec2_query2(Config, "MonitorInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")) of
         {ok, Doc} ->
@@ -2321,11 +2317,11 @@ extract_monitor_state(Node) ->
 
 %%
 %%
--spec(purchase_reserved_instances_offering/1 :: ([string() | {string(), pos_integer()}]) -> [string()]).
+-spec purchase_reserved_instances_offering([string() | {string(), pos_integer()}]) -> [string()].
 purchase_reserved_instances_offering(ReservedInstancesOfferings) ->
     purchase_reserved_instances_offering(ReservedInstancesOfferings, default_config()).
 
--spec(purchase_reserved_instances_offering/2 :: ([string() | {string(), pos_integer()}], aws_config()) -> [string()]).
+-spec purchase_reserved_instances_offering([string() | {string(), pos_integer()}], aws_config()) -> [string()].
 purchase_reserved_instances_offering(ReservedInstancesOfferings, Config)
   when is_list(ReservedInstancesOfferings), length(ReservedInstancesOfferings) > 0 ->
     Params = lists:flatten(
@@ -2348,20 +2344,20 @@ purchase_reserved_instances_offering(ReservedInstancesOfferings, Config)
 
 %%
 %%
--spec(reboot_instances/1 :: ([string()]) -> ok).
+-spec reboot_instances([string()]) -> ok.
 reboot_instances(InstanceIDs) -> reboot_instances(InstanceIDs, default_config()).
 
--spec(reboot_instances/2 :: ([string()], aws_config()) -> ok).
+-spec reboot_instances([string()], aws_config()) -> ok.
 reboot_instances(InstanceIDs, Config)
   when is_list(InstanceIDs) ->
     ec2_simple_query2(Config, "RebootInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")).
 
 %%
 %%
--spec(register_image/1 :: (ec2_image_spec()) -> proplist()).
+-spec register_image(ec2_image_spec()) -> proplist().
 register_image(ImageSpec) -> register_image(ImageSpec, default_config()).
 
--spec(register_image/2 :: (ec2_image_spec(), aws_config()) -> proplist()).
+-spec register_image(ec2_image_spec(), aws_config()) -> proplist().
 register_image(ImageSpec, Config) ->
     Params = [
               {"ImageLocation", ImageSpec#ec2_image_spec.image_location},
@@ -2382,16 +2378,16 @@ register_image(ImageSpec, Config) ->
 
 %%
 %%
--spec(release_address/1 :: (string()) -> ok).
+-spec release_address(string()) -> ok.
 release_address(PublicIP) -> release_address(PublicIP, default_config()).
 
 %%
 %%
--spec(replace_network_acl_association/2 :: (string(), string()) -> string()).
+-spec replace_network_acl_association(string(), string()) -> string().
 replace_network_acl_association(AssociationID, NetworkAclID) ->
     replace_network_acl_association(AssociationID, NetworkAclID, default_config()).
 
--spec(replace_network_acl_association/3 :: (string(), string(), aws_config()) -> string()).
+-spec replace_network_acl_association(string(), string(), aws_config()) -> string().
 replace_network_acl_association(AssociationID, NetworkAclID, Config) ->
     Params = [{"AssociationId", AssociationID},
               {"NetworkAclId", NetworkAclID}],
@@ -2405,22 +2401,22 @@ replace_network_acl_association(AssociationID, NetworkAclID, Config) ->
 
 %%
 %%
--spec(replace_network_acl_entry/1 :: (ec2_network_acl_spec()) -> ok).
+-spec replace_network_acl_entry(ec2_network_acl_spec()) -> ok.
 replace_network_acl_entry(Spec) ->
     replace_network_acl_entry(Spec, default_config()).
 
--spec(replace_network_acl_entry/2 :: (ec2_network_acl_spec(), aws_config()) -> ok).
+-spec replace_network_acl_entry(ec2_network_acl_spec(), aws_config()) -> ok.
 replace_network_acl_entry(Spec, Config) ->
     Params = network_acl_spec_to_params(Spec),
     ec2_simple_query2(Config, "ReplaceNetworkAclEntry", Params, ?NEW_API_VERSION).
 
 %%
 %%
--spec(request_spot_instances/1 :: (ec2_spot_instance_request()) -> [proplist()]).
+-spec request_spot_instances(ec2_spot_instance_request()) -> [proplist()].
 request_spot_instances(Request) ->
     request_spot_instances(Request, default_config()).
 
--spec(request_spot_instances/2 :: (ec2_spot_instance_request(), aws_config()) -> [proplist()]).
+-spec request_spot_instances(ec2_spot_instance_request(), aws_config()) -> [proplist()].
 request_spot_instances(Request, Config) ->
     InstanceSpec = Request#ec2_spot_instance_request.launch_specification,
     Params = [
@@ -2482,13 +2478,13 @@ extract_describe_spot_fleet_request(Doc) ->
      {instance_type, get_text("instanceType", Doc)}
     ].
 
--spec(describe_spot_fleet_instances_all/1 :: (string()) ->
-    {ok, [{instances, [proplist()]}]} | {error, term()}).
+-spec describe_spot_fleet_instances_all(string()) ->
+    {ok, [{instances, [proplist()]}]} | {error, term()}.
 describe_spot_fleet_instances_all(SpotFleetRequestId) ->
     describe_spot_fleet_instances_all(SpotFleetRequestId, default_config()).
 
--spec(describe_spot_fleet_instances_all/2 :: (string(), aws_config()) ->
-    {ok, [{instances, [proplist()]}]} | {error, term()}).
+-spec describe_spot_fleet_instances_all(string(), aws_config()) ->
+    {ok, [{instances, [proplist()]}]} | {error, term()}.
 describe_spot_fleet_instances_all(SpotFleetRequestId, Config) ->
     ListAll = fun(Fun, NextToken, Acc) ->
         case describe_spot_fleet_instances(SpotFleetRequestId, NextToken, undefined, Config) of
@@ -2503,21 +2499,21 @@ describe_spot_fleet_instances_all(SpotFleetRequestId, Config) ->
     end,
     ListAll(ListAll, undefined, []).
 
--type(describe_spot_fleet_instances_return() :: {ok, [{instances, [proplist()]} | {next_token, string()}]} | {error, term()}).
+-type describe_spot_fleet_instances_return() :: {ok, [{instances, [proplist()]} | {next_token, string()}]} | {error, term()}.
 
--spec(describe_spot_fleet_instances/1 :: (string()) -> describe_spot_fleet_instances_return()).
+-spec describe_spot_fleet_instances(string()) -> describe_spot_fleet_instances_return().
 describe_spot_fleet_instances(SpotFleetRequestId) ->
     describe_spot_fleet_instances(SpotFleetRequestId, undefined, undefined, default_config()).
 
--spec(describe_spot_fleet_instances/2 :: (string(), string()) -> describe_spot_fleet_instances_return()).
+-spec describe_spot_fleet_instances(string(), string()) -> describe_spot_fleet_instances_return().
 describe_spot_fleet_instances(SpotFleetRequestId, NextToken) ->
     describe_spot_fleet_instances(SpotFleetRequestId, NextToken, undefined, default_config()).
 
--spec(describe_spot_fleet_instances/3 :: (string(), string(), pos_integer()) -> describe_spot_fleet_instances_return()).
+-spec describe_spot_fleet_instances(string(), string(), pos_integer()) -> describe_spot_fleet_instances_return().
 describe_spot_fleet_instances(SpotFleetRequestId, NextToken, MaxResults) ->
     describe_spot_fleet_instances(SpotFleetRequestId, NextToken, MaxResults, default_config()).
 
--spec(describe_spot_fleet_instances/4 :: (string(), string(), pos_integer(), aws_config()) -> describe_spot_fleet_instances_return()).
+-spec describe_spot_fleet_instances(string(), string(), pos_integer(), aws_config()) -> describe_spot_fleet_instances_return().
 describe_spot_fleet_instances(SpotFleetRequestId, NextToken, MaxResults, Config) ->
     Params = [
         {"SpotFleetRequestId", SpotFleetRequestId},
@@ -2533,12 +2529,12 @@ describe_spot_fleet_instances(SpotFleetRequestId, NextToken, MaxResults, Config)
         {error, _} = E -> E
     end.
 
--spec(modify_spot_fleet_request/3 :: (string(), non_neg_integer(), default | no_termination) -> ok | {error, term()}).
+-spec modify_spot_fleet_request(string(), non_neg_integer(), default | no_termination) -> ok | {error, term()}.
 modify_spot_fleet_request(SpotFleetRequestId, TargetCapacity, ExcessCapacityTerminationPolicy) ->
     modify_spot_fleet_request(SpotFleetRequestId, TargetCapacity,
         ExcessCapacityTerminationPolicy, default_config()).
 
--spec(modify_spot_fleet_request/4 :: (string(), non_neg_integer(), default | no_termination, aws_config()) -> ok | {error, term()}).
+-spec modify_spot_fleet_request(string(), non_neg_integer(), default | no_termination, aws_config()) -> ok | {error, term()}.
 modify_spot_fleet_request(SpotFleetRequestId, TargetCapacity, ExcessCapacityTerminationPolicy, Config) ->
     Params = [
         {"ExcessCapacityTerminationPolicy", encode_termination_policy(ExcessCapacityTerminationPolicy)},
@@ -2570,11 +2566,11 @@ extract_cancel_spot_fleet_response(Doc) ->
          Item <- xmerl_xpath:string("/CancelSpotFleetRequestsResponse/successfulFleetRequestSet/item", Doc)]}
     ].
 
--spec(cancel_spot_fleet_requests/2 :: ([string()], boolean()) -> {ok, proplist()} | {error, term()}).
+-spec cancel_spot_fleet_requests([string()], boolean()) -> {ok, proplist()} | {error, term()}.
 cancel_spot_fleet_requests(SpotFleetRequestIds, TerminateInstances) ->
     cancel_spot_fleet_requests(SpotFleetRequestIds, TerminateInstances, default_config()).
 
--spec(cancel_spot_fleet_requests/3 :: ([string()], boolean(), aws_config()) -> {ok, proplist()} | {error, term()}).
+-spec cancel_spot_fleet_requests([string()], boolean(), aws_config()) -> {ok, proplist()} | {error, term()}.
 cancel_spot_fleet_requests(SpotFleetRequestIds, TerminateInstances, Config) ->
     Params = [
         {"TerminateInstances", TerminateInstances} |
@@ -2590,11 +2586,11 @@ cancel_spot_fleet_requests(SpotFleetRequestIds, TerminateInstances, Config) ->
         {error, _} = E -> E
     end.
 
--spec(request_spot_fleet/1 :: (ec2_spot_fleet_request()) -> {ok, string()} | {error, term()}).
+-spec request_spot_fleet(ec2_spot_fleet_request()) -> {ok, string()} | {error, term()}.
 request_spot_fleet(Request) ->
     request_spot_fleet(Request, default_config()).
 
--spec(request_spot_fleet/2 :: (ec2_spot_fleet_request(), aws_config()) -> {ok, string()} | {error, term()}).
+-spec request_spot_fleet(ec2_spot_fleet_request(), aws_config()) -> {ok, string()} | {error, term()}.
 request_spot_fleet(Request, Config) ->
     LConf = Request#ec2_spot_fleet_request.spot_fleet_request_config,
     {LSpecs, _} = lists:foldl(
@@ -2657,29 +2653,29 @@ request_spot_fleet(Request, Config) ->
 
 %%
 %%
--spec(release_address/2 :: (string(), aws_config()) -> ok).
+-spec release_address(string(), aws_config()) -> ok.
 release_address(PublicIP, Config)
   when is_list(PublicIP) ->
     ec2_simple_query2(Config, "ReleaseAddress", [{"PublicIp", PublicIP}]).
 
 %%
 %%
--spec(reset_image_attribute/2 :: (string(), atom()) -> ok).
+-spec reset_image_attribute(string(), atom()) -> ok.
 reset_image_attribute(ImageID, Attribute) ->
     reset_image_attribute(ImageID, Attribute, default_config()).
 
--spec(reset_image_attribute/3 :: (string(), atom(), aws_config()) -> ok).
+-spec reset_image_attribute(string(), atom(), aws_config()) -> ok.
 reset_image_attribute(ImageID, launch_permission, Config) ->
     ec2_simple_query2(Config, "ResetImageAttribute",
                      [{"ImageId", ImageID}, {"Attribute", "launchPermission"}]).
 
 %%
 %%
--spec(reset_instance_attribute/2 :: (string(), atom()) -> ok).
+-spec reset_instance_attribute(string(), atom()) -> ok.
 reset_instance_attribute(InstanceID, Attribute) ->
     reset_instance_attribute(InstanceID, Attribute, default_config()).
 
--spec(reset_instance_attribute/3 :: (string(), atom(), aws_config()) -> ok).
+-spec reset_instance_attribute(string(), atom(), aws_config()) -> ok.
 reset_instance_attribute(InstanceID, Attribute, Config)
   when is_list(InstanceID),
        Attribute =:= kernel orelse Attribute =:= ramdisk ->
@@ -2688,11 +2684,11 @@ reset_instance_attribute(InstanceID, Attribute, Config)
 
 %%
 %%
--spec(reset_snapshot_attribute/2 :: (string(), atom()) -> ok).
+-spec reset_snapshot_attribute(string(), atom()) -> ok.
 reset_snapshot_attribute(SnapshotID, Attribute) ->
     reset_snapshot_attribute(SnapshotID, Attribute, default_config()).
 
--spec(reset_snapshot_attribute/3 :: (string(), atom(), aws_config()) -> ok).
+-spec reset_snapshot_attribute(string(), atom(), aws_config()) -> ok.
 reset_snapshot_attribute(SnapshotID, create_volume_permission, Config)
   when is_list(SnapshotID) ->
     ec2_simple_query2(Config, "ResetSnapshotAttribute",
@@ -2700,11 +2696,11 @@ reset_snapshot_attribute(SnapshotID, create_volume_permission, Config)
 
 %%
 %%
--spec(revoke_security_group_ingress/2 :: (string(), ec2_ingress_spec()) -> ok).
+-spec revoke_security_group_ingress(string(), ec2_ingress_spec()) -> ok.
 revoke_security_group_ingress(GroupName, IngressSpec) ->
     revoke_security_group_ingress(GroupName, IngressSpec, default_config()).
 
--spec(revoke_security_group_ingress/3 :: (string(), ec2_ingress_spec(), aws_config()) -> ok).
+-spec revoke_security_group_ingress(string(), ec2_ingress_spec(), aws_config()) -> ok.
 revoke_security_group_ingress(GroupName, IngressSpec, Config)
   when is_list(GroupName), is_record(IngressSpec, ec2_ingress_spec) ->
     Params = [{"GroupName", GroupName}|ingress_spec_params(IngressSpec)],
@@ -2712,10 +2708,10 @@ revoke_security_group_ingress(GroupName, IngressSpec, Config)
 
 %%
 %%
--spec(run_instances/1 :: (ec2_instance_spec()) -> proplist()).
+-spec run_instances(ec2_instance_spec()) -> proplist().
 run_instances(InstanceSpec) -> run_instances(InstanceSpec, default_config()).
 
--spec(run_instances/2 :: (ec2_instance_spec(), aws_config()) -> proplist()).
+-spec run_instances(ec2_instance_spec(), aws_config()) -> proplist().
 run_instances(InstanceSpec, Config)
   when is_record(InstanceSpec, ec2_instance_spec) ->
     Params = [
@@ -2775,11 +2771,11 @@ net_if_params(List, Prefix) ->
 
 %%
 %%
--spec(create_tags/2 :: ([string()], [{string(), string()}]) -> proplist()).
+-spec create_tags([string()], [{string(), string()}]) -> proplist().
 create_tags(ResourceIds, TagsList) when is_list(ResourceIds) ->
     create_tags(ResourceIds, TagsList, default_config()).
 
--spec(create_tags/3 :: ([string()], [{string(), string()}], aws_config()) -> proplist()).
+-spec create_tags([string()], [{string(), string()}], aws_config()) -> proplist().
 create_tags(ResourceIds, TagsList, Config) when is_list(ResourceIds)->
     {Tags, _} = lists:foldl(fun({Key, Value}, {Acc, Index}) ->
                                     I = integer_to_list(Index),
@@ -2796,11 +2792,11 @@ create_tags(ResourceIds, TagsList, Config) when is_list(ResourceIds)->
 
 %%
 %%
--spec(delete_tags/2 :: ([string()], [{string(), string()}]) -> proplist()).
+-spec delete_tags([string()], [{string(), string()}]) -> proplist().
 delete_tags(ResourceIds, TagsList) when is_list(ResourceIds) ->
     delete_tags(ResourceIds, TagsList, default_config()).
 
--spec(delete_tags/3 :: ([string()], [{string(), string()}], aws_config()) -> proplist()).
+-spec delete_tags([string()], [{string(), string()}], aws_config()) -> proplist().
 delete_tags(ResourceIds, TagsList, Config) when is_list(ResourceIds)->
     {Tags, _} = lists:foldl(fun({Key, Value}, {Acc, Index}) ->
                                     I = integer_to_list(Index),
@@ -2919,10 +2915,10 @@ block_device_params(Mappings) ->
 
 %%
 %%
--spec(start_instances/1 :: ([string()]) -> proplist()).
+-spec start_instances([string()]) -> proplist().
 start_instances(InstanceIDs) -> start_instances(InstanceIDs, default_config()).
 
--spec(start_instances/2 :: ([string()], aws_config()) -> proplist()).
+-spec start_instances([string()], aws_config()) -> proplist().
 start_instances(InstanceIDs, Config)
   when is_list(InstanceIDs) ->
     case ec2_query2(Config, "StartInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")) of
@@ -2934,17 +2930,17 @@ start_instances(InstanceIDs, Config)
 
 %%
 %%
--spec(stop_instances/1 :: ([string()]) -> proplist()).
+-spec stop_instances([string()]) -> proplist().
 stop_instances(InstanceIDs) -> stop_instances(InstanceIDs, default_config()).
 
--spec(stop_instances/2 :: ([string()], boolean() | aws_config()) -> proplist()).
+-spec stop_instances([string()], boolean() | aws_config()) -> proplist().
 stop_instances(InstanceIDs, Config)
   when is_record(Config, aws_config) ->
     stop_instances(InstanceIDs, false, Config);
 stop_instances(InstanceIDs, Force) ->
     stop_instances(InstanceIDs, Force, default_config()).
 
--spec(stop_instances/3 :: ([string()], boolean(), aws_config()) -> proplist()).
+-spec stop_instances([string()], boolean(), aws_config()) -> proplist().
 stop_instances(InstanceIDs, Force, Config)
   when is_list(InstanceIDs), is_boolean(Force) ->
     case ec2_query2(Config, "StopInstances",
@@ -2957,10 +2953,10 @@ stop_instances(InstanceIDs, Force, Config)
 
 %%
 %%
--spec(terminate_instances/1 :: ([string()]) -> proplist()).
+-spec terminate_instances([string()]) -> proplist().
 terminate_instances(InstanceIDs) -> terminate_instances(InstanceIDs, default_config()).
 
--spec(terminate_instances/2 :: ([string()], aws_config()) -> proplist()).
+-spec terminate_instances([string()], aws_config()) -> proplist().
 terminate_instances(InstanceIDs, Config)
   when is_list(InstanceIDs) ->
     case ec2_query2(Config, "TerminateInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")) of
@@ -2985,11 +2981,11 @@ extract_instance_state_change(Node) ->
 
 %%
 %%
--spec(unmonitor_instances/1 :: ([string()]) -> proplist()).
+-spec unmonitor_instances([string()]) -> proplist().
 unmonitor_instances(InstanceIDs) ->
     unmonitor_instances(InstanceIDs, default_config()).
 
--spec(unmonitor_instances/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec unmonitor_instances([string()], aws_config()) -> [proplist()].
 unmonitor_instances(InstanceIDs, Config) ->
     case ec2_query2(Config, "UnmonitorInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")) of
         {ok, Doc} ->

--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -22,23 +22,23 @@
 
 -import(erlcloud_xml, [get_text/2]).
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 elb_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
@@ -79,11 +79,11 @@ delete_load_balancer(LB, Config) when is_list(LB) ->
                        [{"LoadBalancerName", LB}]).
 
 
--spec register_instance/2 :: (string(), string()) -> proplist().
+-spec register_instance(string(), string()) -> proplist().
 register_instance(LB, InstanceId) ->
     register_instance(LB, InstanceId, default_config()).
 
--spec register_instance/3 :: (string(), string(), aws_config()) -> proplist().
+-spec register_instance(string(), string(), aws_config()) -> proplist().
 register_instance(LB, InstanceId, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "RegisterInstancesWithLoadBalancer",
@@ -91,11 +91,11 @@ register_instance(LB, InstanceId, Config) when is_list(LB) ->
                         erlcloud_aws:param_list([[{"InstanceId", InstanceId}]], "Instances.member")]).
 
 
--spec deregister_instance/2 :: (string(), string()) -> proplist().
+-spec deregister_instance(string(), string()) -> proplist().
 deregister_instance(LB, InstanceId) ->
     deregister_instance(LB, InstanceId, default_config()).
 
--spec deregister_instance/3 :: (string(), string(), aws_config()) -> proplist().
+-spec deregister_instance(string(), string(), aws_config()) -> proplist().
 deregister_instance(LB, InstanceId, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "DeregisterInstancesFromLoadBalancer",
@@ -104,12 +104,12 @@ deregister_instance(LB, InstanceId, Config) when is_list(LB) ->
 
 
 
--spec configure_health_check/2 :: (string(), string()) -> proplist().
+-spec configure_health_check(string(), string()) -> proplist().
 configure_health_check(LB, Target) when is_list(LB),
                                         is_list(Target) ->
     configure_health_check(LB, Target, default_config()).
 
--spec configure_health_check/3 :: (string(), string(), aws_config()) -> proplist().
+-spec configure_health_check(string(), string(), aws_config()) -> proplist().
 configure_health_check(LB, Target, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "ConfigureHealthCheck",

--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -15,8 +15,8 @@
 
          configure_health_check/2, configure_health_check/3]).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 
 -define(API_VERSION, "2012-06-01").
 

--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -2,8 +2,8 @@
 % TODO: Add pagination support
 -module(erlcloud_iam).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
 %% Library initialization.

--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -32,23 +32,23 @@
 
 -define(API_VERSION, "2010-05-08").
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 ec2_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
@@ -57,16 +57,16 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
 %
 % Users API
 %
--spec(get_user/0 :: () -> proplist()).
+-spec get_user() -> proplist().
 get_user() -> get_user([]).
--spec(get_user/1 :: (string() | aws_config()) -> proplist()).
+-spec get_user(string() | aws_config()) -> proplist().
 get_user(Config)
   when is_record(Config, aws_config) ->
     get_user("", Config);
 get_user(UserName) ->
     get_user(UserName, default_config()).
 
--spec(get_user/2 :: (string(), aws_config()) -> proplist()).
+-spec get_user(string(), aws_config()) -> proplist().
 get_user("", Config) ->
     get_user_impl([], Config);
 get_user(UserName, Config) ->
@@ -84,16 +84,16 @@ get_user_impl(UserNameParam, Config)
     end.
 
 % TODO: Make sure to handle pagination of results
--spec(list_users/0 :: () -> proplist()).
+-spec list_users() -> proplist().
 list_users() -> list_users([]).
--spec(list_users/1 :: ([string()] | aws_config()) -> proplist()).
+-spec list_users([string()] | aws_config()) -> proplist().
 list_users(Config)
   when is_record(Config, aws_config) ->
     list_users("/", Config);
 list_users(PathPrefix) ->
     list_users(PathPrefix, default_config()).
 
--spec(list_users/2 :: ([string()], aws_config()) -> proplist()).
+-spec list_users([string()], aws_config()) -> proplist().
 list_users(PathPrefix, Config)
   when is_list(PathPrefix) ->
     case iam_query(Config, "ListUsers", [{"PathPrefix", PathPrefix}]) of
@@ -104,11 +104,11 @@ list_users(PathPrefix, Config)
             Error
     end.
 
--spec(list_groups_for_user/1 :: (string()) -> proplist()).
+-spec list_groups_for_user(string()) -> proplist().
 list_groups_for_user(UserName) ->
     list_groups_for_user(UserName, default_config()).
 
--spec(list_groups_for_user/2 :: (string(), aws_config()) -> proplist()).
+-spec list_groups_for_user(string(), aws_config()) -> proplist().
 list_groups_for_user(UserName, Config)
   when is_record(Config, aws_config) ->
     case iam_query(Config, "ListGroupsForUser", [{"UserName", UserName}]) of
@@ -118,11 +118,11 @@ list_groups_for_user(UserName, Config)
         {error, _} = Error -> Error
     end.
 
--spec(list_user_policies/1 :: (string()) -> proplist()).
+-spec list_user_policies(string()) -> proplist().
 list_user_policies(UserName) ->
     list_user_policies(UserName, default_config()).
 
--spec(list_user_policies/2 :: (string(), aws_config()) -> proplist()).
+-spec list_user_policies(string(), aws_config()) -> proplist().
 list_user_policies(UserName, Config)
   when is_record(Config, aws_config) ->
     case iam_query(Config, "ListUserPolicies", [{"UserName", UserName}]) of
@@ -132,11 +132,11 @@ list_user_policies(UserName, Config)
         {error, _} = Error -> Error
     end.
 
--spec(get_user_policy/2 :: (string(), string()) -> proplist()).
+-spec get_user_policy(string(), string()) -> proplist().
 get_user_policy(UserName, PolicyName) ->
     get_user_policy(UserName, PolicyName, default_config()).
 
--spec(get_user_policy/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec get_user_policy(string(), string(), aws_config()) -> proplist().
 get_user_policy(UserName, PolicyName, Config) 
   when is_record(Config, aws_config) ->
      case iam_query(Config, "GetUserPolicy", [{"UserName", UserName}, {"PolicyName", PolicyName}]) of
@@ -151,11 +151,11 @@ get_user_policy(UserName, PolicyName, Config)
     end.
 
 
--spec(get_login_profile/1 :: (string()) -> proplist()).
+-spec get_login_profile(string()) -> proplist().
 get_login_profile(UserName) ->
     get_login_profile(UserName, default_config()).
 
--spec(get_login_profile/2 :: (string(), aws_config()) -> proplist()).
+-spec get_login_profile(string(), aws_config()) -> proplist().
 get_login_profile(UserName, Config)
   when is_record(Config, aws_config) ->
     case iam_query(Config, "GetLoginProfile", [{"UserName", UserName}]) of
@@ -169,16 +169,16 @@ get_login_profile(UserName, Config)
 %
 % Groups API
 %
--spec(list_groups/0 :: () -> proplist()).
+-spec list_groups() -> proplist().
 list_groups() -> list_groups([]).
--spec(list_groups/1 :: ([string()] | aws_config()) -> proplist()).
+-spec list_groups([string()] | aws_config()) -> proplist().
 list_groups(Config)
   when is_record(Config, aws_config) ->
     list_groups("/", Config);
 list_groups(PathPrefix) ->
     list_groups(PathPrefix, default_config()).
 
--spec(list_groups/2 :: ([string()], aws_config()) -> proplist()).
+-spec list_groups([string()], aws_config()) -> proplist().
 list_groups(PathPrefix, Config)
   when is_list(PathPrefix) ->
     case iam_query(Config, "ListGroups", [{"PathPrefix", PathPrefix}]) of
@@ -189,11 +189,11 @@ list_groups(PathPrefix, Config)
             Error
     end.
 
--spec(list_group_policies/1 :: (string()) -> proplist()).
+-spec list_group_policies(string()) -> proplist().
 list_group_policies(GroupName) ->
     list_group_policies(GroupName, default_config()).
 
--spec(list_group_policies/2 :: (string(), aws_config()) -> proplist()).
+-spec list_group_policies(string(), aws_config()) -> proplist().
 list_group_policies(GroupName, Config)
   when is_record(Config, aws_config) ->
     case iam_query(Config, "ListGroupPolicies", [{"GroupName", GroupName}]) of
@@ -203,11 +203,11 @@ list_group_policies(GroupName, Config)
         {error, _} = Error -> Error
     end.
 
--spec(get_group_policy/2 :: (string(), string()) -> proplist()).
+-spec get_group_policy(string(), string()) -> proplist().
 get_group_policy(GroupName, PolicyName) ->
     get_group_policy(GroupName, PolicyName, default_config()).
 
--spec(get_group_policy/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec get_group_policy(string(), string(), aws_config()) -> proplist().
 get_group_policy(GroupName, PolicyName, Config) 
   when is_record(Config, aws_config) ->
      case iam_query(Config, "GetGroupPolicy", [{"GroupName", GroupName}, {"PolicyName", PolicyName}]) of
@@ -226,16 +226,16 @@ get_group_policy(GroupName, PolicyName, Config)
 %
 % Roles API
 %
--spec(list_roles/0 :: () -> proplist()).
+-spec list_roles() -> proplist().
 list_roles() -> list_roles([]).
--spec(list_roles/1 :: ([string()] | aws_config()) -> proplist()).
+-spec list_roles([string()] | aws_config()) -> proplist().
 list_roles(Config)
   when is_record(Config, aws_config) ->
     list_roles("/", Config);
 list_roles(PathPrefix) ->
     list_roles(PathPrefix, default_config()).
 
--spec(list_roles/2 :: ([string()], aws_config()) -> proplist()).
+-spec list_roles([string()], aws_config()) -> proplist().
 list_roles(PathPrefix, Config)
   when is_list(PathPrefix) ->
     case iam_query(Config, "ListRoles", [{"PathPrefix", PathPrefix}]) of
@@ -246,11 +246,11 @@ list_roles(PathPrefix, Config)
             Error
     end.
 
--spec(list_role_policies/1 :: (string()) -> proplist()).
+-spec list_role_policies(string()) -> proplist().
 list_role_policies(RoleName) ->
     list_role_policies(RoleName, default_config()).
 
--spec(list_role_policies/2 :: ([string()], aws_config()) -> proplist()).
+-spec list_role_policies([string()], aws_config()) -> proplist().
 list_role_policies(RoleName, Config)
   when is_record(Config, aws_config) ->
     case iam_query(Config, "ListRolePolicies", [{"RoleName", RoleName}]) of
@@ -261,11 +261,11 @@ list_role_policies(RoleName, Config)
             Error
     end.
 
--spec(get_role_policy/2 :: (string(), string()) -> proplist()).
+-spec get_role_policy(string(), string()) -> proplist().
 get_role_policy(RoleName, PolicyName) ->
     get_role_policy(RoleName, PolicyName, default_config()).
 
--spec(get_role_policy/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec get_role_policy(string(), string(), aws_config()) -> proplist().
 get_role_policy(RoleName, PolicyName, Config) 
   when is_record(Config, aws_config) ->
      case iam_query(Config, "GetRolePolicy", [{"RoleName", RoleName}, {"PolicyName", PolicyName}]) of
@@ -283,7 +283,7 @@ get_role_policy(RoleName, PolicyName, Config)
 %
 % InstanceProfile
 %
--spec(list_instance_profiles/1 :: (string() | aws_config()) -> proplist()).
+-spec list_instance_profiles(string() | aws_config()) -> proplist().
 list_instance_profiles(Config) 
   when is_record(Config, aws_config) ->
     list_instance_profiles("/", Config);
@@ -291,7 +291,7 @@ list_instance_profiles(Config)
 list_instance_profiles(PathPrefix) ->
     list_instance_profiles(PathPrefix, default_config()).
 
--spec(list_instance_profiles/2 :: (string(), aws_config()) -> proplist()).
+-spec list_instance_profiles(string(), aws_config()) -> proplist().
 list_instance_profiles(PathPrefix, Config)
   when is_record(Config, aws_config) ->
     case iam_query(Config, "ListInstanceProfiles", [{"PathPrefix", PathPrefix}]) of
@@ -312,11 +312,11 @@ list_instance_profiles(PathPrefix, Config)
 %
 % Account APIs
 %
--spec(get_account_password_policy/0 :: () -> proplist()).
+-spec get_account_password_policy() -> proplist().
 get_account_password_policy() ->
     get_account_password_policy(default_config()).
 
--spec(get_account_password_policy/1 :: (aws_config()) -> proplist()).
+-spec get_account_password_policy(aws_config()) -> proplist().
 get_account_password_policy(Config)
   when is_record(Config, aws_config) ->
     case iam_query(Config, "GetRolePolicy", []) of

--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -16,8 +16,8 @@
          split_shards/3, split_shards/4
         ]).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 
 -spec new(string(), string()) -> aws_config().
 

--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -84,13 +84,13 @@ default_config() -> erlcloud_aws:default_config().
 %% @end
 %%------------------------------------------------------------------------------
 
--spec create_stream/2 :: (string(), 1..100) -> proplist().
+-spec create_stream(string(), 1..100) -> proplist().
 
 create_stream(StreamName, ShardCount) when is_integer(ShardCount), ShardCount > 0, ShardCount =< 100 ->
    Json = [{<<"StreamName">>, StreamName}, {<<"ShardCount">>, ShardCount}],
    erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.CreateStream", Json).
 
--spec create_stream/3 :: (string(), 1..100, aws_config()) -> proplist().
+-spec create_stream(string(), 1..100, aws_config()) -> proplist().
 
 create_stream(StreamName, ShardCount, Config) when is_record(Config, aws_config), is_integer(ShardCount), ShardCount > 0, ShardCount =< 100 ->
    Json = [{<<"StreamName">>, StreamName}, {<<"ShardCount">>, ShardCount}],
@@ -113,13 +113,13 @@ create_stream(StreamName, ShardCount, Config) when is_record(Config, aws_config)
 %% @end
 %%------------------------------------------------------------------------------
 
--spec delete_stream/1 :: (string()) -> proplist().
+-spec delete_stream(string()) -> proplist().
 
 delete_stream(StreamName) ->
    Json = [{<<"StreamName">>, StreamName}],
    erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.DeleteStream", Json).
 
--spec delete_stream/2 :: (string(), aws_config()) -> proplist().
+-spec delete_stream(string(), aws_config()) -> proplist().
 
 delete_stream(StreamName, Config) when is_record(Config, aws_config) ->
    Json = [{<<"StreamName">>, StreamName}],
@@ -143,12 +143,12 @@ delete_stream(StreamName, Config) when is_record(Config, aws_config) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec list_streams/0 :: () -> proplist().
+-spec list_streams() -> proplist().
 
 list_streams() ->
    list_streams(default_config()).
 
--spec list_streams/1 :: (string() | aws_config()) -> proplist().
+-spec list_streams(string() | aws_config()) -> proplist().
 
 list_streams(Config) when is_record(Config, aws_config) ->
    erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.ListStreams", []);
@@ -156,7 +156,7 @@ list_streams(ExclusiveStartStreamName) ->
    Json = [{<<"ExclusiveStartStreamName">>, ExclusiveStartStreamName}],
    erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.ListStreams", Json).
 
--spec list_streams/2 :: (string(), 1..100 | aws_config()) -> proplist().
+-spec list_streams(string(), 1..100 | aws_config()) -> proplist().
 
 list_streams(ExclusiveStartStreamName, Config) when is_record(Config, aws_config) ->
    Json = [{<<"ExclusiveStartStreamName">>, ExclusiveStartStreamName}],
@@ -165,7 +165,7 @@ list_streams(ExclusiveStartStreamName, Limit) when is_integer(Limit), Limit > 0,
    Json = [{<<"ExclusiveStartStreamName">>, ExclusiveStartStreamName}, {<<"Limit">>, Limit}],
    erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.ListStreams", Json).
 
--spec list_streams/3 :: (string(), 1..100, aws_config()) -> proplist().
+-spec list_streams(string(), 1..100, aws_config()) -> proplist().
 
 list_streams(ExclusiveStartStreamName, Limit, Config) when is_record(Config, aws_config), is_integer(Limit), Limit > 0, Limit =< 100 ->
    Json = [{<<"ExclusiveStartStreamName">>, ExclusiveStartStreamName}, {<<"Limit">>, Limit}],
@@ -211,12 +211,12 @@ list_streams(ExclusiveStartStreamName, Limit, Config) when is_record(Config, aws
 %% @end
 %%------------------------------------------------------------------------------
 
--spec describe_stream/1 :: (string()) -> proplist().
+-spec describe_stream(string()) -> proplist().
 
 describe_stream(StreamName) ->
    describe_stream(StreamName, default_config()).
 
--spec describe_stream/2 :: (string(), 1..100 | aws_config()) -> proplist().
+-spec describe_stream(string(), 1..100 | aws_config()) -> proplist().
 
 describe_stream(StreamName, Config) when is_record(Config, aws_config) ->
    Json = [{<<"StreamName">>, StreamName}],
@@ -225,7 +225,7 @@ describe_stream(StreamName, Limit) when is_integer(Limit), Limit > 0, Limit =< 1
    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}],
    erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.DescribeStream", Json).
 
--spec describe_stream/3 :: (string(), 1..100, string() | aws_config()) -> proplist().
+-spec describe_stream(string(), 1..100, string() | aws_config()) -> proplist().
 
 describe_stream(StreamName, Limit, Config) when is_record(Config, aws_config) ->
    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}],
@@ -234,7 +234,7 @@ describe_stream(StreamName, Limit, ExcludeShard) when is_integer(Limit), Limit >
    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}, {<<"ExclusiveStartShardId">>, ExcludeShard}],
    erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.DescribeStream", Json).
 
--spec describe_stream/4 :: (string(), 1..100, string(), aws_config()) -> proplist().
+-spec describe_stream(string(), 1..100, string(), aws_config()) -> proplist().
 
 describe_stream(StreamName, Limit, ExcludeShard, Config) when is_record(Config, aws_config), is_integer(Limit), Limit > 0, Limit =< 100 ->
    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}, {<<"ExclusiveStartShardId">>, ExcludeShard}],
@@ -259,13 +259,13 @@ describe_stream(StreamName, Limit, ExcludeShard, Config) when is_record(Config, 
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_shard_iterator/3 :: (string(), string(), string()) -> proplist().
+-spec get_shard_iterator(string(), string(), string()) -> proplist().
 
 get_shard_iterator(StreamName, ShardId, ShardIteratorType) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"ShardId">>, ShardId}, {<<"ShardIteratorType">>, ShardIteratorType}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.GetShardIterator", Json).
 
--spec get_shard_iterator/4 :: (string(), string(), string(), string() | aws_config()) -> proplist().
+-spec get_shard_iterator(string(), string(), string(), string() | aws_config()) -> proplist().
 
 get_shard_iterator(StreamName, ShardId, ShardIteratorType, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"ShardId">>, ShardId}, {<<"ShardIteratorType">>, ShardIteratorType}],
@@ -274,7 +274,7 @@ get_shard_iterator(StreamName, ShardId, ShardIteratorType, StartingSequenceNumbe
   Json = [{<<"StreamName">>, StreamName}, {<<"ShardId">>, ShardId}, {<<"ShardIteratorType">>, ShardIteratorType}, {<<"StartingSequenceNumber">>, StartingSequenceNumber}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.GetShardIterator", Json).
 
--spec get_shard_iterator/5 :: (string(), string(), string(), string(), aws_config()) -> proplist().
+-spec get_shard_iterator(string(), string(), string(), string(), aws_config()) -> proplist().
 
 get_shard_iterator(StreamName, ShardId, ShardIteratorType, StartingSequenceNumber, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"ShardId">>, ShardId}, {<<"ShardIteratorType">>, ShardIteratorType}, {<<"StartingSequenceNumber">>, StartingSequenceNumber}],
@@ -311,13 +311,13 @@ get_shard_iterator(StreamName, ShardId, ShardIteratorType, StartingSequenceNumbe
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_records/1 :: (string()) -> proplist().
+-spec get_records(string()) -> proplist().
 
 get_records(ShardIterator) ->
   Json = [{<<"ShardIterator">>, ShardIterator}],
   get_normalized_records(default_config(), Json).
 
--spec get_records/2 :: (string(), 1..100 | aws_config()) -> proplist().
+-spec get_records(string(), 1..100 | aws_config()) -> proplist().
 
 get_records(ShardIterator, Config) when is_record(Config, aws_config) ->
   Json = [{<<"ShardIterator">>, ShardIterator}],
@@ -326,7 +326,7 @@ get_records(ShardIterator, Limit) when is_integer(Limit), Limit > 0, Limit =< 10
   Json = [{<<"ShardIterator">>, ShardIterator}, {<<"Limit">>, Limit}],
   get_normalized_records(default_config(), Json).
 
--spec get_records/3 :: (string(), 1..100, aws_config()) -> proplist().
+-spec get_records(string(), 1..100, aws_config()) -> proplist().
 
 get_records(ShardIterator, Limit, Config) when is_record(Config, aws_config), is_integer(Limit), Limit > 0, Limit =< 100 ->
   Json = [{<<"ShardIterator">>, ShardIterator}, {<<"Limit">>, Limit}],
@@ -376,13 +376,13 @@ normalize_response([]) -> [].
 %% @end
 %%------------------------------------------------------------------------------
 
--spec put_record/3 :: (string(), string(), string()) -> proplist().
+-spec put_record(string(), string(), string()) -> proplist().
 
 put_record(StreamName, PartitionKey, Data) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"PartitionKey">>, PartitionKey}, {<<"Data">>, base64:encode(Data)}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.PutRecord", Json).
 
--spec put_record/4 :: (string(), string(), string(), string() | aws_config()) -> proplist().
+-spec put_record(string(), string(), string(), string() | aws_config()) -> proplist().
 
 put_record(StreamName, PartitionKey, Data, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"PartitionKey">>, PartitionKey}, {<<"Data">>, base64:encode(Data)}],
@@ -391,7 +391,7 @@ put_record(StreamName, PartitionKey, Data, ExplicitHashKey) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"PartitionKey">>, PartitionKey}, {<<"Data">>, base64:encode(Data)}, {<<"ExplicitHashKey">>, ExplicitHashKey}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.PutRecord", Json).
 
--spec put_record/5 :: (string(), string(), string(), string(), string() | aws_config()) -> proplist().
+-spec put_record(string(), string(), string(), string(), string() | aws_config()) -> proplist().
 
 put_record(StreamName, PartitionKey, Data, ExplicitHashKey, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"PartitionKey">>, PartitionKey}, {<<"Data">>, base64:encode(Data)}, {<<"ExplicitHashKey">>, ExplicitHashKey}],
@@ -400,7 +400,7 @@ put_record(StreamName, PartitionKey, Data, ExplicitHashKey, Ordering) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"PartitionKey">>, PartitionKey}, {<<"Data">>, base64:encode(Data)}, {<<"ExplicitHashKey">>, ExplicitHashKey}, {<<"SequenceNumberForOrdering">>, Ordering}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.PutRecord", Json).
 
--spec put_record/6 :: (string(), string(), string(), string(), string(), aws_config()) -> proplist().
+-spec put_record(string(), string(), string(), string(), string(), aws_config()) -> proplist().
 
 put_record(StreamName, PartitionKey, Data, ExplicitHashKey, Ordering, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"PartitionKey">>, PartitionKey}, {<<"Data">>, base64:encode(Data)}, {<<"ExplicitHashKey">>, ExplicitHashKey}, {<<"SequenceNumberForOrdering">>, Ordering}],
@@ -424,13 +424,13 @@ put_record(StreamName, PartitionKey, Data, ExplicitHashKey, Ordering, Config) wh
 %% @end
 %%------------------------------------------------------------------------------
 
--spec merge_shards/3 :: (string(), string(), string()) -> proplist().
+-spec merge_shards(string(), string(), string()) -> proplist().
 
 merge_shards(StreamName, AdjacentShardToMerge, ShardToMerge) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"AdjacentShardToMerge">>, AdjacentShardToMerge}, {<<"ShardToMerge">>, ShardToMerge}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.MergeShards", Json).
 
--spec merge_shards/4 :: (string(), string(), string(), aws_config()) -> proplist().
+-spec merge_shards(string(), string(), string(), aws_config()) -> proplist().
 
 merge_shards(StreamName, AdjacentShardToMerge, ShardToMerge, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"AdjacentShardToMerge">>, AdjacentShardToMerge}, {<<"ShardToMerge">>, ShardToMerge}],
@@ -453,13 +453,13 @@ merge_shards(StreamName, AdjacentShardToMerge, ShardToMerge, Config) when is_rec
 %% @end
 %%------------------------------------------------------------------------------
 
--spec split_shards/3 :: (string(), string(), string()) -> proplist().
+-spec split_shards(string(), string(), string()) -> proplist().
 
 split_shards(StreamName, ShardToSplit, NewStartingHashKey) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"ShardToSplit">>, ShardToSplit}, {<<"NewStartingHashKey">>, NewStartingHashKey}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.SplitShard", Json).
 
--spec split_shards/4 :: (string(), string(), string(), aws_config()) -> proplist().
+-spec split_shards(string(), string(), string(), aws_config()) -> proplist().
 
 split_shards(StreamName, ShardToSplit, NewStartingHashKey, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"ShardToSplit">>, ShardToSplit}, {<<"NewStartingHashKey">>, NewStartingHashKey}],

--- a/src/erlcloud_mon.erl
+++ b/src/erlcloud_mon.erl
@@ -276,23 +276,23 @@ configure_host(Host, Port, Protocol) ->
                                   mon_protocol=Protocol},
     put(aws_config, NewConfig).
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 mon_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.

--- a/src/erlcloud_mon.erl
+++ b/src/erlcloud_mon.erl
@@ -24,9 +24,9 @@
          test2/0
         ]).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
--include_lib("erlcloud/include/erlcloud_mon.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
+-include("erlcloud_mon.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
 -import(erlcloud_xml, [get_text/2]).

--- a/src/erlcloud_mturk.erl
+++ b/src/erlcloud_mturk.erl
@@ -57,9 +57,9 @@
          update_qualification_type/1, update_qualification_type/2
         ]).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
--include_lib("erlcloud/include/erlcloud_mturk.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
+-include("erlcloud_mturk.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
 -define(API_VERSION, "2008-08-02").

--- a/src/erlcloud_mturk.erl
+++ b/src/erlcloud_mturk.erl
@@ -69,45 +69,45 @@
 -define(XMLNS_EXTERNALQUESTION, "http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2006-07-14/ExternalQuestion.xsd").
 -define(XMLNS_ANSWERKEY, "http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2005-10-01/AnswerKey.xsd").
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyId, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyId,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyId, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyId,
                 secret_access_key=SecretAccessKey,
                 mturk_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyId, SecretAccessKey) ->
     put(aws_config, new(AccessKeyId, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyId, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyId, SecretAccessKey, Host)),
     ok.
 
 default_config() -> erlcloud_aws:default_config().
 
--spec approve_assignment/2 :: (string(), string() | none) -> ok.
+-spec approve_assignment(string(), string() | none) -> ok.
 approve_assignment(AssignmentId, RequesterFeedback) ->
     approve_assignment(AssignmentId, RequesterFeedback, default_config()).
 
--spec approve_assignment/3 :: (string(), string() | none, aws_config()) -> ok.
+-spec approve_assignment(string(), string() | none, aws_config()) -> ok.
 approve_assignment(AssignmentId, RequesterFeedback, Config)
   when is_list(AssignmentId),
        is_list(RequesterFeedback) orelse RequesterFeedback =:= none ->
     mturk_simple_request(Config, "ApproveAssignment",
                          [{"AssignmentId", AssignmentId}, {"RequesterFeedback", RequesterFeedback}]).
 
--spec assign_qualification/2 :: (string(), string()) -> ok.
+-spec assign_qualification(string(), string()) -> ok.
 assign_qualification(QualificationTypeId, WorkerId) ->
     assign_qualification(QualificationTypeId, WorkerId, default_config()).
 
--spec assign_qualification/3 :: (string(), string(), integer() | aws_config()) -> ok.
+-spec assign_qualification(string(), string(), integer() | aws_config()) -> ok.
 assign_qualification(QualificationTypeId, WorkerId, Config)
   when is_record(Config, aws_config) ->
     assign_qualification(QualificationTypeId, WorkerId, 1, Config);
@@ -115,7 +115,7 @@ assign_qualification(QualificationTypeId, WorkerId, IntegerValue) ->
     assign_qualification(QualificationTypeId, WorkerId, IntegerValue, false).
 
 
--spec assign_qualification/4 :: (string(), string(), integer(), boolean() | aws_config()) -> ok.
+-spec assign_qualification(string(), string(), integer(), boolean() | aws_config()) -> ok.
 assign_qualification(QualificationTypeId, WorkerId, IntegerValue, Config)
   when is_record(Config, aws_config) ->
     assign_qualification(QualificationTypeId, WorkerId, IntegerValue, false, Config);
@@ -123,7 +123,7 @@ assign_qualification(QualificationTypeId, WorkerId, IntegerValue, SendNotificati
     assign_qualification(QualificationTypeId, WorkerId, IntegerValue,
                          SendNotification, default_config()).
 
--spec assign_qualification/5 :: (string(), string(), integer(), boolean(), aws_config()) -> ok.
+-spec assign_qualification(string(), string(), integer(), boolean(), aws_config()) -> ok.
 assign_qualification(QualificationTypeId, WorkerId, IntegerValue, SendNotification,
                      Config)
   when is_list(QualificationTypeId), is_list(WorkerId),
@@ -134,33 +134,33 @@ assign_qualification(QualificationTypeId, WorkerId, IntegerValue, SendNotificati
                           {"IntegerValue", IntegerValue},
                           {"SendNotification", SendNotification}]).
 
--spec block_worker/2 :: (string(), string()) -> ok.
+-spec block_worker(string(), string()) -> ok.
 block_worker(WorkerId, Reason) -> block_worker(WorkerId, Reason, default_config()).
 
--spec block_worker/3 :: (string(), string(), aws_config()) -> ok.
+-spec block_worker(string(), string(), aws_config()) -> ok.
 block_worker(WorkerId, Reason, Config)
   when is_list(WorkerId), is_list(Reason) ->
     mturk_simple_request(Config, "BlockWorker",
                          [{"WorkerId", WorkerId}, {"Reason", Reason}]).
 
--spec change_hit_type_of_hit/2 :: (string(), string()) -> ok.
+-spec change_hit_type_of_hit(string(), string()) -> ok.
 change_hit_type_of_hit(HITId, HITTypeId) ->
     change_hit_type_of_hit(HITId, HITTypeId, default_config()).
 
--spec change_hit_type_of_hit/3 :: (string(), string(), aws_config()) -> ok.
+-spec change_hit_type_of_hit(string(), string(), aws_config()) -> ok.
 change_hit_type_of_hit(HITId, HITTypeId, Config)
   when is_list(HITId), is_list(HITTypeId) ->
     mturk_simple_request(Config, "ChangeHITTypeOfHIT",
                          [{"HITId", HITId}, {"HITTypeId", HITTypeId}]).
 
--spec create_hit/5 :: (string(), mturk_question(), 30..3153600,
+-spec create_hit(string(), mturk_question(), 30..3153600,
                        1..1000000000, string() | none) -> proplist().
 create_hit(HITTypeId, Question, LifetimeInSeconds, MaxAssignments,
            RequesterAnnotation) ->
     create_hit(HITTypeId, Question, LifetimeInSeconds, MaxAssignments,
                RequesterAnnotation, default_config()).
 
--spec create_hit/6 :: (string(), mturk_question(), 30..3153600,
+-spec create_hit(string(), mturk_question(), 30..3153600,
                        1..1000000000, string() | none, aws_config()) -> proplist().
 create_hit(HITTypeId, Question, LifetimeInSeconds, MaxAssignments,
            RequesterAnnotation, Config)
@@ -187,11 +187,11 @@ create_hit(HITTypeId, Question, LifetimeInSeconds, MaxAssignments,
       Doc
      ).
 
--spec create_hit/1 :: (#mturk_hit{}) -> proplist().
+-spec create_hit(#mturk_hit{}) -> proplist().
 create_hit(HIT) ->
     create_hit(HIT, default_config()).
 
--spec create_hit/2 :: (#mturk_hit{}, aws_config()) -> proplist().
+-spec create_hit(#mturk_hit{}, aws_config()) -> proplist().
 create_hit(HIT, Config) ->
     QuestionXML = xml_to_string(encode_xml(HIT#mturk_hit.question)),
     Params = [
@@ -245,11 +245,11 @@ encode_locale_value(undefined) -> [];
 encode_locale_value(#mturk_locale{country_code=Country}) ->
     [{"Country", Country}].
 
--spec create_qualification_type/1 :: (#mturk_qualification_type{}) -> proplist().
+-spec create_qualification_type(#mturk_qualification_type{}) -> proplist().
 create_qualification_type(QType) ->
     create_qualification_type(QType, default_config()).
 
--spec create_qualification_type/2 :: (#mturk_qualification_type{}, aws_config()) -> proplist().
+-spec create_qualification_type(#mturk_qualification_type{}, aws_config()) -> proplist().
 create_qualification_type(QType, Config)
   when is_record(QType, mturk_qualification_type) ->
     Doc = mturk_xml_request(Config, "CreateQualificationType",
@@ -274,38 +274,38 @@ qualification_type_params(QType) ->
      {"AutoGrantedValue", case AutoGranted of true -> AutoGrantedValue; false -> undefined end}
     ].
 
--spec disable_hit/1 :: (string()) -> ok.
+-spec disable_hit(string()) -> ok.
 disable_hit(HITId) -> disable_hit(HITId, default_config()).
 
--spec disable_hit/2 :: (string(), aws_config()) -> ok.
+-spec disable_hit(string(), aws_config()) -> ok.
 disable_hit(HITId, Config)
   when is_list(HITId) ->
     mturk_simple_request(Config, "DisableHIT", [{"HITId", HITId}]).
 
--spec dispose_hit/1 :: (string()) -> ok.
+-spec dispose_hit(string()) -> ok.
 dispose_hit(HITId) -> dispose_hit(HITId, default_config()).
 
--spec dispose_hit/2 :: (string(), aws_config()) -> ok.
+-spec dispose_hit(string(), aws_config()) -> ok.
 dispose_hit(HITId, Config)
   when is_list(HITId) ->
     mturk_simple_request(Config, "DisposeHIT", [{"HITId", HITId}]).
 
--spec dispose_qualification_type/1 :: (string()) -> ok.
+-spec dispose_qualification_type(string()) -> ok.
 dispose_qualification_type(QualificationTypeId) ->
     dispose_qualification_type(QualificationTypeId, default_config()).
 
--spec dispose_qualification_type/2 :: (string(), aws_config()) -> ok.
+-spec dispose_qualification_type(string(), aws_config()) -> ok.
 dispose_qualification_type(QualificationTypeId, Config)
   when is_list(QualificationTypeId) ->
     mturk_simple_request(Config, "DisposeQualificationType",
                          [{"QualificationTypeId", QualificationTypeId}]).
 
--spec extend_hit/3 :: (string(), 1..1000000000 | none, 3600..31536000 | none) -> ok.
+-spec extend_hit(string(), 1..1000000000 | none, 3600..31536000 | none) -> ok.
 extend_hit(HITId, MaxAssignmentsIncrement, ExpirationIncrementInSeconds) ->
     extend_hit(HITId, MaxAssignmentsIncrement, ExpirationIncrementInSeconds,
                default_config()).
 
--spec extend_hit/4 :: (string(), 1..1000000000 | none, 3600..31536000 | none, aws_config()) -> ok.
+-spec extend_hit(string(), 1..1000000000 | none, 3600..31536000 | none, aws_config()) -> ok.
 extend_hit(HITId, MaxAssignmentsIncrement, ExpirationIncrementInSeconds, Config)
   when is_list(HITId),
        (MaxAssignmentsIncrement >= 1 andalso MaxAssignmentsIncrement =< 1000000000) orelse MaxAssignmentsIncrement =:= none,
@@ -316,19 +316,19 @@ extend_hit(HITId, MaxAssignmentsIncrement, ExpirationIncrementInSeconds, Config)
                           {"MaxAssignmentsIncrement", MaxAssignmentsIncrement},
                           {"ExpirationIncrementInSeconds", ExpirationIncrementInSeconds}]).
 
--spec force_expire_hit/1 :: (string()) -> ok.
+-spec force_expire_hit(string()) -> ok.
 force_expire_hit(HITId) -> force_expire_hit(HITId, default_config()).
 
--spec force_expire_hit/2 :: (string(), aws_config()) -> ok.
+-spec force_expire_hit(string(), aws_config()) -> ok.
 force_expire_hit(HITId, Config)
   when is_list(HITId) ->
     mturk_simple_request(Config, "ForceExpireHIT", [{"HITId", HITId}]).
 
--spec get_account_balance/0 :: () -> proplist().
+-spec get_account_balance() -> proplist().
 get_account_balance() ->
     get_account_balance(default_config()).
 
--spec get_account_balance/1 :: (aws_config()) -> proplist().
+-spec get_account_balance(aws_config()) -> proplist().
 get_account_balance(Config) ->
     Doc = mturk_xml_request(Config, "GetAccountBalance", []),
     erlcloud_xml:decode(
@@ -339,18 +339,18 @@ get_account_balance(Config) ->
       Doc
      ).
 
--spec get_assignments_for_hit/1 :: (string()) -> proplist().
+-spec get_assignments_for_hit(string()) -> proplist().
 get_assignments_for_hit(HITId) ->
     get_assignments_for_hit(HITId, []).
 
--spec get_assignments_for_hit/2 :: (string(), proplist() | aws_config()) -> proplist().
+-spec get_assignments_for_hit(string(), proplist() | aws_config()) -> proplist().
 get_assignments_for_hit(HITId, Config)
   when is_record(Config, aws_config) ->
     get_assignments_for_hit(HITId, [], Config);
 get_assignments_for_hit(HITId, Options) ->
     get_assignments_for_hit(HITId, Options, default_config()).
 
--spec get_assignments_for_hit/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_assignments_for_hit(string(), proplist(), aws_config()) -> proplist().
 get_assignments_for_hit(HITId, Options, Config)
   when is_list(HITId), is_list(Options) ->
     Params = [
@@ -411,11 +411,11 @@ extract_assignment(Assignment) ->
       Assignment
      ).
 
--spec get_bonus_payments_for_hit/2 :: (string(), proplist()) -> proplist().
+-spec get_bonus_payments_for_hit(string(), proplist()) -> proplist().
 get_bonus_payments_for_hit(HITId, Options) ->
     get_bonus_payments_for_hit(HITId, Options, default_config()).
 
--spec get_bonus_payments_for_hit/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_bonus_payments_for_hit(string(), proplist(), aws_config()) -> proplist().
 get_bonus_payments_for_hit(HITId, Options, Config)
   when is_list(HITId), is_list(Options) ->
     Params = [
@@ -426,11 +426,11 @@ get_bonus_payments_for_hit(HITId, Options, Config)
     Doc = mturk_xml_request(Config, "GetBonusPayments", Params),
     extract_bonus_payments(Doc).
 
--spec get_bonus_payments_for_assignment/2 :: (string(), proplist()) -> proplist().
+-spec get_bonus_payments_for_assignment(string(), proplist()) -> proplist().
 get_bonus_payments_for_assignment(AssignmentId, Options) ->
     get_bonus_payments_for_assignment(AssignmentId, Options, default_config()).
 
--spec get_bonus_payments_for_assignment/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_bonus_payments_for_assignment(string(), proplist(), aws_config()) -> proplist().
 get_bonus_payments_for_assignment(AssignmentId, Options, Config)
   when is_list(AssignmentId), is_list(Options) ->
     Params = [
@@ -466,11 +466,11 @@ extract_bonus_payment(Payment) ->
       Payment
      ).
 
--spec get_file_upload_url/2 :: (string(), string()) -> string().
+-spec get_file_upload_url(string(), string()) -> string().
 get_file_upload_url(AssignmentId, QuestionIdentifier) ->
     get_file_upload_url(AssignmentId, QuestionIdentifier, default_config()).
 
--spec get_file_upload_url/3 :: (string(), string(), aws_config()) -> string().
+-spec get_file_upload_url(string(), string(), aws_config()) -> string().
 get_file_upload_url(AssignmentId, QuestionIdentifier, Config)
   when is_record(Config, aws_config) ->
     Params = [
@@ -480,27 +480,27 @@ get_file_upload_url(AssignmentId, QuestionIdentifier, Config)
     Doc = mturk_xml_request(Config, "GetFileUploadURL", Params),
     erlcloud_xml:get_text("FileUploadURL", Doc).
 
--spec get_hit/1 :: (string()) -> #mturk_hit{}.
+-spec get_hit(string()) -> #mturk_hit{}.
 get_hit(HITId) -> get_hit(HITId, default_config()).
 
--spec get_hit/2 :: (string(), aws_config()) -> #mturk_hit{}.
+-spec get_hit(string(), aws_config()) -> #mturk_hit{}.
 get_hit(HITId, Config)
   when is_list(HITId) ->
     Doc = mturk_xml_request(Config, "GetHIT", [{"HITId", HITId}]),
     hd(extract_hits([Doc])).
 
--spec get_hits_for_qualification_type/1 :: (string()) -> proplist().
+-spec get_hits_for_qualification_type(string()) -> proplist().
 get_hits_for_qualification_type(QualificationTypeId) ->
     get_hits_for_qualification_type(QualificationTypeId, []).
 
--spec get_hits_for_qualification_type/2 :: (string(), proplist() | aws_config()) -> proplist().
+-spec get_hits_for_qualification_type(string(), proplist() | aws_config()) -> proplist().
 get_hits_for_qualification_type(QualificationTypeId, Config)
   when is_record(Config, aws_config) ->
     get_hits_for_qualification_type(QualificationTypeId, [], Config);
 get_hits_for_qualification_type(QualificationTypeId, Options) ->
     get_hits_for_qualification_type(QualificationTypeId, Options, default_config()).
 
--spec get_hits_for_qualification_type/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_hits_for_qualification_type(string(), proplist(), aws_config()) -> proplist().
 get_hits_for_qualification_type(QualificationTypeId, Options, Config)
   when is_list(Options) ->
     Params = [
@@ -519,18 +519,18 @@ get_hits_for_qualification_type(QualificationTypeId, Options, Config)
       Doc
      ).
 
--spec get_reviewable_hits/0 :: () -> proplist().
+-spec get_reviewable_hits() -> proplist().
 get_reviewable_hits() ->
     get_reviewable_hits([]).
 
--spec get_reviewable_hits/1 :: (proplist() | aws_config()) -> proplist().
+-spec get_reviewable_hits(proplist() | aws_config()) -> proplist().
 get_reviewable_hits(Config)
   when is_record(Config, aws_config) ->
     get_reviewable_hits([], Config);
 get_reviewable_hits(Options) ->
     get_reviewable_hits(Options, default_config()).
 
--spec get_reviewable_hits/2 :: (proplist(), aws_config()) -> proplist().
+-spec get_reviewable_hits(proplist(), aws_config()) -> proplist().
 get_reviewable_hits(Options, Config)
   when is_list(Options) ->
     Params = [
@@ -573,11 +573,11 @@ get_reviewable_hits(Options, Config)
       Doc
      ).
 
--spec get_qualification_score/2 :: (string(), string()) -> proplist().
+-spec get_qualification_score(string(), string()) -> proplist().
 get_qualification_score(QualificationTypeId, SubjectId) ->
     get_qualification_score(QualificationTypeId, SubjectId, default_config()).
 
--spec get_qualification_score/3 :: (string(), string(), aws_config()) -> proplist().
+-spec get_qualification_score(string(), string(), aws_config()) -> proplist().
 get_qualification_score(QualificationTypeId, SubjectId, Config)
   when is_list(QualificationTypeId), is_list(SubjectId) ->
     Doc = mturk_xml_request(Config, "GetQualificationScore",
@@ -596,11 +596,11 @@ get_qualification_score(QualificationTypeId, SubjectId, Config)
       Doc
      ).
 
--spec get_qualification_type/1 :: (string()) -> #mturk_qualification_type{}.
+-spec get_qualification_type(string()) -> #mturk_qualification_type{}.
 get_qualification_type(QualificationTypeId) ->
     get_qualification_type(QualificationTypeId, default_config()).
 
--spec get_qualification_type/2 :: (string(), aws_config()) -> #mturk_qualification_type{}.
+-spec get_qualification_type(string(), aws_config()) -> #mturk_qualification_type{}.
 get_qualification_type(QualificationTypeId, Config)
   when is_record(Config, aws_config) ->
     Doc = mturk_xml_request(Config, "GetQualificationType",
@@ -635,18 +635,18 @@ extract_qualification_type(Node) ->
 decode_keywords(String) ->
     [string:strip(Keyword) || Keyword <- string:tokens(String, ",")].
 
--spec get_qualifications_for_qualification_type/1 :: (string()) -> proplist().
+-spec get_qualifications_for_qualification_type(string()) -> proplist().
 get_qualifications_for_qualification_type(QualificationTypeId) ->
     get_qualifications_for_qualification_type(QualificationTypeId, default_config()).
 
--spec get_qualifications_for_qualification_type/2 :: (string(), proplist() | aws_config()) -> proplist().
+-spec get_qualifications_for_qualification_type(string(), proplist() | aws_config()) -> proplist().
 get_qualifications_for_qualification_type(QualificationTypeId, Config)
   when is_record(Config, aws_config) ->
     get_qualifications_for_qualification_type(QualificationTypeId, [], Config);
 get_qualifications_for_qualification_type(QualificationTypeId, Options) ->
     get_qualifications_for_qualification_type(QualificationTypeId, Options, default_config()).
 
--spec get_qualifications_for_qualification_type/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_qualifications_for_qualification_type(string(), proplist(), aws_config()) -> proplist().
 get_qualifications_for_qualification_type(QualificationTypeId, Options, Config)
   when is_list(QualificationTypeId), is_list(Options) ->
     Params = [
@@ -672,18 +672,18 @@ get_qualifications_for_qualification_type(QualificationTypeId, Options, Config)
        Item
       ) || Item <- xmerl_xpath:string("Qualification", Doc)].
 
--spec get_qualification_requests/0 :: () -> proplist().
+-spec get_qualification_requests() -> proplist().
 get_qualification_requests() ->
     get_qualification_requests([]).
 
--spec get_qualification_requests/1 :: (proplist() | aws_config()) -> proplist().
+-spec get_qualification_requests(proplist() | aws_config()) -> proplist().
 get_qualification_requests(Config)
   when is_record(Config, aws_config) ->
     get_qualification_requests([], Config);
 get_qualification_requests(Options) ->
     get_qualification_requests(Options, default_config()).
 
--spec get_qualification_requests/2 :: (proplist(), aws_config()) -> proplist().
+-spec get_qualification_requests(proplist(), aws_config()) -> proplist().
 get_qualification_requests(Options, Config)
   when is_list(Options) ->
     Params = [
@@ -732,18 +732,18 @@ extract_qualification_request(Request) ->
       Request
      ).
 
--spec get_requester_statistic/2 :: (string(), one_day | seven_days | thirty_days | life_to_date) -> [{datetime(), float()}].
+-spec get_requester_statistic(string(), one_day | seven_days | thirty_days | life_to_date) -> [{datetime(), float()}].
 get_requester_statistic(Statistic, TimePeriod) ->
     get_requester_statistic(Statistic, TimePeriod, default_config()).
 
--spec get_requester_statistic/3 :: (string(), one_day | seven_days | thirty_days | life_to_date, pos_integer() | aws_config()) -> [{datetime(), float()}].
+-spec get_requester_statistic(string(), one_day | seven_days | thirty_days | life_to_date, pos_integer() | aws_config()) -> [{datetime(), float()}].
 get_requester_statistic(Statistic, TimePeriod, Config)
   when is_record(Config, aws_config) ->
     get_requester_statistic(Statistic, TimePeriod, 1, Config);
 get_requester_statistic(Statistic, TimePeriod, Count) ->
     get_requester_statistic(Statistic, TimePeriod, Count, default_config()).
 
--spec get_requester_statistic/4 :: (string(), one_day | seven_days | thirty_days | life_to_date, pos_integer(), aws_config()) -> [{datetime(), float()}].
+-spec get_requester_statistic(string(), one_day | seven_days | thirty_days | life_to_date, pos_integer(), aws_config()) -> [{datetime(), float()}].
 get_requester_statistic(Statistic, TimePeriod, Count, Config)
   when is_list(Statistic),
        TimePeriod =:= one_day orelse TimePeriod =:= seven_days orelse
@@ -769,11 +769,11 @@ get_requester_statistic(Statistic, TimePeriod, Count, Config)
       end} ||
         DP <- xmerl_xpath:string("DataPoint", Doc)].
 
--spec grant_bonus/4 :: (string(), string(), #mturk_money{}, string()) -> ok.
+-spec grant_bonus(string(), string(), #mturk_money{}, string()) -> ok.
 grant_bonus(WorkerId, AssignmentId, BonusAmount, Reason) ->
     grant_bonus(WorkerId, AssignmentId, BonusAmount, Reason, default_config()).
 
--spec grant_bonus/5 :: (string(), string(), #mturk_money{}, string(), aws_config()) -> ok.
+-spec grant_bonus(string(), string(), #mturk_money{}, string(), aws_config()) -> ok.
 grant_bonus(WorkerId, AssignmentId, BonusAmount, Reason, Config) ->
     mturk_simple_request(Config, "GrantBonus",
                          [
@@ -784,18 +784,18 @@ grant_bonus(WorkerId, AssignmentId, BonusAmount, Reason, Config) ->
                          ]
                         ).
 
--spec grant_qualification/1 :: (string()) -> ok.
+-spec grant_qualification(string()) -> ok.
 grant_qualification(QualificationRequestId) ->
     grant_qualification(QualificationRequestId, none).
 
--spec grant_qualification/2 :: (string(), integer() | none | aws_config()) -> ok.
+-spec grant_qualification(string(), integer() | none | aws_config()) -> ok.
 grant_qualification(QualificationRequestId, Config)
   when is_record(Config, aws_config) ->
     grant_qualification(QualificationRequestId, none, Config);
 grant_qualification(QualificationRequestId, Value) ->
     grant_qualification(QualificationRequestId, Value, default_config()).
 
--spec grant_qualification/3 :: (string(), integer() | none, aws_config()) -> ok.
+-spec grant_qualification(string(), integer() | none, aws_config()) -> ok.
 grant_qualification(QualificationRequestId, Value, Config)
   when is_list(QualificationRequestId),
        is_integer(Value) orelse Value =:= none ->
@@ -1090,11 +1090,11 @@ extract_money(Money) ->
 encode_money(#mturk_money{amount=Amount, currency_code=CurrencyCode}) ->
     [{"Amount", Amount}, {"CurrencyCode", CurrencyCode}].
 
--spec notify_workers/3 :: (string(), string(), [string()]) -> ok.
+-spec notify_workers(string(), string(), [string()]) -> ok.
 notify_workers(Subject, MessageText, WorkerIds) ->
     notify_workers(Subject, MessageText, WorkerIds, default_config()).
 
--spec notify_workers/4 :: (string(), string(), [string()], aws_config()) -> ok.
+-spec notify_workers(string(), string(), [string()], aws_config()) -> ok.
 notify_workers(Subject, MessageText, WorkerIds, Config)
   when is_list(Subject), is_list(MessageText),
        is_list(WorkerIds), length(WorkerIds) =< 100 ->
@@ -1106,11 +1106,11 @@ notify_workers(Subject, MessageText, WorkerIds, Config)
                          ]
                         ).
 
--spec register_hit_type/1 :: (#mturk_hit{}) -> proplist().
+-spec register_hit_type(#mturk_hit{}) -> proplist().
 register_hit_type(HIT) ->
     register_hit_type(HIT, default_config()).
 
--spec register_hit_type/2 :: (#mturk_hit{}, aws_config()) -> proplist().
+-spec register_hit_type(#mturk_hit{}, aws_config()) -> proplist().
 register_hit_type(HIT, Config) ->
     Params = [
               {"Title", HIT#mturk_hit.title},
@@ -1130,18 +1130,18 @@ register_hit_type(HIT, Config) ->
       Doc
      ).
 
--spec reject_assignment/1 :: (string()) -> ok.
+-spec reject_assignment(string()) -> ok.
 reject_assignment(AssignmentId) ->
     reject_assignment(AssignmentId, none).
 
--spec reject_assignment/2 :: (string(), string() | none | aws_config()) -> ok.
+-spec reject_assignment(string(), string() | none | aws_config()) -> ok.
 reject_assignment(AssignmentId, Config)
   when is_record(Config, aws_config) ->
     reject_assignment(AssignmentId, none, Config);
 reject_assignment(AssignmentId, Reason) ->
     reject_assignment(AssignmentId, Reason, default_config()).
 
--spec reject_assignment/3 :: (string(), string() | none, aws_config()) -> ok.
+-spec reject_assignment(string(), string() | none, aws_config()) -> ok.
 reject_assignment(AssignmentId, Reason, Config)
   when is_list(AssignmentId),
        is_list(Reason) orelse Reason =:= none ->
@@ -1152,18 +1152,18 @@ reject_assignment(AssignmentId, Reason, Config)
                          ]
                         ).
 
--spec reject_qualification_request/1 :: (string()) -> ok.
+-spec reject_qualification_request(string()) -> ok.
 reject_qualification_request(QualificationRequestId) ->
     reject_qualification_request(QualificationRequestId, none).
 
--spec reject_qualification_request/2 :: (string(), string() | none | aws_config()) -> ok.
+-spec reject_qualification_request(string(), string() | none | aws_config()) -> ok.
 reject_qualification_request(QualificationRequestId, Config)
   when is_record(Config, aws_config) ->
     reject_qualification_request(QualificationRequestId, none, Config);
 reject_qualification_request(QualificationRequestId, Reason) ->
     reject_qualification_request(QualificationRequestId, Reason, default_config()).
 
--spec reject_qualification_request/3 :: (string(), string() | none, aws_config()) -> ok.
+-spec reject_qualification_request(string(), string() | none, aws_config()) -> ok.
 reject_qualification_request(QualificationRequestId, Reason, Config)
   when is_list(QualificationRequestId),
        is_list(Reason) orelse Reason =:= none ->
@@ -1174,18 +1174,18 @@ reject_qualification_request(QualificationRequestId, Reason, Config)
                          ]
                         ).
 
--spec revoke_qualification/2 :: (string(), string()) -> ok.
+-spec revoke_qualification(string(), string()) -> ok.
 revoke_qualification(QualificationTypeId, WorkerId) ->
     revoke_qualification(QualificationTypeId, WorkerId, none).
 
--spec revoke_qualification/3 :: (string(), string(), string() | none | aws_config()) -> ok.
+-spec revoke_qualification(string(), string(), string() | none | aws_config()) -> ok.
 revoke_qualification(QualificationTypeId, WorkerId, Config)
   when is_record(Config, aws_config) ->
     revoke_qualification(QualificationTypeId, WorkerId, none, Config);
 revoke_qualification(QualificationTypeId, WorkerId, Reason) ->
     revoke_qualification(QualificationTypeId, WorkerId, Reason, default_config()).
 
--spec revoke_qualification/4 :: (string(), string(), string() | none, aws_config()) -> ok.
+-spec revoke_qualification(string(), string(), string() | none, aws_config()) -> ok.
 revoke_qualification(QualificationTypeId, WorkerId, Reason, Config) ->
     mturk_simple_request(Config, "RevokeQualification",
                          [
@@ -1195,18 +1195,18 @@ revoke_qualification(QualificationTypeId, WorkerId, Reason, Config) ->
                          ]
                         ).
 
--spec search_hits/0 :: () -> proplist().
+-spec search_hits() -> proplist().
 search_hits() ->
     search_hits([]).
 
--spec search_hits/1 :: (proplist() | aws_config()) -> proplist().
+-spec search_hits(proplist() | aws_config()) -> proplist().
 search_hits(Config)
   when is_record(Config, aws_config) ->
     search_hits([], Config);
 search_hits(Options) ->
     search_hits(Options, default_config()).
 
--spec search_hits/2 :: (proplist(), aws_config()) -> proplist().
+-spec search_hits(proplist(), aws_config()) -> proplist().
 search_hits(Options, Config)
   when is_list(Options) ->
     Params = [
@@ -1241,18 +1241,18 @@ search_hits(Options, Config)
       Doc
      ).
 
--spec search_qualification_types/0 :: () -> proplist().
+-spec search_qualification_types() -> proplist().
 search_qualification_types() ->
     search_qualification_types([]).
 
--spec search_qualification_types/1 :: (proplist() | aws_config()) -> proplist().
+-spec search_qualification_types(proplist() | aws_config()) -> proplist().
 search_qualification_types(Config)
   when is_record(Config, aws_config) ->
     search_qualification_types([], Config);
 search_qualification_types(Options) ->
     search_qualification_types(Options, default_config()).
 
--spec search_qualification_types/2 :: (proplist(), aws_config()) -> proplist().
+-spec search_qualification_types(proplist(), aws_config()) -> proplist().
 search_qualification_types(Options, Config) ->
     Params = [
               {"Query", proplists:get_value(search_query, Options)},
@@ -1285,11 +1285,11 @@ search_qualification_types(Options, Config) ->
       Doc
      ).
 
--spec send_test_event_notification/2 :: (proplist(), mturk_event_type()) -> ok.
+-spec send_test_event_notification(proplist(), mturk_event_type()) -> ok.
 send_test_event_notification(Notificaiton, TestEventType) ->
     send_test_event_notification(Notificaiton, TestEventType, default_config()).
 
--spec send_test_event_notification/3 :: (proplist(), mturk_event_type(), aws_config()) -> ok.
+-spec send_test_event_notification(proplist(), mturk_event_type(), aws_config()) -> ok.
 send_test_event_notification(Notification, TestEventType, Config) ->
     mturk_simple_request(Config, "SendTestEventNotification",
                          [
@@ -1301,18 +1301,18 @@ send_test_event_notification(Notification, TestEventType, Config) ->
                          ]
                         ).
 
--spec set_hit_as_reviewing/1 :: (string()) -> ok.
+-spec set_hit_as_reviewing(string()) -> ok.
 set_hit_as_reviewing(HITId) ->
     set_hit_as_reviewing(HITId, false).
 
--spec set_hit_as_reviewing/2 :: (string(), boolean() | aws_config()) -> ok.
+-spec set_hit_as_reviewing(string(), boolean() | aws_config()) -> ok.
 set_hit_as_reviewing(HITId, Config)
   when is_record(Config, aws_config) ->
     set_hit_as_reviewing(HITId, false, Config);
 set_hit_as_reviewing(HITId, Revert) ->
     set_hit_as_reviewing(HITId, Revert, default_config()).
 
--spec set_hit_as_reviewing/3 :: (string(), boolean(), aws_config()) -> ok.
+-spec set_hit_as_reviewing(string(), boolean(), aws_config()) -> ok.
 set_hit_as_reviewing(HITId, Revert, Config) ->
     mturk_simple_request(Config, "SetHITAsReviewing",
                          [
@@ -1321,18 +1321,18 @@ set_hit_as_reviewing(HITId, Revert, Config) ->
                          ]
                         ).
 
--spec set_hit_type_notification/2 :: (string(), proplist()) -> ok.
+-spec set_hit_type_notification(string(), proplist()) -> ok.
 set_hit_type_notification(HITTypeId, Notification) ->
     set_hit_type_notification(HITTypeId, Notification, undefined).
 
--spec set_hit_type_notification/3 :: (string(), proplist(), boolean() | undefined | aws_config()) -> ok.
+-spec set_hit_type_notification(string(), proplist(), boolean() | undefined | aws_config()) -> ok.
 set_hit_type_notification(HITTypeId, Notification, Config)
   when is_record(Config, aws_config) ->
     set_hit_type_notification(HITTypeId, Notification, undefined, Config);
 set_hit_type_notification(HITTypeId, Notification, Active) ->
     set_hit_type_notification(HITTypeId, Notification, Active, default_config()).
 
--spec set_hit_type_notification/4 :: (string(), proplist(), boolean() | undefined, aws_config()) -> ok.
+-spec set_hit_type_notification(string(), proplist(), boolean() | undefined, aws_config()) -> ok.
 set_hit_type_notification(HITTypeId, Notification, Active, Config)
   when is_list(HITTypeId), is_list(Notification),
        is_boolean(Active) orelse Active =:= undefined ->
@@ -1358,29 +1358,29 @@ encode_transport(email) -> "Email";
 encode_transport(soap) -> "SOAP";
 encode_transport(rest) -> "REST".
 
--spec unblock_worker/1 :: (string()) -> ok.
+-spec unblock_worker(string()) -> ok.
 unblock_worker(WorkerId) -> unblock_worker(WorkerId, none).
 
--spec unblock_worker/2 :: (string(), string() | none | aws_config()) -> ok.
+-spec unblock_worker(string(), string() | none | aws_config()) -> ok.
 unblock_worker(WorkerId, Config)
   when is_record(Config, aws_config) ->
     unblock_worker(WorkerId, none, Config);
 unblock_worker(WorkerId, Reason) ->
     unblock_worker(WorkerId, Reason, default_config()).
 
--spec unblock_worker/3 :: (string(), string() | none, aws_config()) -> ok.
+-spec unblock_worker(string(), string() | none, aws_config()) -> ok.
 unblock_worker(WorkerId, Reason, Config)
   when is_list(WorkerId),
        is_list(Reason) orelse Reason =:= none ->
     mturk_simple_request(Config, "UnblockWorker",
                          [{"WorkerId", WorkerId}, {"Reason", Reason}]).
 
--spec update_qualification_score/3 :: (string(), string(), integer()) -> ok.
+-spec update_qualification_score(string(), string(), integer()) -> ok.
 update_qualification_score(QualificationTypeId, SubjectId, IntegerValue) ->
     update_qualification_score(QualificationTypeId, SubjectId,
                                IntegerValue, default_config()).
 
--spec update_qualification_score/4 :: (string(), string(), integer(), aws_config()) -> ok.
+-spec update_qualification_score(string(), string(), integer(), aws_config()) -> ok.
 update_qualification_score(QualificationTypeId, SubjectId, IntegerValue, Config)
   when is_list(SubjectId), is_list(QualificationTypeId),
        is_integer(IntegerValue) ->
@@ -1392,11 +1392,11 @@ update_qualification_score(QualificationTypeId, SubjectId, IntegerValue, Config)
                          ]
                         ).
 
--spec update_qualification_type/1 :: (#mturk_qualification_type{}) -> #mturk_qualification_type{}.
+-spec update_qualification_type(#mturk_qualification_type{}) -> #mturk_qualification_type{}.
 update_qualification_type(QType) ->
     update_qualification_type(QType, default_config()).
 
--spec update_qualification_type/2 :: (#mturk_qualification_type{}, aws_config()) -> #mturk_qualification_type{}.
+-spec update_qualification_type(#mturk_qualification_type{}, aws_config()) -> #mturk_qualification_type{}.
 update_qualification_type(QType, Config) ->
     Doc = mturk_xml_request(Config, "UpdateQualificationType",
                             [

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -34,8 +34,8 @@
          get_bucket_and_key/1
         ]).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
 %%% Note that get_bucket_and_key/1 may be used to obtain the Bucket and Key to pass to various

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -328,7 +328,7 @@ list_buckets(Config) ->
 % @doc Get S3 bucket policy JSON object
 % API Document: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETacl.html
 %
--spec(get_bucket_policy/1 :: (BucketName::string()) -> ok | {error, Reason::term()}).
+-spec get_bucket_policy(BucketName::string()) -> ok | {error, Reason::term()}.
 get_bucket_policy(BucketName) ->
     get_bucket_policy(BucketName, default_config()).
 
@@ -344,7 +344,7 @@ get_bucket_policy(BucketName) ->
 %                                   <RequestId>DC1EA9456B266EF5</RequestId>
 %                                   <HostId>DRtkAB80cAeom+4ffSGU3PFCxS7QvtiW+wxLnPF0dM2nxoaRqQk1SK/z62ZJVHAD</HostId>
 %                               </Error>"}}
--spec(get_bucket_policy/2 :: (BucketName::string(), Config::aws_config()) -> {ok, Policy::string()} | {error, Reason::term()}).
+-spec get_bucket_policy(BucketName::string(), Config::aws_config()) -> {ok, Policy::string()} | {error, Reason::term()}.
 get_bucket_policy(BucketName, Config)
     when is_record(Config, aws_config) ->
         case s3_request2(Config, get, BucketName, "/", "policy", [], <<>>, []) of

--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -33,8 +33,8 @@
 -compile(export_all).
 -endif.
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 
 -define(API_VERSION, "2009-04-15").
 -define(SDB_TIMEOUT, 10000).

--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -39,52 +39,52 @@
 -define(API_VERSION, "2009-04-15").
 -define(SDB_TIMEOUT, 10000).
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 sdb_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
 default_config() -> erlcloud_aws:default_config().
 
--spec create_domain/1 :: (string()) -> proplist().
+-spec create_domain(string()) -> proplist().
 create_domain(Name) ->
     create_domain(Name, default_config()).
 
--spec create_domain/2 :: (string(), aws_config()) -> proplist().
+-spec create_domain(string(), aws_config()) -> proplist().
 create_domain(Name, Config)
   when is_list(Name) ->
     sdb_simple_request(Config, "CreateDomain", [{"DomainName", Name}]).
 
--spec delete_domain/1 :: (string()) -> proplist().
+-spec delete_domain(string()) -> proplist().
 delete_domain(Name) ->
     delete_domain(Name, default_config()).
 
--spec delete_domain/2 :: (string(), aws_config()) -> proplist().
+-spec delete_domain(string(), aws_config()) -> proplist().
 delete_domain(Name, Config)
   when is_list(Name) ->
     sdb_simple_request(Config, "DeleteDomain", [{"DomainName", Name}]).
 
--spec domain_metadata/1 :: (string()) -> proplist().
+-spec domain_metadata(string()) -> proplist().
 domain_metadata(Name) ->
     domain_metadata(Name, default_config()).
 
--spec domain_metadata/2 :: (string(), aws_config()) -> proplist().
+-spec domain_metadata(string(), aws_config()) -> proplist().
 domain_metadata(Name, Config)
   when is_list(Name) ->
     {Doc, Result} = sdb_request(Config, "DomainMetadata", [{"DomainName", Name}]),
@@ -100,36 +100,36 @@ domain_metadata(Name, Config)
                                    ], MR),
     [{domain_metadata, Metadata}|Result].
 
--spec batch_put_attributes/2 :: (string(), [{string(), sdb_attributes()}]) -> proplist().
+-spec batch_put_attributes(string(), [{string(), sdb_attributes()}]) -> proplist().
 batch_put_attributes(DomainName, Items) ->
     batch_put_attributes(DomainName, Items, default_config()).
 
--spec batch_put_attributes/3 :: (string(), [{string(), sdb_attributes()}], aws_config()) -> proplist().
+-spec batch_put_attributes(string(), [{string(), sdb_attributes()}], aws_config()) -> proplist().
 batch_put_attributes(DomainName, Items, Config)
   when is_list(DomainName), is_list(Items) ->
     ItemParams = [[{"ItemName", Name}|attributes_list(Attrs)] || {Name, Attrs} <- Items],
     sdb_simple_request(Config, "BatchPutAttributes",
                        [{"DomainName", DomainName}|erlcloud_aws:param_list(ItemParams, "Item")]).
 
--spec delete_attributes/2 :: (string(), string()) -> proplist().
+-spec delete_attributes(string(), string()) -> proplist().
 delete_attributes(DomainName, ItemName) ->
     delete_attributes(DomainName, ItemName, []).
 
--spec delete_attributes/3 :: (string(), string(), sdb_delete_attributes() | aws_config()) -> proplist().
+-spec delete_attributes(string(), string(), sdb_delete_attributes() | aws_config()) -> proplist().
 delete_attributes(DomainName, ItemName, Config)
   when is_record(Config, aws_config) ->
     delete_attributes(DomainName, ItemName, [], Config);
 delete_attributes(DomainName, ItemName, Attributes) ->
     delete_attributes(DomainName, ItemName, Attributes, []).
 
--spec delete_attributes/4 :: (string(), string(), sdb_delete_attributes(), sdb_conditionals() | aws_config()) -> proplist().
+-spec delete_attributes(string(), string(), sdb_delete_attributes(), sdb_conditionals() | aws_config()) -> proplist().
 delete_attributes(DomainName, ItemName, Attributes, Config)
   when is_record(Config, aws_config) ->
     delete_attributes(DomainName, ItemName, Attributes, [], Config);
 delete_attributes(DomainName, ItemName, Attributes, Conditionals) ->
     delete_attributes(DomainName, ItemName, Attributes, Conditionals, default_config()).
 
--spec delete_attributes/5 :: (string(), string(), sdb_delete_attributes(), sdb_conditionals(), aws_config()) -> proplist().
+-spec delete_attributes(string(), string(), sdb_delete_attributes(), sdb_conditionals(), aws_config()) -> proplist().
 delete_attributes(DomainName, ItemName, Attributes, Conditionals, Config)
   when is_list(DomainName), is_list(ItemName), is_list(Attributes),
        is_list(Conditionals) ->
@@ -137,11 +137,11 @@ delete_attributes(DomainName, ItemName, Attributes, Conditionals, Config)
               delete_attributes_list(Attributes)] ++ conditionals_list(Conditionals),
     sdb_simple_request(Config, "DeleteAttributes", Params).
 
--spec get_attributes/2 :: (string(), string()) -> proplist().
+-spec get_attributes(string(), string()) -> proplist().
 get_attributes(DomainName, ItemName) ->
     get_attributes(DomainName, ItemName, []).
 
--spec get_attributes/3 :: (string(), string(), [string()] | boolean() | aws_config()) -> proplist().
+-spec get_attributes(string(), string(), [string()] | boolean() | aws_config()) -> proplist().
 get_attributes(DomainName, ItemName, Config)
   when is_record(Config, aws_config) ->
     get_attributes(DomainName, ItemName, [], Config);
@@ -151,7 +151,7 @@ get_attributes(DomainName, ItemName, ConsistentRead)
 get_attributes(DomainName, ItemName, AttributeNames) ->
     get_attributes(DomainName, ItemName, AttributeNames, false).
 
--spec get_attributes/4 :: (string(), string(), [string()], boolean() | aws_config()) -> proplist().
+-spec get_attributes(string(), string(), [string()], boolean() | aws_config()) -> proplist().
 get_attributes(DomainName, ItemName, AttributeNames, Config)
   when is_record(Config, aws_config) ->
     get_attributes(DomainName, ItemName, AttributeNames, false, Config);
@@ -159,7 +159,7 @@ get_attributes(DomainName, ItemName, AttributeNames, ConsistentRead) ->
     get_attributes(DomainName, ItemName, AttributeNames, ConsistentRead,
                    default_config()).
 
--spec get_attributes/5 :: (string(), string(), [string()], boolean(), aws_config()) -> proplist().
+-spec get_attributes(string(), string(), [string()], boolean(), aws_config()) -> proplist().
 get_attributes(DomainName, ItemName, AttributeNames, ConsistentRead, Config) ->
     {Doc, Result} = sdb_request(Config, "GetAttributes",
                                 [{"DomainName", DomainName}, {"ItemName", ItemName},
@@ -175,11 +175,11 @@ extract_attributes(Attributes) ->
 extract_attribute(Node) ->
     {erlcloud_xml:get_text("Name", Node), erlcloud_xml:get_text("Value", Node)}.
 
--spec list_domains/0 :: () -> proplist().
+-spec list_domains() -> proplist().
 list_domains() ->
     list_domains(default_config()).
 
--spec list_domains/1 :: (string() | 1..100 | none | aws_config()) -> proplist().
+-spec list_domains(string() | 1..100 | none | aws_config()) -> proplist().
 list_domains(Config) when is_record(Config, aws_config) ->
     list_domains("", Config);
 list_domains(MaxDomains) when is_integer(MaxDomains); MaxDomains =:= none ->
@@ -187,7 +187,7 @@ list_domains(MaxDomains) when is_integer(MaxDomains); MaxDomains =:= none ->
 list_domains(FirstToken) ->
     list_domains(FirstToken, none).
 
--spec list_domains/2 :: (string(), 1..100 | none | aws_config()) -> proplist().
+-spec list_domains(string(), 1..100 | none | aws_config()) -> proplist().
 list_domains(FirstToken, Config) when is_record(Config, aws_config) ->
     list_domains(FirstToken, none, Config);
 list_domains(FirstToken, MaxDomains) ->
@@ -203,7 +203,7 @@ maybe_add_nexttoken([], Params) ->
 maybe_add_nexttoken(Token, Params) ->
     [{"NextToken", Token} | Params].
 
--spec list_domains/3 :: (string(), 1..100 | none, aws_config()) -> proplist().
+-spec list_domains(string(), 1..100 | none, aws_config()) -> proplist().
 list_domains(FirstToken, MaxDomains, Config)
   when is_list(FirstToken),
        is_integer(MaxDomains) orelse MaxDomains =:= none ->
@@ -217,18 +217,18 @@ list_domains(FirstToken, MaxDomains, Config)
     [{domains, erlcloud_xml:get_list("/ListDomainsResponse/ListDomainsResult/DomainName", Doc)},
      {next_token, erlcloud_xml:get_text("/ListDomainsResponse/ListDomainsResult/NextToken", Doc)}|Result].
 
--spec put_attributes/3 :: (string(), string(), sdb_attributes()) -> proplist().
+-spec put_attributes(string(), string(), sdb_attributes()) -> proplist().
 put_attributes(DomainName, ItemName, Attributes) ->
     put_attributes(DomainName, ItemName, Attributes, []).
 
--spec put_attributes/4 :: (string(), string(), sdb_attributes(), sdb_conditionals() | aws_config()) -> proplist().
+-spec put_attributes(string(), string(), sdb_attributes(), sdb_conditionals() | aws_config()) -> proplist().
 put_attributes(DomainName, ItemName, Attributes, Config)
   when is_record(Config, aws_config) ->
     put_attributes(DomainName, ItemName, Attributes, [], Config);
 put_attributes(DomainName, ItemName, Attributes, Conditionals) ->
     put_attributes(DomainName, ItemName, Attributes, Conditionals, default_config()).
 
--spec put_attributes/5 :: (string(), string(), sdb_attributes(), sdb_conditionals(), aws_config()) -> proplist().
+-spec put_attributes(string(), string(), sdb_attributes(), sdb_conditionals(), aws_config()) -> proplist().
 put_attributes(DomainName, ItemName, Attributes, Conditionals, Config)
   when is_list(DomainName), is_list(ItemName), is_list(Attributes),
        is_list(Conditionals) ->
@@ -239,10 +239,10 @@ put_attributes(DomainName, ItemName, Attributes, Conditionals, Config)
 %% These functions will return the first page of results along with
 %% a token to retrieve the next page, if any.
 
--spec select/1 :: (string()) -> proplist().
+-spec select(string()) -> proplist().
 select(SelectExpression) -> select(SelectExpression, none).
 
--spec select/2 :: (string(), string() | none | boolean() | aws_config()) -> proplist().
+-spec select(string(), string() | none | boolean() | aws_config()) -> proplist().
 select(SelectExpression, Config)
   when is_record(Config, aws_config) ->
     select(SelectExpression, none, Config);
@@ -252,14 +252,14 @@ select(SelectExpression, ConsistentRead)
 select(SelectExpression, NextToken) ->
     select(SelectExpression, NextToken, false).
 
--spec select/3 :: (string(), string() | none, boolean() | aws_config()) -> proplist().
+-spec select(string(), string() | none, boolean() | aws_config()) -> proplist().
 select(SelectExpression, NextToken, Config)
   when is_record(Config, aws_config) ->
     select(SelectExpression, NextToken, false, Config);
 select(SelectExpression, NextToken, ConsistentRead) ->
     select(SelectExpression, NextToken, ConsistentRead, default_config()).
 
--spec select/4 :: (string(), string() | none, boolean(), aws_config()) -> proplist().
+-spec select(string(), string() | none, boolean(), aws_config()) -> proplist().
 select(SelectExpression, NextToken, ConsistentRead, Config)
   when is_list(SelectExpression),
        is_list(NextToken) orelse NextToken =:= none,
@@ -277,25 +277,24 @@ select(SelectExpression, NextToken, ConsistentRead, Config)
 %% These functions will make multiple requests until all
 %% pages of results have been consumed.
 
--spec select_all/1 :: (string()) -> proplist().
+-spec select_all(string()) -> proplist().
 select_all(SelectExpression) ->
     select_all(SelectExpression, false).
 
--spec select_all/2 :: (string(), boolean()) -> proplist().
+-spec select_all(string(), boolean()) -> proplist().
 select_all(SelectExpression, ConsistentRead)
     when is_boolean(ConsistentRead) ->
     select_all(SelectExpression, ConsistentRead, default_config());
 select_all(SelectExpression, Config) ->
     select_all(SelectExpression, false, Config).
 
--spec select_all/3 :: (string(), boolean(), aws_config()) -> proplist().
+-spec select_all(string(), boolean(), aws_config()) -> proplist().
 select_all(SelectExpression, ConsistentRead, Config)
   when is_list(SelectExpression),
        is_boolean(ConsistentRead) ->
     select_all(SelectExpression, none, ConsistentRead, Config, [], []).
 
--spec select_all/6 :: (string(), string() | none | done, boolean(),
-                       aws_config(), proplist(), proplist()) -> proplist().
+-spec select_all(string(), string() | none | done, boolean(), aws_config(), proplist(), proplist()) -> proplist().
 select_all(_, done, _, _, Items, Metadata) ->
     [{items, Items}|Metadata];
 select_all(SelectExpression, NextToken, ConsistentRead, Config, Items, Metadata) ->

--- a/src/erlcloud_ses.erl
+++ b/src/erlcloud_ses.erl
@@ -75,23 +75,23 @@
 %%% Library initialization
 %%%------------------------------------------------------------------------------
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 ses_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.

--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -94,12 +94,12 @@
 -export_type([sns_acl/0, sns_endpoint_attribute/0,
               sns_message/0, sns_application/0, sns_endpoint/0]).
 
--spec add_permission/3 :: (string(), string(), sns_acl()) -> ok.
+-spec add_permission(string(), string(), sns_acl()) -> ok.
 
 add_permission(TopicArn, Label, Permissions) ->
     add_permission(TopicArn, Label, Permissions, default_config()).
 
--spec add_permission/4 :: (string(), string(), sns_acl(), aws_config()) -> ok.
+-spec add_permission(string(), string(), sns_acl(), aws_config()) -> ok.
 add_permission(TopicArn, Label, Permissions, Config)
   when is_list(TopicArn),
        is_list(Label), length(Label) =< 80,
@@ -112,19 +112,19 @@ add_permission(TopicArn, Label, Permissions, Config)
 
 
 
--spec create_platform_endpoint/2 :: (string(), string()) -> string().
+-spec create_platform_endpoint(string(), string()) -> string().
 create_platform_endpoint(PlatformApplicationArn, Token) ->
     create_platform_endpoint(PlatformApplicationArn, Token, "").
 
--spec create_platform_endpoint/3 :: (string(), string(), string()) -> string().
+-spec create_platform_endpoint(string(), string(), string()) -> string().
 create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData) ->
     create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, []).
 
--spec create_platform_endpoint/4 :: (string(), string(), string(), [{sns_endpoint_attribute(), string()}]) -> string().
+-spec create_platform_endpoint(string(), string(), string(), [{sns_endpoint_attribute(), string()}]) -> string().
 create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, Attributes) ->
     create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, Attributes, default_config()).
 
--spec create_platform_endpoint/5 :: (string(), string(), string(), [{sns_endpoint_attribute(), string()}], aws_config()) -> string().
+-spec create_platform_endpoint(string(), string(), string(), [{sns_endpoint_attribute(), string()}], aws_config()) -> string().
 create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, Attributes, Config) ->
     Doc =
         sns_xml_request(
@@ -137,43 +137,43 @@ create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, Attribut
     erlcloud_xml:get_text(
         "CreatePlatformEndpointResult/EndpointArn", Doc).
 
--spec create_platform_endpoint/6 :: (string(), string(), string(), [{sns_endpoint_attribute(), string()}], string(), string()) -> string().
+-spec create_platform_endpoint(string(), string(), string(), [{sns_endpoint_attribute(), string()}], string(), string()) -> string().
 create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, Attributes, AccessKeyID, SecretAccessKey) ->
     create_platform_endpoint(PlatformApplicationArn, Token, CustomUserData, Attributes, new_config(AccessKeyID, SecretAccessKey)).
 
 
--spec create_topic/1 :: (string()) -> string().
+-spec create_topic(string()) -> string().
 create_topic(TopicName) ->
     create_topic(TopicName, default_config()).
 
--spec create_topic/2 :: (string(), aws_config()) -> string().
+-spec create_topic(string(), aws_config()) -> string().
 create_topic(TopicName, Config)
     when is_record(Config, aws_config) ->
         Doc = sns_xml_request(Config, "CreateTopic", [{"Name", TopicName}]),
         erlcloud_xml:get_text("/CreateTopicResponse/CreateTopicResult/TopicArn", Doc).
 
 
--spec confirm_subscription/1 :: (sns_event()) -> string().
+-spec confirm_subscription(sns_event()) -> string().
 confirm_subscription(SnsEvent) ->
     confirm_subscription(SnsEvent, default_config()).
 
--spec confirm_subscription/2 :: (sns_event(), aws_config()) -> string().
+-spec confirm_subscription(sns_event(), aws_config()) -> string().
 confirm_subscription(SnsEvent, Config) ->
     Token = binary_to_list(proplists:get_value(<<"Token">>, SnsEvent, <<>>)),
     TopicArn = binary_to_list(proplists:get_value(<<"TopicArn">>, SnsEvent, <<>>)),
     confirm_subscription2(Token, TopicArn, Config).
 
--spec confirm_subscription/3 :: (sns_event(), string(), string()) -> string().
+-spec confirm_subscription(sns_event(), string(), string()) -> string().
 confirm_subscription(SnsEvent, AccessKeyID, SecretAccessKey) ->
     confirm_subscription(SnsEvent, new_config(AccessKeyID, SecretAccessKey)).
 
 
 
--spec confirm_subscription2/2 :: (string(), string()) -> string().
+-spec confirm_subscription2(string(), string()) -> string().
 confirm_subscription2(Token, TopicArn) ->
     confirm_subscription2(Token, TopicArn, default_config()).
 
--spec confirm_subscription2/3 :: (string(), string(), aws_config()) -> string().
+-spec confirm_subscription2(string(), string(), aws_config()) -> string().
 confirm_subscription2(Token, TopicArn, Config) ->
     Doc =
         sns_xml_request(
@@ -184,42 +184,42 @@ confirm_subscription2(Token, TopicArn, Config) ->
     erlcloud_xml:get_text(
         "ConfirmSubscriptionResult/SubscriptionArn", Doc).
 
--spec confirm_subscription2/4 :: (string(), string(), string(), string()) -> string().
+-spec confirm_subscription2(string(), string(), string(), string()) -> string().
 confirm_subscription2(Token, TopicArn, AccessKeyID, SecretAccessKey) ->
     confirm_subscription2(Token, TopicArn, new_config(AccessKeyID, SecretAccessKey)).
 
 
 
--spec delete_endpoint/1 :: (string()) -> ok.
+-spec delete_endpoint(string()) -> ok.
 delete_endpoint(EndpointArn) ->
     delete_endpoint(EndpointArn, default_config()).
 
--spec delete_endpoint/2 :: (string(), aws_config()) -> ok.
+-spec delete_endpoint(string(), aws_config()) -> ok.
 delete_endpoint(EndpointArn, Config) ->
     sns_simple_request(Config, "DeleteEndpoint", [{"EndpointArn", EndpointArn}]).
 
--spec delete_endpoint/3 :: (string(), string(), string()) -> ok.
+-spec delete_endpoint(string(), string(), string()) -> ok.
 delete_endpoint(EndpointArn, AccessKeyID, SecretAccessKey) ->
     delete_endpoint(EndpointArn, new_config(AccessKeyID, SecretAccessKey)).
 
 
 
--spec delete_topic/1 :: (string()) -> ok.
+-spec delete_topic(string()) -> ok.
 delete_topic(TopicArn) ->
     delete_topic(TopicArn, default_config()).
 
--spec delete_topic/2 :: (string(), aws_config()) -> ok.
+-spec delete_topic(string(), aws_config()) -> ok.
 delete_topic(TopicArn, Config)
     when is_record(Config, aws_config) ->
         sns_simple_request(Config, "DeleteTopic", [{"TopicArn", TopicArn}]).
 
 
 
--spec get_endpoint_attributes/1 :: (string()) -> sns_endpoint().
+-spec get_endpoint_attributes(string()) -> sns_endpoint().
 get_endpoint_attributes(EndpointArn) ->
     get_endpoint_attributes(EndpointArn, default_config()).
 
--spec get_endpoint_attributes/2 :: (string(), aws_config()) -> sns_endpoint().
+-spec get_endpoint_attributes(string(), aws_config()) -> sns_endpoint().
 get_endpoint_attributes(EndpointArn, Config) ->
     Params = [{"EndpointArn", EndpointArn}],
     Doc = sns_xml_request(Config, "GetEndpointAttributes", Params),
@@ -231,16 +231,16 @@ get_endpoint_attributes(EndpointArn, Config) ->
             Doc),
     [{arn, EndpointArn} | Decoded].
 
--spec get_endpoint_attributes/3 :: (string(), string(), string()) -> sns_endpoint().
+-spec get_endpoint_attributes(string(), string(), string()) -> sns_endpoint().
 get_endpoint_attributes(EndpointArn, AccessKeyID, SecretAccessKey) ->
     get_endpoint_attributes(EndpointArn, new_config(AccessKeyID, SecretAccessKey)).
 
 
 
--spec set_endpoint_attributes/2 :: (string(), [{sns_endpoint_attribute(), string()}]) -> string().
+-spec set_endpoint_attributes(string(), [{sns_endpoint_attribute(), string()}]) -> string().
 set_endpoint_attributes(EndpointArn, Attributes) ->
     set_endpoint_attributes(EndpointArn, Attributes, default_config()).
--spec set_endpoint_attributes/3 :: (string(), [{sns_endpoint_attribute(), string()}], aws_config()) -> string().
+-spec set_endpoint_attributes(string(), [{sns_endpoint_attribute(), string()}], aws_config()) -> string().
 set_endpoint_attributes(EndpointArn, Attributes, Config) ->
     Doc = sns_xml_request(Config, "SetEndpointAttributes", [{"EndpointArn", EndpointArn} |
                                                             encode_attributes(Attributes)]),
@@ -248,13 +248,13 @@ set_endpoint_attributes(EndpointArn, Attributes, Config) ->
 
 
 
--spec list_endpoints_by_platform_application/1 :: (string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
+-spec list_endpoints_by_platform_application(string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
 list_endpoints_by_platform_application(PlatformApplicationArn) ->
     list_endpoints_by_platform_application(PlatformApplicationArn, undefined).
--spec list_endpoints_by_platform_application/2 :: (string(), undefined|string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
+-spec list_endpoints_by_platform_application(string(), undefined|string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
 list_endpoints_by_platform_application(PlatformApplicationArn, NextToken) ->
     list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, default_config()).
--spec list_endpoints_by_platform_application/3 :: (string(), undefined|string(), aws_config()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
+-spec list_endpoints_by_platform_application(string(), undefined|string(), aws_config()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
 list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, Config) ->
     Params =
         case NextToken of
@@ -270,21 +270,21 @@ list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, Config
              {next_token, "ListEndpointsByPlatformApplicationResult/NextToken", text}],
             Doc),
     Decoded.
--spec list_endpoints_by_platform_application/4 :: (string(), undefined|string(), string(), string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
+-spec list_endpoints_by_platform_application(string(), undefined|string(), string(), string()) -> [{endpoints, [sns_endpoint()]} | {next_token, string()}].
 list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, AccessKeyID, SecretAccessKey) ->
     list_endpoints_by_platform_application(PlatformApplicationArn, NextToken, new_config(AccessKeyID, SecretAccessKey)).
 
--spec list_topics/0 :: () -> [{topics, [[{arn, string()}]]} | {next_token, string()}].
+-spec list_topics() -> [{topics, [[{arn, string()}]]} | {next_token, string()}].
 list_topics() ->
     list_topics(default_config()).
 
--spec list_topics/1 :: (undefined | string() | aws_config()) -> [{topics, [[{arn, string()}]]} | {next_token, string()}].
+-spec list_topics(undefined | string() | aws_config()) -> [{topics, [[{arn, string()}]]} | {next_token, string()}].
 list_topics(Config) when is_record(Config, aws_config) ->
     list_topics(undefined, Config);
 list_topics(NextToken) ->
     list_topics(NextToken, default_config()).
 
--spec list_topics/2 :: (undefined | string(), aws_config()) ->  [{topics, [[{arn, string()}]]} | {next_token, string()}].
+-spec list_topics(undefined | string(), aws_config()) ->  [{topics, [[{arn, string()}]]} | {next_token, string()}].
 list_topics(NextToken, Config) ->
     Params =
         case NextToken of
@@ -301,24 +301,24 @@ list_topics(NextToken, Config) ->
             Doc),
     Decoded.
 
--spec list_topics_all/0 :: () -> [[{arn, string()}]].
+-spec list_topics_all() -> [[{arn, string()}]].
 list_topics_all() ->
     list_topics_all(default_config()).
 
--spec list_topics_all/1 :: (aws_config()) -> [[{arn, string()}]].
+-spec list_topics_all(aws_config()) -> [[{arn, string()}]].
 list_topics_all(Config) ->
     list_all(fun list_topics/2, topics, Config, undefined, []).
 
 
--spec list_platform_applications/0 :: () -> [sns_application()].
+-spec list_platform_applications() -> [sns_application()].
 list_platform_applications() ->
     list_platform_applications(undefined).
 
--spec list_platform_applications/1 :: (undefined|string()) -> [sns_application()].
+-spec list_platform_applications(undefined|string()) -> [sns_application()].
 list_platform_applications(NextToken) ->
     list_platform_applications(NextToken, default_config()).
 
--spec list_platform_applications/2 :: (undefined|string(), aws_config()) -> [sns_application()].
+-spec list_platform_applications(undefined|string(), aws_config()) -> [sns_application()].
 list_platform_applications(NextToken, Config) ->
     Params =
         case NextToken of
@@ -334,45 +334,45 @@ list_platform_applications(NextToken, Config) ->
             Doc),
     proplists:get_value(applications, Decoded, []).
 
--spec list_platform_applications/3 :: (undefined|string(), string(), string()) -> [sns_application()].
+-spec list_platform_applications(undefined|string(), string(), string()) -> [sns_application()].
 list_platform_applications(NextToken, AccessKeyID, SecretAccessKey) ->
     list_platform_applications(NextToken, new_config(AccessKeyID, SecretAccessKey)).
 
 
 
--spec publish_to_topic/2 :: (string(), sns_message()) -> string().
+-spec publish_to_topic(string(), sns_message()) -> string().
 publish_to_topic(TopicArn, Message) ->
     publish_to_topic(TopicArn, Message, undefined).
 
--spec publish_to_topic/3 :: (string(), sns_message(), undefined|string()) -> string().
+-spec publish_to_topic(string(), sns_message(), undefined|string()) -> string().
 publish_to_topic(TopicArn, Message, Subject) ->
     publish_to_topic(TopicArn, Message, Subject, default_config()).
 
--spec publish_to_topic/4 :: (string(), sns_message(), undefined|string(), aws_config()) -> string().
+-spec publish_to_topic(string(), sns_message(), undefined|string(), aws_config()) -> string().
 publish_to_topic(TopicArn, Message, Subject, Config) ->
     publish(topic, TopicArn, Message, Subject, Config).
 
--spec publish_to_topic/5 :: (string(), sns_message(), undefined|string(), string(), string()) -> string().
+-spec publish_to_topic(string(), sns_message(), undefined|string(), string(), string()) -> string().
 publish_to_topic(TopicArn, Message, Subject, AccessKeyID, SecretAccessKey) ->
     publish_to_topic(TopicArn, Message, Subject, new_config(AccessKeyID, SecretAccessKey)).
 
--spec publish_to_target/2 :: (string(), sns_message()) -> string().
+-spec publish_to_target(string(), sns_message()) -> string().
 publish_to_target(TargetArn, Message) ->
     publish_to_target(TargetArn, Message, undefined).
 
--spec publish_to_target/3 :: (string(), sns_message(), undefined|string()) -> string().
+-spec publish_to_target(string(), sns_message(), undefined|string()) -> string().
 publish_to_target(TargetArn, Message, Subject) ->
     publish_to_target(TargetArn, Message, Subject, default_config()).
 
--spec publish_to_target/4 :: (string(), sns_message(), undefined|string(), aws_config()) -> string().
+-spec publish_to_target(string(), sns_message(), undefined|string(), aws_config()) -> string().
 publish_to_target(TargetArn, Message, Subject, Config) ->
     publish(target, TargetArn, Message, Subject, Config).
 
--spec publish_to_target/5 :: (string(), sns_message(), undefined|string(), string(), string()) -> string().
+-spec publish_to_target(string(), sns_message(), undefined|string(), string(), string()) -> string().
 publish_to_target(TargetArn, Message, Subject, AccessKeyID, SecretAccessKey) ->
     publish_to_target(TargetArn, Message, Subject, new_config(AccessKeyID, SecretAccessKey)).
 
--spec publish/5 :: (topic|target, string(), sns_message(), undefined|string(), aws_config()) -> string().
+-spec publish(topic|target, string(), sns_message(), undefined|string(), aws_config()) -> string().
 publish(Type, RecipientArn, Message, Subject, Config) ->
     RecipientParam =
         case Type of
@@ -402,18 +402,18 @@ publish(Type, RecipientArn, Message, Subject, Config) ->
 
 
 
--spec parse_event/1 :: (iodata()) -> sns_event().
+-spec parse_event(iodata()) -> sns_event().
 parse_event(EventSource) ->
     jsx:decode(EventSource).
 
--spec get_event_type/1 :: (sns_event()) -> sns_event_type().
+-spec get_event_type(sns_event()) -> sns_event_type().
 get_event_type(Event) ->
     case proplists:get_value(<<"Type">>, Event) of
         <<"SubscriptionConfirmation">> -> subscription_confirmation;
         <<"Notification">> -> notification
     end.
 
--spec parse_event_message/1 :: (sns_event()) -> sns_notification() | binary().
+-spec parse_event_message(sns_event()) -> sns_notification() | binary().
 parse_event_message(Event) ->
     Message = proplists:get_value(<<"Message">>, Event, <<>>),
     case get_event_type(Event) of
@@ -421,7 +421,7 @@ parse_event_message(Event) ->
         notification -> jsx:decode(Message)
     end.
 
--spec get_notification_attribute/2 :: (binary(), sns_notification()) -> sns_application_attribute() | binary().
+-spec get_notification_attribute(binary(), sns_notification()) -> sns_application_attribute() | binary().
 get_notification_attribute(<<"EventType">>, Notification) ->
     case proplists:get_value(<<"EventType">>, Notification) of
         <<"EndpointCreated">> -> event_endpoint_created;
@@ -434,11 +434,11 @@ get_notification_attribute(Attribute, Notification) ->
 
 
 
--spec(set_topic_attributes/3 :: (sns_topic_attribute_name(), string(), string()) -> ok).
+-spec set_topic_attributes(sns_topic_attribute_name(), string(), string()) -> ok.
 set_topic_attributes(AttributeName, AttributeValue, TopicArn) ->
     set_topic_attributes(AttributeName, AttributeValue, TopicArn, default_config()).
 
--spec(set_topic_attributes/4 :: (sns_topic_attribute_name(), string(), string(), aws_config()) -> ok).
+-spec set_topic_attributes(sns_topic_attribute_name(), string(), string(), aws_config()) -> ok.
 set_topic_attributes(AttributeName, AttributeValue, TopicArn, Config)
     when is_record(Config, aws_config) ->
         sns_simple_request(Config, "SetTopicAttributes", [
@@ -447,11 +447,11 @@ set_topic_attributes(AttributeName, AttributeValue, TopicArn, Config)
             {"TopicArn", TopicArn}]).
 
 
--spec(subscribe/3 :: (string(), sns_subscribe_protocol_type(), string()) -> Arn::string()).
+-spec subscribe(string(), sns_subscribe_protocol_type(), string()) -> Arn::string().
 subscribe(Endpoint, Protocol, TopicArn) ->
     subscribe(Endpoint, Protocol, TopicArn, default_config()).
 
--spec(subscribe/4 :: (string(), sns_subscribe_protocol_type(), string(), aws_config()) -> Arn::string()).
+-spec subscribe(string(), sns_subscribe_protocol_type(), string(), aws_config()) -> Arn::string().
 subscribe(Endpoint, Protocol, TopicArn, Config)
     when is_record(Config, aws_config) ->
          Doc = sns_xml_request(Config, "Subscribe", [

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -19,8 +19,8 @@
          set_queue_attributes/2, set_queue_attributes/3
         ]).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 
 -define(API_VERSION, "2012-11-05").
 

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -39,33 +39,33 @@
 
 
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 sqs_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
 
--spec add_permission/3 :: (string(), string(), sqs_acl()) -> ok.
+-spec add_permission(string(), string(), sqs_acl()) -> ok.
 add_permission(QueueName, Label, Permissions) ->
     add_permission(QueueName, Label, Permissions, default_config()).
 
--spec add_permission/4 :: (string(), string(), sqs_acl(), aws_config()) -> ok.
+-spec add_permission(string(), string(), sqs_acl(), aws_config()) -> ok.
 add_permission(QueueName, Label, Permissions, Config)
   when is_list(QueueName),
        is_list(Label), length(Label) =< 80,
@@ -87,28 +87,28 @@ encode_permission({AccountId, Permission}) ->
          get_queue_attributes -> "GetQueueAttributes"
      end}.
 
--spec change_message_visibility/3 :: (string(), string(), 0..43200) -> ok.
+-spec change_message_visibility(string(), string(), 0..43200) -> ok.
 change_message_visibility(QueueName, ReceiptHandle, VisibilityTimeout) ->
     change_message_visibility(QueueName, ReceiptHandle, VisibilityTimeout,
                               default_config()).
 
--spec change_message_visibility/4 :: (string(), string(), 0..43200, aws_config()) -> ok.
+-spec change_message_visibility(string(), string(), 0..43200, aws_config()) -> ok.
 change_message_visibility(QueueName, ReceiptHandle, VisibilityTimeout, Config) ->
     sqs_simple_request(Config, QueueName, "ChangeMessageVisibility",
                        [{"ReceiptHandle", ReceiptHandle}, {"VisibilityTimeout", VisibilityTimeout}]).
 
--spec create_queue/1 :: (string()) -> proplist().
+-spec create_queue(string()) -> proplist().
 create_queue(QueueName) ->
     create_queue(QueueName, default_config()).
 
--spec create_queue/2 :: (string(), 0..43200 | none | aws_config()) -> proplist().
+-spec create_queue(string(), 0..43200 | none | aws_config()) -> proplist().
 create_queue(QueueName, Config)
   when is_record(Config, aws_config) ->
     create_queue(QueueName, none, Config);
 create_queue(QueueName, DefaultVisibilityTimeout) ->
     create_queue(QueueName, DefaultVisibilityTimeout, default_config()).
 
--spec create_queue/3 :: (string(), 0..43200 | none, aws_config()) -> proplist().
+-spec create_queue(string(), 0..43200 | none, aws_config()) -> proplist().
 create_queue(QueueName, DefaultVisibilityTimeout, Config)
   when is_list(QueueName),
        (is_integer(DefaultVisibilityTimeout) andalso
@@ -124,37 +124,37 @@ create_queue(QueueName, DefaultVisibilityTimeout, Config)
       Doc
      ).
 
--spec delete_message/2 :: (string(), string()) -> ok.
+-spec delete_message(string(), string()) -> ok.
 delete_message(QueueName, ReceiptHandle) ->
     delete_message(QueueName, ReceiptHandle, default_config()).
 
--spec delete_message/3 :: (string(), string(), aws_config()) -> ok.
+-spec delete_message(string(), string(), aws_config()) -> ok.
 delete_message(QueueName, ReceiptHandle, Config)
   when is_list(QueueName), is_list(ReceiptHandle) ->
     sqs_simple_request(Config, QueueName, "DeleteMessage",
                        [{"ReceiptHandle", ReceiptHandle}]).
 
--spec delete_queue/1 :: (string()) -> ok.
+-spec delete_queue(string()) -> ok.
 delete_queue(QueueName) ->
     delete_queue(QueueName, default_config()).
 
--spec delete_queue/2 :: (string(), aws_config()) -> ok.
+-spec delete_queue(string(), aws_config()) -> ok.
 delete_queue(QueueName, Config)
   when is_list(QueueName) ->
     sqs_simple_request(Config, QueueName, "DeleteQueue", []).
 
--spec get_queue_attributes/1 :: (string()) -> proplist().
+-spec get_queue_attributes(string()) -> proplist().
 get_queue_attributes(QueueName) ->
     get_queue_attributes(QueueName, all).
 
--spec get_queue_attributes/2 :: (string(), all | [sqs_queue_attribute_name()] | aws_config()) -> proplist().
+-spec get_queue_attributes(string(), all | [sqs_queue_attribute_name()] | aws_config()) -> proplist().
 get_queue_attributes(QueueName, Config)
   when is_record(Config, aws_config) ->
     get_queue_attributes(QueueName, all, Config);
 get_queue_attributes(QueueName, AttributeNames) ->
     get_queue_attributes(QueueName, AttributeNames, default_config()).
 
--spec get_queue_attributes/3 :: (string(), all | [sqs_queue_attribute_name()], aws_config()) -> proplist().
+-spec get_queue_attributes(string(), all | [sqs_queue_attribute_name()], aws_config()) -> proplist().
 get_queue_attributes(QueueName, all, Config) ->
     get_queue_attributes(QueueName, [all], Config);
 get_queue_attributes(QueueName, AttributeNames, Config)
@@ -202,43 +202,43 @@ decode_attribute_value("RedrivePolicy", Value) -> Value;
 decode_attribute_value(_, Value) -> list_to_integer(Value).
 
 
--spec list_queues/0 :: () -> [string()].
+-spec list_queues() -> [string()].
 list_queues() ->
     list_queues("").
 
--spec list_queues/1 :: (string() | aws_config()) -> [string()].
+-spec list_queues(string() | aws_config()) -> [string()].
 list_queues(Config)
   when is_record(Config, aws_config) ->
     list_queues("", Config);
 list_queues(QueueNamePrefix) ->
     list_queues(QueueNamePrefix, default_config()).
 
--spec list_queues/2 :: (string(), aws_config()) -> [string()].
+-spec list_queues(string(), aws_config()) -> [string()].
 list_queues(QueueNamePrefix, Config)
   when is_list(QueueNamePrefix) ->
     Doc = sqs_xml_request(Config, "/", "ListQueues",
                           [{"QueueNamePrefix", QueueNamePrefix}]),
     erlcloud_xml:get_list("ListQueuesResult/QueueUrl", Doc).
 
--spec receive_message/1 :: (string()) -> proplist().
+-spec receive_message(string()) -> proplist().
 receive_message(QueueName) ->
     receive_message(QueueName, default_config()).
 
--spec receive_message/2 :: (string(), [sqs_msg_attribute_name()] | all | aws_config()) -> proplist().
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all | aws_config()) -> proplist().
 receive_message(QueueName, Config)
   when is_record(Config, aws_config) ->
     receive_message(QueueName, [], Config);
 receive_message(QueueName, AttributeNames) ->
     receive_message(QueueName, AttributeNames, default_config()).
 
--spec receive_message/3 :: (string(), [sqs_msg_attribute_name()] | all, 1..10 | aws_config()) -> proplist().
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all, 1..10 | aws_config()) -> proplist().
 receive_message(QueueName, AttributeNames, Config)
   when is_record(Config, aws_config) ->
     receive_message(QueueName, AttributeNames, 1, Config);
 receive_message(QueueName, AttributeNames, MaxNumberOfMessages) ->
     receive_message(QueueName, AttributeNames, MaxNumberOfMessages, default_config()).
 
--spec receive_message/4 :: (string(), [sqs_msg_attribute_name()] | all, 1..10, 0..43200 | none | aws_config()) -> proplist().
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all, 1..10, 0..43200 | none | aws_config()) -> proplist().
 receive_message(QueueName, AttributeNames, MaxNumberOfMessages, Config)
   when is_record(Config, aws_config) ->
     receive_message(QueueName, AttributeNames, MaxNumberOfMessages, none, Config);
@@ -246,8 +246,8 @@ receive_message(QueueName, AttributeNames, MaxNumberOfMessages, VisibilityTimeou
     receive_message(QueueName, AttributeNames, MaxNumberOfMessages,
                     VisibilityTimeout, default_config()).
 
--spec receive_message/5 :: (string(), [sqs_msg_attribute_name()] | all, 1..10,
-                            0..43200 | none, 0..20 | none | aws_config()) -> proplist().
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all, 1..10,
+                      0..43200 | none, 0..20 | none | aws_config()) -> proplist().
 receive_message(QueueName, AttributeNames, MaxNumberOfMessages,
                 VisibilityTimeout, Config)
   when is_record(Config, aws_config) ->
@@ -258,8 +258,8 @@ receive_message(QueueName, AttributeNames, MaxNumberOfMessages,
     receive_message(QueueName, AttributeNames, MaxNumberOfMessages,
                     VisibilityTimeout, WaitTimeSeconds, default_config()).
 
--spec receive_message/6 :: (string(), [sqs_msg_attribute_name()] | all, 1..10,
-                            0..43200 | none, 0..20 | none, aws_config()) -> proplist().
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all, 1..10,
+                      0..43200 | none, 0..20 | none, aws_config()) -> proplist().
 receive_message(QueueName, all, MaxNumberOfMessages, VisibilityTimeout,
 			   WaitTimeoutSeconds, Config) ->
     receive_message(QueueName, [all], MaxNumberOfMessages,
@@ -329,28 +329,28 @@ decode_attributes(Attrs) ->
     [{erlcloud_xml:get_text("Name", Attr), erlcloud_xml:get_text("Value", Attr)} ||
         Attr <- Attrs].
 
--spec remove_permission/2 :: (string(), string()) -> ok.
+-spec remove_permission(string(), string()) -> ok.
 remove_permission(QueueName, Label) ->
     remove_permission(QueueName, Label, default_config()).
 
--spec remove_permission/3 :: (string(), string(), aws_config()) -> ok.
+-spec remove_permission(string(), string(), aws_config()) -> ok.
 remove_permission(QueueName, Label, Config)
   when is_list(QueueName), is_list(Label) ->
     sqs_simple_request(Config, QueueName, "RemovePermission",
                        [{"Label", Label}]).
 
--spec send_message/2 :: (string(), string()) -> proplist().
+-spec send_message(string(), string()) -> proplist().
 send_message(QueueName, MessageBody) ->
     send_message(QueueName, MessageBody, default_config()).
 
--spec send_message/3 :: (string(), string(), 0..900 | none | aws_config()) -> proplist().
+-spec send_message(string(), string(), 0..900 | none | aws_config()) -> proplist().
 send_message(QueueName, MessageBody, Config)
   when is_record(Config, aws_config) ->
     send_message(QueueName, MessageBody, none, Config);
 send_message(QueueName, MessageBody, DelaySeconds) ->
     send_message(QueueName, MessageBody, DelaySeconds, default_config()).
 
--spec send_message/4 :: (string(), string(), 0..900 | none, aws_config()) -> proplist().
+-spec send_message(string(), string(), 0..900 | none, aws_config()) -> proplist().
 send_message(QueueName, MessageBody, DelaySeconds, Config)
   when is_list(QueueName), is_list(MessageBody),
        (DelaySeconds >= 0 andalso DelaySeconds =< 900) orelse
@@ -366,11 +366,11 @@ send_message(QueueName, MessageBody, DelaySeconds, Config)
       Doc
      ).
 
--spec set_queue_attributes/2 :: (string(), [{visibility_timeout, integer()} | {policy, string()}]) -> ok.
+-spec set_queue_attributes(string(), [{visibility_timeout, integer()} | {policy, string()}]) -> ok.
 set_queue_attributes(QueueName, Attributes) ->
     set_queue_attributes(QueueName, Attributes, default_config()).
 
--spec set_queue_attributes/3 :: (string(), [{visibility_timeout, integer()} | {policy, string()}], aws_config()) -> ok.
+-spec set_queue_attributes(string(), [{visibility_timeout, integer()} | {policy, string()}], aws_config()) -> ok.
 set_queue_attributes(QueueName, Attributes, Config)
   when is_list(QueueName), is_list(Attributes) ->
     Params = lists:flatten(erlcloud_aws:param_list([encode_attribute_name(Name) || {Name, _} <- Attributes], "Attribute.Name"),

--- a/src/erlcloud_sts.erl
+++ b/src/erlcloud_sts.erl
@@ -21,7 +21,7 @@ assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds) ->
 
 
 % See http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
--spec assume_role/5 :: (#aws_config{}, string(), string(), 900..3600, undefined | string()) -> {#aws_config{}, proplist()}.
+-spec assume_role(#aws_config{}, string(), string(), 900..3600, undefined | string()) -> {#aws_config{}, proplist()}.
 assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds, ExternalId)
     when length(RoleArn) >= 20,
          length(RoleSessionName) >= 2, length(RoleSessionName) =< 32,
@@ -65,7 +65,7 @@ get_federation_token(AwsConfig, DurationSeconds, Name) ->
         get_federation_token(AwsConfig, DurationSeconds, Name, undefined).
 
 % See http://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html
--spec get_federation_token/4 :: (#aws_config{}, 900..129600, string(), undefined | string()) -> {#aws_config{}, proplist()}.
+-spec get_federation_token(#aws_config{}, 900..129600, string(), undefined | string()) -> {#aws_config{}, proplist()}.
 get_federation_token(AwsConfig, DurationSeconds, Name, Policy)
   when length(Name) >= 2, length(Name) =< 32,
        DurationSeconds >= 900, DurationSeconds =< 129600 ->

--- a/src/erlcloud_sts.erl
+++ b/src/erlcloud_sts.erl
@@ -1,8 +1,8 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 -module(erlcloud_sts).
 
--include_lib("erlcloud/include/erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/erlcloud_waf.erl
+++ b/src/erlcloud_waf.erl
@@ -1,8 +1,8 @@
 -module(erlcloud_waf).
 -author('pavel@alertlogic.com').
 
--include_lib("erlcloud/include/erlcloud_aws.hrl").
--include_lib("erlcloud/include/erlcloud_waf.hrl").
+-include("erlcloud_aws.hrl").
+-include("erlcloud_waf.hrl").
 
 %%% Library initialization.
 -export([configure/2, configure/3, configure/4, new/2, new/3, new/4]).

--- a/src/erlcloud_waf.erl
+++ b/src/erlcloud_waf.erl
@@ -119,18 +119,16 @@ default_config() ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_CreateByteMatchSet.html
 %%%------------------------------------------------------------------------------
--spec create_byte_match_set/2 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary()) ->
-        waf_return_val().
+-spec create_byte_match_set(ChangeToken :: string() | binary(),
+                            Name :: string() | binary()) ->
+    waf_return_val().
 create_byte_match_set(ChangeToken, Name) ->
     create_byte_match_set(ChangeToken, Name, default_config()).
 
--spec create_byte_match_set/3 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec create_byte_match_set(ChangeToken :: string() | binary(),
+                            Name :: string() | binary(),
+                            Config :: aws_config()) ->
+    waf_return_val().
 create_byte_match_set(ChangeToken, Name, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"Name">>, to_binary(Name)}],
@@ -142,18 +140,16 @@ create_byte_match_set(ChangeToken, Name, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_CreateIPSet.html
 %%%------------------------------------------------------------------------------
--spec create_ip_set/2 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary()) ->
-        waf_return_val().
+-spec create_ip_set(ChangeToken :: string() | binary(),
+                    Name :: string() | binary()) ->
+    waf_return_val().
 create_ip_set(ChangeToken, Name) ->
     create_ip_set(ChangeToken, Name, default_config()).
 
--spec create_ip_set/3 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec create_ip_set(ChangeToken :: string() | binary(),
+                    Name :: string() | binary(),
+                    Config :: aws_config()) ->
+    waf_return_val().
 create_ip_set(ChangeToken, Name, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"Name">>, to_binary(Name)}],
@@ -165,20 +161,18 @@ create_ip_set(ChangeToken, Name, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_CreateRule.html
 %%%------------------------------------------------------------------------------
--spec create_rule/3 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         MetricName :: string() | binary()) ->
-        waf_return_val().
+-spec create_rule(ChangeToken :: string() | binary(),
+                  Name :: string() | binary(),
+                  MetricName :: string() | binary()) ->
+    waf_return_val().
 create_rule(ChangeToken, Name, MetricName) ->
     create_rule(ChangeToken, Name, MetricName, default_config()).
 
--spec create_rule/4 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         MetricName :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec create_rule(ChangeToken :: string() | binary(),
+                  Name :: string() | binary(),
+                  MetricName :: string() | binary(),
+                  Config :: aws_config()) ->
+    waf_return_val().
 create_rule(ChangeToken, Name, MetricName, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"MetricName">>, to_binary(MetricName)},
@@ -191,18 +185,16 @@ create_rule(ChangeToken, Name, MetricName, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_CreateSizeConstraintSet.html
 %%%------------------------------------------------------------------------------
--spec create_size_constraint_set/2 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary()) ->
-        waf_return_val().
+-spec create_size_constraint_set(ChangeToken :: string() | binary(),
+                                 Name :: string() | binary()) ->
+    waf_return_val().
 create_size_constraint_set(ChangeToken, Name) ->
     create_size_constraint_set(ChangeToken, Name, default_config()).
 
--spec create_size_constraint_set/3 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec create_size_constraint_set(ChangeToken :: string() | binary(),
+                                 Name :: string() | binary(),
+                                 Config :: aws_config()) ->
+    waf_return_val().
 create_size_constraint_set(ChangeToken, Name, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"Name">>, to_binary(Name)}],
@@ -214,18 +206,16 @@ create_size_constraint_set(ChangeToken, Name, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_CreateSqlInjectionMatchSet.html
 %%%------------------------------------------------------------------------------
--spec create_sql_injection_match_set/2 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary()) ->
-        waf_return_val().
+-spec create_sql_injection_match_set(ChangeToken :: string() | binary(),
+                                     Name :: string() | binary()) ->
+    waf_return_val().
 create_sql_injection_match_set(ChangeToken, Name) ->
     create_sql_injection_match_set(ChangeToken, Name, default_config()).
 
--spec create_sql_injection_match_set/3 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec create_sql_injection_match_set(ChangeToken :: string() | binary(),
+                                     Name :: string() | binary(),
+                                     Config :: aws_config()) ->
+    waf_return_val().
 create_sql_injection_match_set(ChangeToken, Name, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"Name">>, to_binary(Name)}],
@@ -237,22 +227,20 @@ create_sql_injection_match_set(ChangeToken, Name, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_CreateWebACL.html
 %%%------------------------------------------------------------------------------
--spec create_web_acl/4 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         MetricName :: string() | binary(),
-         DefaultAction:: waf_acl_action_type()) ->
-        waf_return_val().
+-spec create_web_acl(ChangeToken :: string() | binary(),
+                     Name :: string() | binary(),
+                     MetricName :: string() | binary(),
+                     DefaultAction:: waf_acl_action_type()) ->
+    waf_return_val().
 create_web_acl(ChangeToken, Name, MetricName, DefaultAction) ->
     create_web_acl(ChangeToken, Name, MetricName, DefaultAction, default_config()).
 
--spec create_web_acl/5 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         MetricName :: string() | binary(),
-         DefaultAction:: waf_acl_action_type(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec create_web_acl(ChangeToken :: string() | binary(),
+                     Name :: string() | binary(),
+                     MetricName :: string() | binary(),
+                     DefaultAction:: waf_acl_action_type(),
+                     Config :: aws_config()) ->
+    waf_return_val().
 create_web_acl(ChangeToken, Name, MetricName, DefaultAction, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"DefaultAction">>, [{<<"Type">>, get_default_action_type(DefaultAction)}]},
@@ -265,18 +253,16 @@ create_web_acl(ChangeToken, Name, MetricName, DefaultAction, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_CreateXssMatchSet.html
 %%%------------------------------------------------------------------------------
--spec create_xss_match_set/2 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary()) ->
-        waf_return_val().
+-spec create_xss_match_set(ChangeToken :: string() | binary(),
+                           Name :: string() | binary()) ->
+    waf_return_val().
 create_xss_match_set(ChangeToken, Name) ->
     create_xss_match_set(ChangeToken, Name, default_config()).
 
--spec create_xss_match_set/3 ::
-        (ChangeToken :: string() | binary(),
-         Name :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec create_xss_match_set(ChangeToken :: string() | binary(),
+                           Name :: string() | binary(),
+                           Config :: aws_config()) ->
+    waf_return_val().
 create_xss_match_set(ChangeToken, Name, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"Name">>, to_binary(Name)}],
@@ -289,18 +275,16 @@ create_xss_match_set(ChangeToken, Name, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteByteMatchSet.html
 %%%------------------------------------------------------------------------------
--spec delete_byte_match_set/2 ::
-        (ChangeToken :: string() | binary(),
-         ByteMatchSetId :: string() | binary()) ->
-        waf_return_val().
+-spec delete_byte_match_set(ChangeToken :: string() | binary(),
+                            ByteMatchSetId :: string() | binary()) ->
+    waf_return_val().
 delete_byte_match_set(ChangeToken, ByteMatchSetId) ->
     delete_byte_match_set(ChangeToken, ByteMatchSetId, default_config()).
 
--spec delete_byte_match_set/3 ::
-        (ChangeToken:: string() | binary(),
-         ByteMatchSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec delete_byte_match_set(ChangeToken:: string() | binary(),
+                            ByteMatchSetId :: string() | binary(),
+                            Config :: aws_config()) ->
+    waf_return_val().
 delete_byte_match_set(ChangeToken, ByteMatchSetId, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"ByteMatchSetId">>, to_binary(ByteMatchSetId)}],
@@ -312,18 +296,16 @@ delete_byte_match_set(ChangeToken, ByteMatchSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteIPSet.html
 %%%------------------------------------------------------------------------------
--spec delete_ip_set/2 ::
-        (ChangeToken :: string() | binary(),
-         IPSetId :: string() | binary()) ->
-        waf_return_val().
+-spec delete_ip_set(ChangeToken :: string() | binary(),
+                    IPSetId :: string() | binary()) ->
+    waf_return_val().
 delete_ip_set(ChangeToken, IPSetId) ->
     delete_ip_set(ChangeToken, IPSetId, default_config()).
 
--spec delete_ip_set/3 ::
-        (ChangeToken:: string() | binary(),
-         IPSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec delete_ip_set(ChangeToken:: string() | binary(),
+                    IPSetId :: string() | binary(),
+                    Config :: aws_config()) ->
+    waf_return_val().
 delete_ip_set(ChangeToken, IPSetId, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"IPSetId">>, to_binary(IPSetId)}],
@@ -335,18 +317,16 @@ delete_ip_set(ChangeToken, IPSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteRule.html
 %%%------------------------------------------------------------------------------
--spec delete_rule/2 ::
-        (ChangeToken :: string() | binary(),
-         RuleId :: string() | binary()) ->
-        waf_return_val().
+-spec delete_rule(ChangeToken :: string() | binary(),
+                  RuleId :: string() | binary()) ->
+    waf_return_val().
 delete_rule(ChangeToken, RuleId) ->
     delete_rule(ChangeToken, RuleId, default_config()).
 
--spec delete_rule/3 ::
-        (ChangeToken:: string() | binary(),
-         RuleId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec delete_rule(ChangeToken:: string() | binary(),
+                  RuleId :: string() | binary(),
+                  Config :: aws_config()) ->
+    waf_return_val().
 delete_rule(ChangeToken, RuleId, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"RuleId">>, to_binary(RuleId)}],
@@ -358,18 +338,16 @@ delete_rule(ChangeToken, RuleId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteSizeConstraintSet.html
 %%%------------------------------------------------------------------------------
--spec delete_size_constraint_set/2 ::
-        (ChangeToken :: string() | binary(),
-         SizeConstraintSetId :: string() | binary()) ->
-        waf_return_val().
+-spec delete_size_constraint_set(ChangeToken :: string() | binary(),
+                                 SizeConstraintSetId :: string() | binary()) ->
+    waf_return_val().
 delete_size_constraint_set(ChangeToken, SizeConstraintSetId) ->
     delete_size_constraint_set(ChangeToken, SizeConstraintSetId, default_config()).
 
--spec delete_size_constraint_set/3 ::
-        (ChangeToken:: string() | binary(),
-         SizeConstraintSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec delete_size_constraint_set(ChangeToken:: string() | binary(),
+                                 SizeConstraintSetId :: string() | binary(),
+                                 Config :: aws_config()) ->
+    waf_return_val().
 delete_size_constraint_set(ChangeToken, SizeConstraintSetId, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"SizeConstraintSetId">>, to_binary(SizeConstraintSetId)}],
@@ -381,18 +359,18 @@ delete_size_constraint_set(ChangeToken, SizeConstraintSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteSqlInjectionMatchSet.html
 %%%------------------------------------------------------------------------------
--spec delete_sql_injection_match_set/2 ::
-        (ChangeToken :: string() | binary(),
-         SqlInjectionMatchSetId :: string() | binary()) ->
-        waf_return_val().
+-spec delete_sql_injection_match_set(ChangeToken :: string() | binary(),
+                                     SqlInjectionMatchSetId ::
+                                         string() | binary()) ->
+    waf_return_val().
 delete_sql_injection_match_set(ChangeToken, SqlInjectionMatchSetId) ->
     delete_sql_injection_match_set(ChangeToken, SqlInjectionMatchSetId, default_config()).
 
--spec delete_sql_injection_match_set/3 ::
-        (ChangeToken:: string() | binary(),
-         SqlInjectionMatchSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec delete_sql_injection_match_set(ChangeToken:: string() | binary(),
+                                     SqlInjectionMatchSetId ::
+                                         string() | binary(),
+                                     Config :: aws_config()) ->
+    waf_return_val().
 delete_sql_injection_match_set(ChangeToken, SqlInjectionMatchSetId, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)}, 
             {<<"SqlInjectionMatchSetId">>, to_binary(SqlInjectionMatchSetId)}],
@@ -403,18 +381,16 @@ delete_sql_injection_match_set(ChangeToken, SqlInjectionMatchSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteWebACL.html
 %%%------------------------------------------------------------------------------
--spec delete_web_acl/2 ::
-        (ChangeToken :: string() | binary(),
-         WebACLId :: string() | binary()) ->
-        waf_return_val().
+-spec delete_web_acl(ChangeToken :: string() | binary(),
+                     WebACLId :: string() | binary()) ->
+    waf_return_val().
 delete_web_acl(ChangeToken, WebACLId) ->
     delete_web_acl(ChangeToken, WebACLId, default_config()).
 
--spec delete_web_acl/3 ::
-        (ChangeToken:: string() | binary(),
-         WebACLId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec delete_web_acl(ChangeToken:: string() | binary(),
+                     WebACLId :: string() | binary(),
+                     Config :: aws_config()) ->
+    waf_return_val().
 delete_web_acl(ChangeToken, WebACLId, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)}, 
             {<<"WebACLId">>, to_binary(WebACLId)}],
@@ -426,18 +402,16 @@ delete_web_acl(ChangeToken, WebACLId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteXssMatchSet.html
 %%%------------------------------------------------------------------------------
--spec delete_xss_match_set/2 ::
-        (ChangeToken :: string() | binary(),
-         XssMatchSetId :: string() | binary()) ->
-        waf_return_val().
+-spec delete_xss_match_set(ChangeToken :: string() | binary(),
+                           XssMatchSetId :: string() | binary()) ->
+    waf_return_val().
 delete_xss_match_set(ChangeToken, XssMatchSetId) ->
     delete_xss_match_set(ChangeToken, XssMatchSetId, default_config()).
 
--spec delete_xss_match_set/3 ::
-        (ChangeToken:: string() | binary(),
-         XssMatchSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec delete_xss_match_set(ChangeToken:: string() | binary(),
+                           XssMatchSetId :: string() | binary(),
+                           Config :: aws_config()) ->
+    waf_return_val().
 delete_xss_match_set(ChangeToken, XssMatchSetId, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"XssMatchSetId">>, to_binary(XssMatchSetId)}],
@@ -448,16 +422,14 @@ delete_xss_match_set(ChangeToken, XssMatchSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetByteMatchSet.html
 %%%------------------------------------------------------------------------------
--spec get_byte_match_set/1 ::
-        (ByteMatchSetId :: string() | binary()) ->
-        waf_return_val().
+-spec get_byte_match_set(ByteMatchSetId :: string() | binary()) ->
+    waf_return_val().
 get_byte_match_set(ByteMatchSetId) ->
     get_byte_match_set(ByteMatchSetId, default_config()).
 
--spec get_byte_match_set/2 ::
-        (ByteMatchSetId:: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_byte_match_set(ByteMatchSetId:: string() | binary(),
+                         Config :: aws_config()) ->
+    waf_return_val().
 get_byte_match_set(ByteMatchSetId, Config) ->
     Json = [{<<"ByteMatchSetId">>, to_binary(ByteMatchSetId)}],
     waf_request(Config, "GetByteMatchSet", Json).
@@ -468,15 +440,11 @@ get_byte_match_set(ByteMatchSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetChangeToken.html
 %%%------------------------------------------------------------------------------
--spec get_change_token/0 ::
-        () ->
-        waf_return_val().
+-spec get_change_token() -> waf_return_val().
 get_change_token() ->
     get_change_token(default_config()).
 
--spec get_change_token/1 ::
-        (Config :: aws_config()) ->
-        waf_return_val().
+-spec get_change_token(Config :: aws_config()) -> waf_return_val().
 get_change_token(Config) ->
     waf_request(Config, "GetChangeToken", []).
 
@@ -486,16 +454,14 @@ get_change_token(Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetChangeTokenStatus.html
 %%%------------------------------------------------------------------------------
--spec get_change_token_status/1 ::
-        (ChangeToken :: string() | binary()) ->
-        waf_return_val().
+-spec get_change_token_status(ChangeToken :: string() | binary()) ->
+    waf_return_val().
 get_change_token_status(ChangeToken) ->
     get_change_token_status(ChangeToken, default_config()).
 
--spec get_change_token_status/2 ::
-        (ChangeToken:: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_change_token_status(ChangeToken:: string() | binary(),
+                              Config :: aws_config()) ->
+    waf_return_val().
 get_change_token_status(ChangeToken, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)}],
     waf_request(Config, "GetChangeTokenStatus", Json).
@@ -506,16 +472,14 @@ get_change_token_status(ChangeToken, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetIPSet.html
 %%%------------------------------------------------------------------------------
--spec get_ip_set/1 ::
-        (IPSetId :: string() | binary()) ->
-        waf_return_val().
+-spec get_ip_set(IPSetId :: string() | binary()) ->
+    waf_return_val().
 get_ip_set(IPSetId) ->
     get_ip_set(IPSetId, default_config()).
 
--spec get_ip_set/2 ::
-        (IPSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_ip_set(IPSetId :: string() | binary(),
+                 Config :: aws_config()) ->
+    waf_return_val().
 get_ip_set(IPSetId, Config) ->
     Json = [{<<"IPSetId">>, to_binary(IPSetId)}],
     waf_request(Config, "GetIPSet", Json).
@@ -526,16 +490,14 @@ get_ip_set(IPSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetRule.html
 %%%------------------------------------------------------------------------------
--spec get_rule/1 ::
-        (RuleId :: string() | binary()) ->
-        waf_return_val().
+-spec get_rule(RuleId :: string() | binary()) ->
+    waf_return_val().
 get_rule(RuleId) ->
     get_rule(RuleId, default_config()).
 
--spec get_rule/2 ::
-        (RuleId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_rule(RuleId :: string() | binary(),
+               Config :: aws_config()) ->
+    waf_return_val().
 get_rule(RuleId, Config) ->
     Json = [{<<"RuleId">>, to_binary(RuleId)}],
     waf_request(Config, "GetRule", Json).
@@ -546,24 +508,22 @@ get_rule(RuleId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetSampledRequests.html
 %%%------------------------------------------------------------------------------
--spec get_sampled_requests/5 ::
-        (WebAclId :: string() | binary(),
-         RuleId :: string() | binary(),
-         StartTime :: pos_integer(),
-         EndTime :: pos_integer(),
-         MaxItems :: 1..100) ->
-        waf_return_val().
+-spec get_sampled_requests(WebAclId :: string() | binary(),
+                           RuleId :: string() | binary(),
+                           StartTime :: pos_integer(),
+                           EndTime :: pos_integer(),
+                           MaxItems :: 1..100) ->
+    waf_return_val().
 get_sampled_requests(WebAclId, RuleId, StartTime, EndTime, MaxItems) ->
     get_sampled_requests(WebAclId, RuleId, StartTime, EndTime, MaxItems, default_config()).
 
--spec get_sampled_requests/6 ::
-        (WebAclId :: string() | binary(),
-         RuleId :: string() | binary(),
-         StartTime :: pos_integer(),
-         EndTime :: pos_integer(),
-         MaxItems :: 1..100,
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_sampled_requests(WebAclId :: string() | binary(),
+                           RuleId :: string() | binary(),
+                           StartTime :: pos_integer(),
+                           EndTime :: pos_integer(),
+                           MaxItems :: 1..100,
+                           Config :: aws_config()) ->
+    waf_return_val().
 get_sampled_requests(WebAclId, RuleId, StartTime, EndTime, MaxItems, Config) when is_integer(MaxItems) ->
     Json = [{<<"MaxItems">>, MaxItems},
             {<<"RuleId">>, to_binary(RuleId)},
@@ -577,16 +537,14 @@ get_sampled_requests(WebAclId, RuleId, StartTime, EndTime, MaxItems, Config) whe
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetSizeConstraintSet.html
 %%%------------------------------------------------------------------------------
--spec get_size_constraint_set/1 ::
-        (SizeConstraintSetId :: string() | binary()) ->
-        waf_return_val().
+-spec get_size_constraint_set(SizeConstraintSetId :: string() | binary()) ->
+    waf_return_val().
 get_size_constraint_set(SizeConstraintSetId) ->
     get_size_constraint_set(SizeConstraintSetId, default_config()).
 
--spec get_size_constraint_set/2 ::
-        (SizeConstraintSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_size_constraint_set(SizeConstraintSetId :: string() | binary(),
+                              Config :: aws_config()) ->
+    waf_return_val().
 get_size_constraint_set(SizeConstraintSetId, Config) ->
     Json = [{<<"SizeConstraintSetId">>, to_binary(SizeConstraintSetId)}],
     waf_request(Config, "GetSizeConstraintSet", Json).
@@ -597,16 +555,16 @@ get_size_constraint_set(SizeConstraintSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetSqlInjectionMatchSet.html
 %%%------------------------------------------------------------------------------
--spec get_sql_injection_match_set/1 ::
-        (SqlInjectionMatchSetId :: string() | binary()) ->
-        waf_return_val().
+-spec get_sql_injection_match_set(SqlInjectionMatchSetId ::
+                                      string() | binary()) ->
+    waf_return_val().
 get_sql_injection_match_set(SqlInjectionMatchSetId) ->
     get_sql_injection_match_set(SqlInjectionMatchSetId, default_config()).
 
--spec get_sql_injection_match_set/2 ::
-        (SqlInjectionMatchSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_sql_injection_match_set(SqlInjectionMatchSetId ::
+                                      string() | binary(),
+                                  Config :: aws_config()) ->
+    waf_return_val().
 get_sql_injection_match_set(SqlInjectionMatchSetId, Config) ->
     Json = [{<<"SqlInjectionMatchSetId">>, to_binary(SqlInjectionMatchSetId)}],
     waf_request(Config, "GetSqlInjectionMatchSet", Json).
@@ -617,16 +575,14 @@ get_sql_injection_match_set(SqlInjectionMatchSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetWebACL.html
 %%%------------------------------------------------------------------------------
--spec get_web_acl/1 ::
-        (WebACLId :: string() | binary()) ->
-        waf_return_val().
+-spec get_web_acl(WebACLId :: string() | binary()) ->
+    waf_return_val().
 get_web_acl(WebACLId) ->
     get_web_acl(WebACLId, default_config()).
 
--spec get_web_acl/2 ::
-        (WebACLId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_web_acl(WebACLId :: string() | binary(),
+                  Config :: aws_config()) ->
+    waf_return_val().
 get_web_acl(WebACLId, Config) ->
     Json = [{<<"WebACLId">>, to_binary(WebACLId)}],
     waf_request(Config, "GetWebACL", Json).
@@ -637,16 +593,14 @@ get_web_acl(WebACLId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_GetXssMatchSet.html
 %%%------------------------------------------------------------------------------
--spec get_xss_match_set/1 ::
-        (XssMatchSetId :: string() | binary()) ->
-        waf_return_val().
+-spec get_xss_match_set(XssMatchSetId :: string() | binary()) ->
+    waf_return_val().
 get_xss_match_set(XssMatchSetId) ->
     get_xss_match_set(XssMatchSetId, default_config()).
 
--spec get_xss_match_set/2 ::
-        (XssMatchSetId :: string() | binary(),
-         Config :: aws_config()) ->
-        waf_return_val().
+-spec get_xss_match_set(XssMatchSetId :: string() | binary(),
+                        Config :: aws_config()) ->
+    waf_return_val().
 get_xss_match_set(XssMatchSetId, Config) ->
     Json = [{<<"XssMatchSetId">>, to_binary(XssMatchSetId)}],
     waf_request(Config, "GetXssMatchSet", Json).
@@ -658,22 +612,17 @@ get_xss_match_set(XssMatchSetId, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_ListByteMatchSets.html
 %%%------------------------------------------------------------------------------
--spec list_byte_match_sets/0 ::
-        () ->
-       waf_return_val().
+-spec list_byte_match_sets() -> waf_return_val().
 list_byte_match_sets() ->
     list_byte_match_sets(?LIMIT_MAX, default_config()).
 
--spec list_byte_match_sets/1 ::
-       (Limit :: 1..100) ->
-       waf_return_val().
+-spec list_byte_match_sets(Limit :: 1..100) -> waf_return_val().
 list_byte_match_sets(Limit) when is_integer(Limit) ->
     list_byte_match_sets(Limit, default_config()).
 
--spec list_byte_match_sets/2 ::
-       (Limit :: 1..100,
-        binary() | aws_config()) ->
-       waf_return_val().
+-spec list_byte_match_sets(Limit :: 1..100,
+                           binary() | aws_config()) ->
+    waf_return_val().
 list_byte_match_sets(Limit, NextMarker) when is_binary(NextMarker) ->
     list_byte_match_sets(Limit, NextMarker, default_config());
 
@@ -681,11 +630,10 @@ list_byte_match_sets(Limit, Config) when is_integer(Limit), is_record(Config, aw
     Json = [{<<"Limit">>, Limit}],
     waf_request(Config, "ListByteMatchSets", Json).
 
--spec list_byte_match_sets/3 ::
-       (Limit :: 1..100,
-        NextMarker :: binary(),
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec list_byte_match_sets(Limit :: 1..100,
+                           NextMarker :: binary(),
+                           Config :: aws_config()) ->
+    waf_return_val().
 list_byte_match_sets(Limit, NextMarker, Config) when is_integer(Limit), is_binary(NextMarker) ->
     Json = [{<<"Limit">>, Limit},
             {<<"NextMarker">>, NextMarker}],
@@ -697,22 +645,17 @@ list_byte_match_sets(Limit, NextMarker, Config) when is_integer(Limit), is_binar
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_ListIPSets.html
 %%%------------------------------------------------------------------------------
--spec list_ip_sets/0 ::
-        () ->
-       waf_return_val().
+-spec list_ip_sets() -> waf_return_val().
 list_ip_sets() ->
     list_ip_sets(?LIMIT_MAX, default_config()).
 
--spec list_ip_sets/1 ::
-       (Limit :: 1..100) ->
-       waf_return_val().
+-spec list_ip_sets(Limit :: 1..100) -> waf_return_val().
 list_ip_sets(Limit) when is_integer(Limit) ->
     list_ip_sets(Limit, default_config()).
 
--spec list_ip_sets/2 ::
-       (Limit :: 1..100,
-        binary() | aws_config()) ->
-       waf_return_val().
+-spec list_ip_sets(Limit :: 1..100,
+                   binary() | aws_config()) ->
+    waf_return_val().
 list_ip_sets(Limit, NextMarker) when is_binary(NextMarker) ->
     list_ip_sets(Limit, NextMarker, default_config());
 
@@ -720,11 +663,10 @@ list_ip_sets(Limit, Config) when is_integer(Limit), is_record(Config, aws_config
     Json = [{<<"Limit">>, Limit}],
     waf_request(Config, "ListIPSets", Json).
 
--spec list_ip_sets/3 ::
-       (Limit :: 1..100,
-        NextMarker :: binary(),
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec list_ip_sets(Limit :: 1..100,
+                   NextMarker :: binary(),
+                   Config :: aws_config()) ->
+    waf_return_val().
 list_ip_sets(Limit, NextMarker, Config) when is_integer(Limit), is_binary(NextMarker) ->
     Json = [{<<"Limit">>, Limit},
             {<<"NextMarker">>, NextMarker}],
@@ -736,22 +678,17 @@ list_ip_sets(Limit, NextMarker, Config) when is_integer(Limit), is_binary(NextMa
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_ListRules.html
 %%%------------------------------------------------------------------------------
--spec list_rules/0 ::
-        () ->
-       waf_return_val().
+-spec list_rules() -> waf_return_val().
 list_rules() ->
     list_rules(?LIMIT_MAX, default_config()).
 
--spec list_rules/1 ::
-       (Limit :: 1..100) ->
-       waf_return_val().
+-spec list_rules(Limit :: 1..100) -> waf_return_val().
 list_rules(Limit) when Limit > 0, Limit =< 100 ->
     list_rules(Limit, default_config()).
 
--spec list_rules/2 ::
-       (Limit :: 1..100,
-        binary() | aws_config()) ->
-       waf_return_val().
+-spec list_rules(Limit :: 1..100,
+                 binary() | aws_config()) ->
+    waf_return_val().
 list_rules(Limit, NextMarker) when is_binary(NextMarker) ->
     list_rules(Limit, NextMarker, default_config());
 
@@ -759,11 +696,10 @@ list_rules(Limit, Config) when is_integer(Limit), is_record(Config, aws_config) 
     Json = [{<<"Limit">>, Limit}],
     waf_request(Config, "ListRules", Json).
 
--spec list_rules/3 ::
-       (Limit :: 1..100,
-        NextMarker :: binary(),
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec list_rules(Limit :: 1..100,
+                 NextMarker :: binary(),
+                 Config :: aws_config()) ->
+    waf_return_val().
 list_rules(Limit, NextMarker, Config) when is_integer(Limit) ->
     Json = [{<<"Limit">>, Limit},
             {<<"NextMarker">>, NextMarker}],
@@ -775,22 +711,18 @@ list_rules(Limit, NextMarker, Config) when is_integer(Limit) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_ListSizeConstraintSets.html
 %%%------------------------------------------------------------------------------
--spec list_size_constraint_sets/0 ::
-        () ->
-       waf_return_val().
+-spec list_size_constraint_sets() -> waf_return_val().
 list_size_constraint_sets() ->
     list_size_constraint_sets(?LIMIT_MAX, default_config()).
 
--spec list_size_constraint_sets/1 ::
-       (Limit :: 1..100) ->
-       waf_return_val().
+-spec list_size_constraint_sets(Limit :: 1..100) ->
+    waf_return_val().
 list_size_constraint_sets(Limit) when is_integer(Limit) ->
     list_size_constraint_sets(Limit, default_config()).
 
--spec list_size_constraint_sets/2 ::
-       (Limit :: 1..100,
-        binary() | aws_config()) ->
-       waf_return_val().
+-spec list_size_constraint_sets(Limit :: 1..100,
+                                binary() | aws_config()) ->
+    waf_return_val().
 list_size_constraint_sets(Limit, NextMarker) when is_binary(NextMarker) ->
     list_size_constraint_sets(Limit, NextMarker, default_config());
 
@@ -798,11 +730,10 @@ list_size_constraint_sets(Limit, Config) when is_integer(Limit), is_record(Confi
     Json = [{<<"Limit">>, Limit}],
     waf_request(Config, "ListSizeConstraintSets", Json).
 
--spec list_size_constraint_sets/3 ::
-       (Limit :: 1..100,
-        NextMarker :: binary(),
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec list_size_constraint_sets(Limit :: 1..100,
+                                NextMarker :: binary(),
+                                Config :: aws_config()) ->
+    waf_return_val().
 list_size_constraint_sets(Limit, NextMarker, Config) when is_integer(Limit) ->
     Json = [{<<"Limit">>, Limit},
             {<<"NextMarker">>, NextMarker}],
@@ -814,22 +745,19 @@ list_size_constraint_sets(Limit, NextMarker, Config) when is_integer(Limit) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_ListSqlInjectionMatchSets.html
 %%%------------------------------------------------------------------------------
--spec list_sql_injection_match_sets/0 ::
-        () ->
-       waf_return_val().
+-spec list_sql_injection_match_sets() ->
+    waf_return_val().
 list_sql_injection_match_sets() ->
     list_sql_injection_match_sets(?LIMIT_MAX, default_config()).
 
--spec list_sql_injection_match_sets/1 ::
-       (Limit :: 1..100) ->
-       waf_return_val().
+-spec list_sql_injection_match_sets(Limit :: 1..100) ->
+    waf_return_val().
 list_sql_injection_match_sets(Limit) when is_integer(Limit) ->
     list_sql_injection_match_sets(Limit, default_config()).
 
--spec list_sql_injection_match_sets/2 ::
-       (Limit :: 1..100,
-        binary() | aws_config()) ->
-       waf_return_val().
+-spec list_sql_injection_match_sets(Limit :: 1..100,
+                                    binary() | aws_config()) ->
+    waf_return_val().
 list_sql_injection_match_sets(Limit, NextMarker) when is_binary(NextMarker) ->
     list_sql_injection_match_sets(Limit, NextMarker, default_config());
 
@@ -837,11 +765,10 @@ list_sql_injection_match_sets(Limit, Config) when is_integer(Limit), is_record(C
     Json = [{<<"Limit">>, Limit}],
     waf_request(Config, "ListSqlInjectionMatchSets", Json).
 
--spec list_sql_injection_match_sets/3 ::
-       (Limit :: 1..100,
-        NextMarker :: binary(),
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec list_sql_injection_match_sets(Limit :: 1..100,
+                                    NextMarker :: binary(),
+                                    Config :: aws_config()) ->
+    waf_return_val().
 list_sql_injection_match_sets(Limit, NextMarker, Config) when is_integer(Limit) ->
     Json = [{<<"Limit">>, Limit},
             {<<"NextMarker">>, NextMarker}],
@@ -853,22 +780,17 @@ list_sql_injection_match_sets(Limit, NextMarker, Config) when is_integer(Limit) 
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_ListWebACLs.html
 %%%------------------------------------------------------------------------------
--spec list_web_acls/0 ::
-        () ->
-       waf_return_val().
+-spec list_web_acls() -> waf_return_val().
 list_web_acls() ->
     list_web_acls(?LIMIT_MAX, default_config()).
 
--spec list_web_acls/1 ::
-       (Limit :: 1..100) ->
-       waf_return_val().
+-spec list_web_acls(Limit :: 1..100) -> waf_return_val().
 list_web_acls(Limit) when is_integer(Limit) ->
     list_web_acls(Limit, default_config()).
 
--spec list_web_acls/2 ::
-       (Limit :: 1..100,
-        binary() | aws_config()) ->
-       waf_return_val().
+-spec list_web_acls(Limit :: 1..100,
+                    binary() | aws_config()) ->
+    waf_return_val().
 list_web_acls(Limit, NextMarker) when is_binary(NextMarker) ->
     list_web_acls(Limit, NextMarker, default_config());
 
@@ -876,11 +798,10 @@ list_web_acls(Limit, Config) when is_integer(Limit), is_record(Config, aws_confi
     Json = [{<<"Limit">>, Limit}],
     waf_request(Config, "ListWebACLs", Json).
 
--spec list_web_acls/3 ::
-       (Limit :: 1..100,
-        NextMarker :: binary(),
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec list_web_acls(Limit :: 1..100,
+                    NextMarker :: binary(),
+                    Config :: aws_config()) ->
+    waf_return_val().
 list_web_acls(Limit, NextMarker, Config) when is_integer(Limit) ->
     Json = [{<<"Limit">>, Limit},
             {<<"NextMarker">>, NextMarker}],
@@ -892,23 +813,18 @@ list_web_acls(Limit, NextMarker, Config) when is_integer(Limit) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_ListXssMatchSets.html
 %%%------------------------------------------------------------------------------
--spec list_xss_match_sets/0 ::
-        () ->
-       waf_return_val().
+-spec list_xss_match_sets() -> waf_return_val().
 list_xss_match_sets() ->
     list_xss_match_sets(?LIMIT_MAX, default_config()).
 
 
--spec list_xss_match_sets/1 ::
-       (Limit :: 1..100) ->
-       waf_return_val().
+-spec list_xss_match_sets(Limit :: 1..100) -> waf_return_val().
 list_xss_match_sets(Limit) when is_integer(Limit) ->
     list_xss_match_sets(Limit, default_config()).
 
--spec list_xss_match_sets/2 ::
-       (Limit :: 1..100,
-        binary() | aws_config()) ->
-       waf_return_val().
+-spec list_xss_match_sets(Limit :: 1..100,
+                          binary() | aws_config()) ->
+    waf_return_val().
 list_xss_match_sets(Limit, NextMarker) when is_binary(NextMarker) ->
     list_xss_match_sets(Limit, NextMarker, default_config());
 
@@ -916,11 +832,10 @@ list_xss_match_sets(Limit, Config) when is_integer(Limit), is_record(Config, aws
     Json = [{<<"Limit">>, Limit}],
     waf_request(Config, "ListXssMatchSets", Json).
 
--spec list_xss_match_sets/3 ::
-       (Limit :: 1..100,
-        NextMarker :: binary(),
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec list_xss_match_sets(Limit :: 1..100,
+                          NextMarker :: binary(),
+                          Config :: aws_config()) ->
+    waf_return_val().
 list_xss_match_sets(Limit, NextMarker, Config) when is_integer(Limit) ->
     Json = [{<<"Limit">>, Limit},
             {<<"NextMarker">>, NextMarker}],
@@ -932,20 +847,18 @@ list_xss_match_sets(Limit, NextMarker, Config) when is_integer(Limit) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_UpdateByteMatchSet.html
 %%%------------------------------------------------------------------------------
--spec update_byte_match_set/3 ::
-       (ChangeToken :: string() | binary(),
-        ByteMatchSetId :: string() | binary(),
-        Updates :: [waf_byte_match_set_update()]) ->
-       waf_return_val().
+-spec update_byte_match_set(ChangeToken :: string() | binary(),
+                            ByteMatchSetId :: string() | binary(),
+                            Updates :: [waf_byte_match_set_update()]) ->
+    waf_return_val().
 update_byte_match_set(ChangeToken, ByteMatchSetId, Updates) ->
     update_byte_match_set(ChangeToken, ByteMatchSetId, Updates, default_config()).
 
--spec update_byte_match_set/4 ::
-       (ChangeToken :: string() | binary(),
-        ByteMatchSetId :: string() | binary(),
-        Updates :: [waf_byte_match_set_update()],
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec update_byte_match_set(ChangeToken :: string() | binary(),
+                            ByteMatchSetId :: string() | binary(),
+                            Updates :: [waf_byte_match_set_update()],
+                            Config :: aws_config()) ->
+    waf_return_val().
 update_byte_match_set(ChangeToken, ByteMatchSetId, Updates, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"ByteMatchSetId">>, to_binary(ByteMatchSetId)},
@@ -958,20 +871,18 @@ update_byte_match_set(ChangeToken, ByteMatchSetId, Updates, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_UpdateIPSet.html
 %%%------------------------------------------------------------------------------
--spec update_ip_set/3 ::
-       (ChangeToken :: string() | binary(),
-        IPSetId :: string() | binary(),
-        Updates :: [waf_ip_set_update()]) ->
-       waf_return_val().
+-spec update_ip_set(ChangeToken :: string() | binary(),
+                    IPSetId :: string() | binary(),
+                    Updates :: [waf_ip_set_update()]) ->
+    waf_return_val().
 update_ip_set(ChangeToken, IPSetId, Updates) ->
     update_ip_set(ChangeToken, IPSetId, Updates, default_config()).
 
--spec update_ip_set/4 ::
-       (ChangeToken :: string() | binary(),
-        IPSetId :: string() | binary(),
-        Updates :: [waf_ip_set_update()],
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec update_ip_set(ChangeToken :: string() | binary(),
+                    IPSetId :: string() | binary(),
+                    Updates :: [waf_ip_set_update()],
+                    Config :: aws_config()) ->
+    waf_return_val().
 update_ip_set(ChangeToken, IPSetId, Updates, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"IPSetId">>, to_binary(IPSetId)},
@@ -984,20 +895,18 @@ update_ip_set(ChangeToken, IPSetId, Updates, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_UpdateRule.html
 %%%------------------------------------------------------------------------------
--spec update_rule/3 ::
-       (ChangeToken :: string() | binary(),
-        RuleId :: string(),
-        Updates :: [waf_rule_update()]) ->
-       waf_return_val().
+-spec update_rule(ChangeToken :: string() | binary(),
+                  RuleId :: string(),
+                  Updates :: [waf_rule_update()]) ->
+    waf_return_val().
 update_rule(ChangeToken, RuleId, Updates) ->
     update_rule(ChangeToken, RuleId, Updates, default_config()).
 
--spec update_rule/4 ::
-       (ChangeToken :: string() | binary(),
-        RuleId :: string() | binary(),
-        Updates :: [waf_rule_update()],
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec update_rule(ChangeToken :: string() | binary(),
+                  RuleId :: string() | binary(),
+                  Updates :: [waf_rule_update()],
+                  Config :: aws_config()) ->
+    waf_return_val().
 update_rule(ChangeToken, RuleId, Updates, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"RuleId">>, to_binary(RuleId)},
@@ -1010,20 +919,18 @@ update_rule(ChangeToken, RuleId, Updates, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_UpdateSizeConstraintSet.html
 %%%------------------------------------------------------------------------------
--spec update_size_constraint_set/3 ::
-       (ChangeToken :: string() | binary(),
-        SizeConstraintSetId :: string() | binary(),
-        Updates :: [waf_size_constraint_update()]) ->
-       waf_return_val().
+-spec update_size_constraint_set(ChangeToken :: string() | binary(),
+                                 SizeConstraintSetId :: string() | binary(),
+                                 Updates :: [waf_size_constraint_update()]) ->
+    waf_return_val().
 update_size_constraint_set(ChangeToken, SizeConstraintSetId, Updates) ->
     update_size_constraint_set(ChangeToken, SizeConstraintSetId, Updates, default_config()).
 
--spec update_size_constraint_set/4 ::
-       (ChangeToken :: string() | binary(),
-        SizeConstraintSetId :: string() | binary(),
-        Updates :: [waf_size_constraint_update()],
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec update_size_constraint_set(ChangeToken :: string() | binary(),
+                                 SizeConstraintSetId :: string() | binary(),
+                                 Updates :: [waf_size_constraint_update()],
+                                 Config :: aws_config()) ->
+    waf_return_val().
 update_size_constraint_set(ChangeToken, SizeConstraintSetId, Updates, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"SizeConstraintSetId">>, to_binary(SizeConstraintSetId)},
@@ -1035,20 +942,18 @@ update_size_constraint_set(ChangeToken, SizeConstraintSetId, Updates, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_UpdateSqlInjectionMatchSet.html
 %%%------------------------------------------------------------------------------
--spec update_sql_injection_match_set/3 ::
-       (ChangeToken :: string() | binary(),
-        SqlInjectionMatchSetId :: string() | binary(),
-        Updates :: [waf_sql_injection_match_set_update()]) ->
-       waf_return_val().
+-spec update_sql_injection_match_set(
+    ChangeToken :: string() | binary(),
+    SqlInjectionMatchSetId :: string() | binary(),
+    Updates :: [waf_sql_injection_match_set_update()]) -> waf_return_val().
 update_sql_injection_match_set(ChangeToken, SqlInjectionMatchSetId, Updates) ->
     update_sql_injection_match_set(ChangeToken, SqlInjectionMatchSetId, Updates, default_config()).
 
--spec update_sql_injection_match_set/4 ::
-       (ChangeToken :: string() | binary(),
-        SqlInjectionMatchSetId:: string() | binary(),
-        Updates :: [waf_sql_injection_match_set_update()],
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec update_sql_injection_match_set(
+    ChangeToken :: string() | binary(),
+    SqlInjectionMatchSetId :: string() | binary(),
+    Updates :: [waf_sql_injection_match_set_update()],
+    Config :: aws_config()) -> waf_return_val().
 update_sql_injection_match_set(ChangeToken, SqlInjectionMatchSetId, Updates, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"SqlInjectionMatchSetId">>, to_binary(SqlInjectionMatchSetId)},
@@ -1077,20 +982,18 @@ get_web_acl_opts([{updates, Updates} | T], Res) ->
 
 get_web_acl_opts([_ | T], Res) -> get_web_acl_opts(T, Res).
 
--spec update_web_acl/3 ::
-       (ChangeToken :: string() | binary(),
-        WebACLId :: string() | binary(),
-        Opts :: update_web_acl_opts()) ->
-       waf_return_val().
+-spec update_web_acl(ChangeToken :: string() | binary(),
+                     WebACLId :: string() | binary(),
+                     Opts :: update_web_acl_opts()) ->
+    waf_return_val().
 update_web_acl(ChangeToken, WebACLId, Opts) ->
     update_web_acl(ChangeToken, WebACLId, Opts, default_config()).
 
--spec update_web_acl/4 ::
-       (ChangeToken :: string() | binary(),
-        WebACLId :: string() | binary(),
-        Opts :: update_web_acl_opts(),
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec update_web_acl(ChangeToken :: string() | binary(),
+                     WebACLId :: string() | binary(),
+                     Opts :: update_web_acl_opts(),
+                     Config :: aws_config()) ->
+    waf_return_val().
 update_web_acl(ChangeToken, WebACLId, Opts, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"WebACLId">>, to_binary(WebACLId)} | get_web_acl_opts(Opts)],
@@ -1102,20 +1005,18 @@ update_web_acl(ChangeToken, WebACLId, Opts, Config) ->
 %%
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_UpdateXssMatchSet.html
 %%%------------------------------------------------------------------------------
--spec update_xss_match_set/3 ::
-       (ChangeToken :: string() | binary(),
-        XssMatchSetId :: string() | binary(),
-        Updates :: [waf_xss_match_set_update()]) ->
-       waf_return_val().
+-spec update_xss_match_set(ChangeToken :: string() | binary(),
+                           XssMatchSetId :: string() | binary(),
+                           Updates :: [waf_xss_match_set_update()]) ->
+    waf_return_val().
 update_xss_match_set(ChangeToken, XssMatchSetId, Updates) ->
     update_xss_match_set(ChangeToken, XssMatchSetId, Updates, default_config()).
 
--spec update_xss_match_set/4 ::
-       (ChangeToken :: string() | binary(),
-        XssMatchSetId :: string() | binary(),
-        Updates :: [waf_xss_match_set_update()],
-        Config :: aws_config()) ->
-       waf_return_val().
+-spec update_xss_match_set(ChangeToken :: string() | binary(),
+                           XssMatchSetId :: string() | binary(),
+                           Updates :: [waf_xss_match_set_update()],
+                           Config :: aws_config()) ->
+    waf_return_val().
 update_xss_match_set(ChangeToken, XssMatchSetId, Updates, Config) ->
     Json = [{<<"ChangeToken">>, to_binary(ChangeToken)},
             {<<"XssMatchSetId">>, to_binary(XssMatchSetId)},
@@ -1125,14 +1026,13 @@ update_xss_match_set(ChangeToken, XssMatchSetId, Updates, Config) ->
 %%%------------------------------------------------------------------------------
 %%% Internal Functions
 %%%------------------------------------------------------------------------------
--spec transform_to_proplist/1 ::
-        (waf_byte_match_set_update() |
-         waf_ip_set_update() |
-         waf_rule_update() |
-         waf_size_constraint_update() |
-         waf_sql_injection_match_set_update() |
-         waf_web_acl_update()) ->
-       proplists:proplist().
+-spec transform_to_proplist(waf_byte_match_set_update() |
+                            waf_ip_set_update() |
+                            waf_rule_update() |
+                            waf_size_constraint_update() |
+                            waf_sql_injection_match_set_update() |
+                            waf_web_acl_update()) ->
+    proplists:proplist().
 transform_to_proplist(#waf_byte_match_set_update{action = Action, byte_match_tuple = ByteMatchTuple}) ->
     [{<<"Action">>, get_update_action(Action)},
      {<<"ByteMatchTuple">>, record_to_proplist(ByteMatchTuple)}];
@@ -1161,15 +1061,14 @@ transform_to_proplist(#waf_xss_match_set_update{action = Action, xss_match_tuple
     [{<<"Action">>, get_update_action(Action)},
      {<<"XssMatchTuple">>, record_to_proplist(XssMatchTuple)}].
 
--spec record_to_proplist/1 ::
-        (waf_rule_predicate() |
-         waf_ip_set_descriptor() |
-         waf_byte_match_tuple() |
-         waf_size_constraint() |
-         waf_sql_injection_match_tuple() |
-         waf_activated_rule() |
-         waf_xss_match_tuple()) ->
-        proplists:proplist().
+-spec record_to_proplist(waf_rule_predicate() |
+                         waf_ip_set_descriptor() |
+                         waf_byte_match_tuple() |
+                         waf_size_constraint() |
+                         waf_sql_injection_match_tuple() |
+                         waf_activated_rule() |
+                         waf_xss_match_tuple()) ->
+    proplists:proplist().
 record_to_proplist(#waf_rule_predicate{data_id = DataId, negated = Negated, type = Type}) ->
     [{<<"DataId">>, to_binary(DataId)},
      {<<"Negated">>, to_binary(Negated)},
@@ -1286,8 +1185,7 @@ waf_request_no_update(Config, Operation, Body) ->
         {error, _} = Error-> Error
     end.
 
--spec waf_result_fun/1 ::
-          (Request :: aws_request()) -> aws_request().
+-spec waf_result_fun(Request :: aws_request()) -> aws_request().
 waf_result_fun(#aws_request{response_type = ok} = Request) ->
     Request;
 waf_result_fun(#aws_request{response_type = error,


### PR DESCRIPTION
* -spec syntax is fixed to not cause compilation syntax errors
* -include_lib for erlcloud is changed to -include to work with rebar2

Other changes that would be nice, but are not included in this pull request are mentioned in the issue  #278