### PR TITLE
Add function to fetch instance id

### DIFF
--- a/include/erlcloud_as.hrl
+++ b/include/erlcloud_as.hrl
@@ -44,3 +44,13 @@
           progress :: integer()
          }).
 -type(aws_autoscaling_activity() :: #aws_autoscaling_activity{}).
+
+-record(aws_autoscaling_lifecycle_hook,{
+          group_name :: string(),
+          lifecycle_hook_name :: string(),
+          global_timeout :: non_neg_integer(),
+          heartbeat_timeout :: non_neg_integer(),
+          default_result :: string(),
+          lifecycle_transition :: string()
+         }).
+-type(aws_autoscaling_lifecycle_hook() :: #aws_autoscaling_lifecycle_hook{}).

--- a/src/erlcloud_as.erl
+++ b/src/erlcloud_as.erl
@@ -16,7 +16,10 @@
 
          suspend_processes/1, suspend_processes/2, suspend_processes/3,
          resume_processes/1, resume_processes/2, resume_processes/3,
-         detach_instances/2, detach_instances/3, detach_instances/4]).
+         detach_instances/2, detach_instances/3, detach_instances/4,
+
+         describe_lifecycle_hooks/1, describe_lifecycle_hooks/2, describe_lifecycle_hooks/3,
+         complete_lifecycle_action/4, complete_lifecycle_action/5]).
 
 -define(API_VERSION, "2011-01-01").
 -define(DEFAULT_MAX_RECORDS, 20).
@@ -54,6 +57,12 @@
 %% xpath for detach instances:
 -define(DETACH_INSTANCES_ACTIVITY, 
         "/DetachInstancesResponse/DetachInstancesResult/Activities/member").
+
+-define(DESCRIBE_LIFECYCLE_HOOKS_PATH, 
+        "/DescribeLifecycleHooksResponse/DescribeLifecycleHooksResult/LifecycleHooks/member").
+
+-define(COMPLETE_LIFECYCLE_ACTION_ACTIVITY, 
+        "/CompleteLifecycleActionResponse/ResponseMetadata/RequestId").
 
 
 %% --------------------------------------------------------------------
@@ -255,8 +264,8 @@ describe_instances(I, MaxRecords, NextToken, Config) ->
     describe_instances(I, [{"MaxRecords", MaxRecords}, {"NextToken", NextToken}], Config).
 
 -spec describe_instances(list(string()), list({string(), term()}), aws_config()) -> 
-                                {ok, list(aws_launch_config())} | 
-                                {{paged, string()}, list(aws_launch_config)} | 
+                                {ok, list(aws_autoscaling_instance())} | 
+                                {{paged, string()}, list(aws_autoscaling_instance())} | 
                                 {error, term()}.                       
 describe_instances(I, Params, Config) ->
     P = member_params("InstanceIds.member.", I) ++ Params,
@@ -411,6 +420,60 @@ detach_instances(InstanceIds, GroupName, ShouldDecrementDesiredCapacity, Config)
             {error, Reason}
     end.
 
+
+describe_lifecycle_hooks(GroupName) ->
+    describe_lifecycle_hooks(GroupName, [], erlcloud_aws:default_config()).
+
+describe_lifecycle_hooks(GroupName, LifecycleHookNames) when is_list(LifecycleHookNames) ->
+    describe_lifecycle_hooks(GroupName, LifecycleHookNames, erlcloud_aws:default_config());
+describe_lifecycle_hooks(GroupName, Config) ->
+    describe_lifecycle_hooks(GroupName, [], Config).
+
+-spec describe_lifecycle_hooks(string(), list(string()), aws_config()) -> {ok, list(aws_autoscaling_lifecycle_hook())} | {error, term()}.
+describe_lifecycle_hooks(GroupName, LifecycleHookNames, Config) ->
+    Params = [{"AutoScalingGroupName", GroupName} | member_params("LifecycleHookNames.member.", LifecycleHookNames)],
+    case as_query(Config, "DescribeLifecycleHooks", Params, ?API_VERSION) of
+        {ok, Doc} ->
+            LifecycleHooks = xmerl_xpath:string(?DESCRIBE_LIFECYCLE_HOOKS_PATH, Doc),            
+            Hooks = [extract_lifecycle_hook(H) || H <- LifecycleHooks],
+            {ok, Hooks};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+extract_lifecycle_hook(H) -> 
+    #aws_autoscaling_lifecycle_hook{
+          group_name = erlcloud_xml:get_text("AutoScalingGroupName", H),
+          lifecycle_hook_name = erlcloud_xml:get_text("LifecycleHookName", H),
+          global_timeout = erlcloud_xml:get_integer("GlobalTimeout", H),
+          heartbeat_timeout = erlcloud_xml:get_integer("HeartbeatTimeout", H),
+          default_result = erlcloud_xml:get_text("DefaultResult", H),
+          lifecycle_transition = erlcloud_xml:get_text("LifecycleTransition", H)}.
+
+
+-spec complete_lifecycle_action(string(), string(), string(), {instance_id | token, string()}) -> {ok, string()} | {error, term()}.
+complete_lifecycle_action(GroupName, LifecycleActionResult, LifecycleHookName, InstanceIdOrLifecycleActionToken) ->
+    complete_lifecycle_action(GroupName, LifecycleActionResult, LifecycleHookName, InstanceIdOrLifecycleActionToken, erlcloud_aws:default_config()).
+
+-spec complete_lifecycle_action(string(), string(), string(), {instance_id | token, string()}, aws_config()) -> {ok, string()} | {error, term()}.
+complete_lifecycle_action(GroupName, LifecycleActionResult, LifecycleHookName, InstanceIdOrLifecycleActionToken, Config) ->
+    InstanceIdOrLifecycleActionTokenParam = case InstanceIdOrLifecycleActionToken of
+        {instance_id,InstanceId} ->
+            {"InstanceId", InstanceId};
+        {token,LifecycleActionToken} ->
+            {"LifecycleActionToken", LifecycleActionToken}
+    end,
+    Params = [{"AutoScalingGroupName", GroupName},
+              {"LifecycleActionResult", LifecycleActionResult},
+              {"LifecycleHookName", LifecycleHookName},
+              InstanceIdOrLifecycleActionTokenParam],
+    case as_query(Config, "CompleteLifecycleAction", Params, ?API_VERSION) of
+        {ok, Doc} ->
+            RequestId = erlcloud_xml:get_text(?COMPLETE_LIFECYCLE_ACTION_ACTIVITY, Doc),            
+            {ok, RequestId};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 %% given a list of member identifiers, return a list of 
 %% {key with prefix, member identifier} for use in autoscaling calls.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -12,6 +12,7 @@
          service_config/3,
          configure/1, format_timestamp/1,
          http_headers_body/1,
+         http_body/1,
          request_to_return/1,
          sign_v4_headers/5,
          sign_v4/8,
@@ -393,20 +394,13 @@ timestamp_to_gregorian_seconds(Timestamp) ->
 get_credentials_from_metadata(Config) ->
     %% TODO this function should retry on errors getting credentials
     %% First get the list of roles
-    case http_body(
-           erlcloud_httpc:request(
-             "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
-             get, [], <<>>, get_timeout(Config), Config)) of
+    case erlcloud_ec2_meta:get_instance_metadata("iam/security-credentials/", Config) of
         {error, Reason} ->
             {error, Reason};
         {ok, Body} ->
             %% Always use the first role
             [Role | _] = binary:split(Body, <<$\n>>),
-            case http_body(
-                   erlcloud_httpc:request(
-                     "http://169.254.169.254/latest/meta-data/iam/security-credentials/" ++
-                         binary_to_list(Role),
-                     get, [], <<>>, get_timeout(Config), Config)) of
+            case erlcloud_ec2_meta:get_instance_metadata("iam/security-credentials/" ++ binary_to_list(Role), Config) of
                 {error, Reason} ->
                     {error, Reason};
                 {ok, Json} ->

--- a/src/erlcloud_ec2_meta.erl
+++ b/src/erlcloud_ec2_meta.erl
@@ -1,0 +1,71 @@
+-module(erlcloud_ec2_meta).
+
+-include("erlcloud.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
+
+-export([get_instance_metadata/0, get_instance_metadata/1, get_instance_metadata/2,
+        get_instance_user_data/0, get_instance_user_data/1,
+        get_instance_dynamic_data/0, get_instance_dynamic_data/1, get_instance_dynamic_data/2]).
+
+
+
+
+-spec get_instance_metadata() -> {ok, binary()} | {error, tuple()}.
+get_instance_metadata() ->
+   get_instance_metadata(erlcloud_aws:default_config()).
+
+-spec get_instance_metadata(Config :: aws_config() ) -> {ok, binary()} | {error, tuple()}.
+get_instance_metadata(Config) ->
+   get_instance_metadata("", Config).
+
+
+%%%---------------------------------------------------------------------------
+-spec get_instance_metadata( ItemPath :: string(), Config :: aws_config() ) -> {ok, binary()} | {error, tuple()}.
+%%%---------------------------------------------------------------------------
+%% @doc Retrieve the instance meta data for the instance this code is running on. Will fail if not an EC2 instance.
+%%
+%% This convenience function will retrieve the instance id from the AWS metadata available at 
+%% http://169.254.169.254/latest/meta-data/*
+%% ItemPath allows fetching specific pieces of metadata.
+%%
+%%
+get_instance_metadata(ItemPath, Config) ->
+    MetaDataPath = "http://169.254.169.254/latest/meta-data/" ++ ItemPath,
+    erlcloud_aws:http_body(erlcloud_httpc:request(MetaDataPath, get, [], <<>>, erlcloud_aws:get_timeout(Config), Config)).
+
+
+-spec get_instance_user_data() -> {ok, binary()} | {error, tuple()}.
+get_instance_user_data() ->
+   get_instance_user_data(erlcloud_aws:default_config()).
+
+%%%---------------------------------------------------------------------------
+-spec get_instance_user_data( Config :: aws_config() ) -> {ok, binary()} | {error, tuple()}.
+%%%---------------------------------------------------------------------------
+%% @doc Retrieve the user data for the instance this code is running on. Will fail if not an EC2 instance.
+%%
+%% This convenience function will retrieve the user data the instance was started with, i.e. what's available at 
+%% http://169.254.169.254/latest/user-data
+%%
+%%
+get_instance_user_data(Config) ->
+    UserDataPath = "http://169.254.169.254/latest/user-data/",
+    erlcloud_aws:http_body(erlcloud_httpc:request(UserDataPath, get, [], <<>>, erlcloud_aws:get_timeout(Config), Config)).
+
+
+-spec get_instance_dynamic_data() -> {ok, binary()} | {error, tuple()}.
+get_instance_dynamic_data() ->
+   get_instance_dynamic_data(erlcloud_aws:default_config()).
+
+-spec get_instance_dynamic_data(Config :: aws_config() ) -> {ok, binary()} | {error, tuple()}.
+get_instance_dynamic_data(Config) ->
+   get_instance_dynamic_data("", Config).
+
+
+%%%---------------------------------------------------------------------------
+-spec get_instance_dynamic_data( ItemPath :: string(), Config :: aws_config() ) -> {ok, binary()} | {error, tuple()}.
+%%%---------------------------------------------------------------------------
+
+get_instance_dynamic_data(ItemPath, Config) ->
+    DynamicDataPath = "http://169.254.169.254/latest/dynamic/" ++ ItemPath,
+    erlcloud_aws:http_body(erlcloud_httpc:request(DynamicDataPath, get, [], <<>>, erlcloud_aws:get_timeout(Config), Config)).
+

--- a/test/erlcloud_as_tests.erl
+++ b/test/erlcloud_as_tests.erl
@@ -19,7 +19,8 @@ autoscaling_test_() ->
      fun stop/1,
      [fun description_tests/1,
       fun terminate_tests/1,
-      fun detach_instances_tests/1]}.
+      fun detach_instances_tests/1,
+      fun lifecycle_hooks_tests/1]}.
 
 start() ->
     meck:new(erlcloud_aws, [non_strict]),
@@ -53,6 +54,14 @@ detach_instances_tests(_) ->
              Res = extract_result(erlcloud_as:detach_instances(["i-bdae7a84"], "my-test-asg-lbs", false)),
              ?assertEqual(Res, expected_detach_activities()) end].
     
+lifecycle_hooks_tests(_) ->
+     [fun() ->
+             Res = extract_result(erlcloud_as:describe_lifecycle_hooks("my-test-asg-lbs", ["TestHook"])),
+             ?assertEqual(Res, expected_describe_lifecycle_hooks()) end,
+      fun() ->
+             Res = extract_result(erlcloud_as:complete_lifecycle_action("my-test-asg-lbs", "CONTINUE", "TestHook", {instance_id, "i-bdae7a84"})),
+             ?assertEqual(Res, expected_complete_lifecycle_action()) end].
+    
 mocked_aws_xml() ->
     meck:expect(erlcloud_aws, default_config, [{[], #aws_config{}}]),
     meck:expect(erlcloud_aws, aws_request_xml4, [
@@ -60,7 +69,9 @@ mocked_aws_xml() ->
                                                  mocked_instances(),
                                                  mocked_launch_configs(),
                                                  mocked_activity(),
-                                                 mocked_detach_instances()]).
+                                                 mocked_detach_instances(),
+                                                 mocked_describe_lifecycle_hooks(),
+                                                 mocked_complete_lifecycle_action()]).
 
 parsed_mock_response(Text) ->
     {ok, element(1, xmerl_scan:string(Text))}.
@@ -271,3 +282,57 @@ expected_detach_activities() ->
         status_code = "InProgress",status_msg = [],
         start_time = {{2016,2,3},{16,10,3}},
         end_time = undefined,progress = 50}].
+
+
+mocked_describe_lifecycle_hooks() ->
+    {[post, '_', "/", [
+                       {"Action", "DescribeLifecycleHooks"},
+                       {"Version", "2011-01-01"},
+                       {"AutoScalingGroupName", "my-test-asg-lbs"},
+                       {"LifecycleHookNames.member.1", "TestHook"}],
+      "autoscaling", '_'], parsed_mock_response("
+<DescribeLifecycleHooksResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\">
+  <DescribeLifecycleHooksResult>
+    <LifecycleHooks>
+      <member>
+        <AutoScalingGroupName>my-test-asg-lbs</AutoScalingGroupName>
+        <LifecycleTransition>autoscaling:EC2_INSTANCE_LAUNCHING</LifecycleTransition>
+        <GlobalTimeout>172800</GlobalTimeout>
+        <LifecycleHookName>TestHook</LifecycleHookName>
+        <HeartbeatTimeout>3600</HeartbeatTimeout>
+        <DefaultResult>ABANDON</DefaultResult>
+      </member>
+    </LifecycleHooks>
+  </DescribeLifecycleHooksResult>
+  <ResponseMetadata>
+    <RequestId>ff028e98-1dc1-11e6-89f3-81231a887c98</RequestId>
+  </ResponseMetadata>
+</DescribeLifecycleHooksResponse>")}.
+
+expected_describe_lifecycle_hooks() ->
+    [#aws_autoscaling_lifecycle_hook{
+        group_name = "my-test-asg-lbs",
+        lifecycle_hook_name = "TestHook",
+        global_timeout = 172800,
+        heartbeat_timeout = 3600,
+        default_result = "ABANDON",
+        lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"}].
+
+mocked_complete_lifecycle_action() ->
+    {[post, '_', "/", [
+                       {"Action", "CompleteLifecycleAction"},
+                       {"Version", "2011-01-01"},
+                       {"AutoScalingGroupName", "my-test-asg-lbs"},
+                       {"LifecycleActionResult", "CONTINUE"},
+                       {"LifecycleHookName", "TestHook"},
+                       {"InstanceId", "i-bdae7a84"}],
+      "autoscaling", '_'], parsed_mock_response("
+<CompleteLifecycleActionResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\">
+  <CompleteLifecycleActionResult/>
+  <ResponseMetadata>
+    <RequestId>ff028e98-1dc1-11e6-89f3-81231a887c98</RequestId>
+  </ResponseMetadata>
+</CompleteLifecycleActionResponse>")}.
+
+expected_complete_lifecycle_action() ->
+    "ff028e98-1dc1-11e6-89f3-81231a887c98".


### PR DESCRIPTION
Add convenience function erlcloud_aws:get_instance_id/1 to fetch instance id of current instance from AWS metadata