### PR TITLE
Make associate_public_ip optional in ec2 instance creation

### DIFF
--- a/include/erlcloud_ec2.hrl
+++ b/include/erlcloud_ec2.hrl
@@ -16,7 +16,7 @@
           subnet_id           :: string(),
           security_group=[]   :: [string()],
           private_ip=[]       :: [string()],
-          associate_public_ip :: boolean()
+          associate_public_ip :: undefined | boolean()
 }).
 
 -record(ec2_instance_spec, {

--- a/include/erlcloud_ec2.hrl
+++ b/include/erlcloud_ec2.hrl
@@ -12,10 +12,10 @@
 
 %% Network interface (used by launch specification)
 -record(ec2_net_if, {
-          device_index   :: string(),
-          subnet_id      :: string(),
-          security_group :: [string()],
-          private_ip     :: [string()],
+          device_index        :: string(),
+          subnet_id           :: string(),
+          security_group=[]   :: [string()],
+          private_ip=[]       :: [string()],
           associate_public_ip :: boolean()
 }).
 

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -2751,21 +2751,23 @@ run_instances(InstanceSpec, Config)
             Error
     end.
 
-net_if_params(#ec2_net_if{private_ip=undefined}=X) ->
-    [
-        {"DeviceIndex", X#ec2_net_if.device_index},
-        {"SubnetId",    X#ec2_net_if.subnet_id},
-        {"AssociatePublicIpAddress", X#ec2_net_if.associate_public_ip}
-    ] ++ erlcloud_aws:param_list(X#ec2_net_if.security_group, "SecurityGroupId");
+private_ip_params(undefined) -> [];
+private_ip_params([HeadIP|TailIPs]) ->
+    [{"PrivateIpAddress", HeadIP}|
+      erlcloud_aws:param_list(
+        [[{"PrivateIpAddress", IP}] || IP <- TailIPs], "PrivateIpAddresses")].
+
+public_ip_params(undefined) -> [];
+public_ip_params(Bool) -> [{"AssociatePublicIpAddress", Bool}].
+
 net_if_params(#ec2_net_if{}=X) ->
     [
         {"DeviceIndex", X#ec2_net_if.device_index},
-        {"SubnetId",    X#ec2_net_if.subnet_id},
-        {"AssociatePublicIpAddress", X#ec2_net_if.associate_public_ip},
-        {"PrivateIpAddress", hd(X#ec2_net_if.private_ip)}
-    ] ++ erlcloud_aws:param_list(
-        [ [{"PrivateIpAddress", IP}] || IP <- tl(X#ec2_net_if.private_ip)], "PrivateIpAddresses"
-    ) ++ erlcloud_aws:param_list(X#ec2_net_if.security_group, "SecurityGroupId").
+        {"SubnetId",    X#ec2_net_if.subnet_id}
+    ]
+    ++ public_ip_params(X#ec2_net_if.associate_public_ip)
+    ++ private_ip_params(X#ec2_net_if.private_ip)
+    ++ erlcloud_aws:param_list(X#ec2_net_if.security_group, "SecurityGroupId").
 net_if_params(List, Prefix) ->
     erlcloud_aws:param_list([net_if_params(X) || X <- List], Prefix).
 

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -2751,7 +2751,7 @@ run_instances(InstanceSpec, Config)
             Error
     end.
 
-private_ip_params(undefined) -> [];
+private_ip_params([]) -> [];
 private_ip_params([HeadIP|TailIPs]) ->
     [{"PrivateIpAddress", HeadIP}|
       erlcloud_aws:param_list(


### PR DESCRIPTION
If more than one interface is specified server returns
"The associatePublicIPAddress parameter cannot be specified when
launching with multiple network interfaces"