### PR TITLE
Add eini application dependency.

### DIFF
--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -12,6 +12,7 @@
                   ssl,
                   xmerl,
                   inets,
+                  eini,
                   jsx,
                   %% hackney,
                   lhttpc]},


### PR DESCRIPTION
The eini dependency is currently missing from the .app.src file, but is present in the rebar.config.  Due to the fetch of the dep being required and the dependency being used in the source code, it is best to make it a dependency in the .app file that is generated.