### PR TITLE
Add compatibility source code for Erlang/OTP 19.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,13 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+{require_otp_vsn, "R14|R15|R16|17|18|19"}.
 {erl_opts,
  [debug_info,
+  {platform_define, "^R14", 'ERLANG_OTP_VERSION_14'},
+  {platform_define, "^R15", 'ERLANG_OTP_VERSION_15'},
+  {platform_define, "^R16", 'ERLANG_OTP_VERSION_16'},
+  {platform_define, "^17.", 'ERLANG_OTP_VERSION_17'},
+  {platform_define, "^18.", 'ERLANG_OTP_VERSION_18'},
+  {platform_define, "^19.", 'ERLANG_OTP_VERSION_19'},
   %% warnings_as_errors, % disabled due to disabled function
   strict_validation,
   warn_bif_clash,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,25 +1,7 @@
 %% -*- mode: erlang; -*-
-OldHash = case erlang:system_info(otp_release) of
-    [$R | _] = Release ->
-        Release =< "R15B01";
-    _  ->
-        %% As from OTP 17, the OTP release number corresponds to the major OTP version number
-        false
-end,
-Config1 = case OldHash of
-    true ->
-        HashDefine = [{d,old_hash}],
-        case lists:keysearch(erl_opts, 1, CONFIG) of
-            {value, {erl_opts, Opts}} ->
-                lists:keyreplace(erl_opts,1,CONFIG,{erl_opts,Opts++HashDefine});
-            false ->
-                CONFIG ++ [{erl_opts, HashDefine}]
-        end;
-    false -> CONFIG
-end,
 case erlang:function_exported(rebar3, main, 1) of
     true -> % rebar3
-        Config1;
+        CONFIG;
     false -> % rebar 2.x or older
         %% Use git-based deps
         %% profiles
@@ -28,5 +10,5 @@ case erlang:function_exported(rebar3, main, 1) of
                  %% {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.2.0"}}},
                  {eini, ".*", {git, "https://github.com/accense/eini.git", {tag, "1.2.1"}}},
                  {lhttpc, ".*", {git, "git://github.com/talko/lhttpc", {tag, "1.4.0"}}}]}
-         | lists:keydelete(deps, 1, Config1)]
+         | lists:keydelete(deps, 1, CONFIG)]
 end.

--- a/src/erlcloud_ddb1.erl
+++ b/src/erlcloud_ddb1.erl
@@ -292,7 +292,7 @@ update_table(Table, ReadUnits, WriteUnits, Config) ->
 -spec backoff(pos_integer()) -> ok.
 backoff(1) -> ok;
 backoff(Attempt) -> 
-    timer:sleep(random:uniform((1 bsl (Attempt - 1)) * 100)).
+    timer:sleep(erlcloud_util:rand_uniform((1 bsl (Attempt - 1)) * 100)).
 
 -type attempt() :: {attempt, pos_integer()} | {error, term()}.
 -type retry_fun() :: fun((pos_integer(), term()) -> attempt()).

--- a/src/erlcloud_ddb_impl.erl
+++ b/src/erlcloud_ddb_impl.erl
@@ -107,7 +107,7 @@ request(Config0, Operation, Json) ->
 -spec backoff(pos_integer()) -> ok.
 backoff(1) -> ok;
 backoff(Attempt) ->
-    timer:sleep(random:uniform((1 bsl (Attempt - 1)) * 100)).
+    timer:sleep(erlcloud_util:rand_uniform((1 bsl (Attempt - 1)) * 100)).
 
 %% HTTPC timeout for a request
 timeout(1, #aws_config{timeout = undefined}) ->

--- a/src/erlcloud_kinesis_impl.erl
+++ b/src/erlcloud_kinesis_impl.erl
@@ -81,7 +81,7 @@ request(Config0, Operation, Json) ->
 -spec backoff(pos_integer()) -> ok.
 backoff(1) -> ok;
 backoff(Attempt) ->
-    timer:sleep(random:uniform((1 bsl (Attempt - 1)) * 100)).
+    timer:sleep(erlcloud_util:rand_uniform((1 bsl (Attempt - 1)) * 100)).
 
 -type attempt() :: {attempt, pos_integer()} | {error, term()}.
 -type retry_fun() :: fun((pos_integer(), term()) -> attempt()).

--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -39,7 +39,7 @@ no_retry(Request) ->
 -spec backoff(pos_integer()) -> ok.
 backoff(1) -> ok;
 backoff(Attempt) ->
-    timer:sleep(random:uniform((1 bsl (Attempt - 1)) * 100)).
+    timer:sleep(erlcloud_util:rand_uniform((1 bsl (Attempt - 1)) * 100)).
 
 %% Currently matches DynamoDB retry
 %% It's likely this is too many retries for other services

--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -353,7 +353,7 @@ sdb_request_with_retry(Config, Action, Params, Try, Timeout, StartTime) ->
                     Wait = math:pow(2, Try) * 200.0,
                     %% Not exactly random since we're relying on the
                     %% calling process to hold our PRNG state.
-                    FuzzWait = random:uniform(round(Wait)),
+                    FuzzWait = erlcloud_util:rand_uniform(round(Wait)),
                     timer:sleep(FuzzWait),
                     sdb_request_with_retry(Config, Action, Params,
                                            Try + 1, Timeout, StartTime)

--- a/src/erlcloud_util.erl
+++ b/src/erlcloud_util.erl
@@ -1,6 +1,9 @@
 -module(erlcloud_util).
--export([sha_mac/2, sha256_mac/2,
-         md5/1, sha256/1]).
+-export([sha_mac/2,
+         sha256_mac/2,
+         md5/1,
+         sha256/1,
+         rand_uniform/1]).
 
 sha_mac(K, S) ->
     try
@@ -22,7 +25,25 @@ sha256_mac(K, S) ->
             crypto:hmac_final(R1)
     end.
 
--ifdef(old_hash).
+-ifdef(ERLANG_OTP_VERSION_14).
+-else.
+-ifdef(ERLANG_OTP_VERSION_15).
+-else.
+-define(ERLANG_OTP_VERSION_16_FEATURES, true).
+-ifdef(ERLANG_OTP_VERSION_16).
+-else.
+-ifdef(ERLANG_OTP_VERSION_17).
+-else.
+-ifdef(ERLANG_OTP_VERSION_18).
+-else.
+-define(ERLANG_OTP_VERSION_19_FEATURES, true).
+-endif.
+-endif.
+-endif.
+-endif.
+-endif.
+
+-ifndef(ERLANG_OTP_VERSION_16_FEATURES).
 sha256(V) ->
     crypto:sha256(V).
 -else.
@@ -30,10 +51,19 @@ sha256(V) ->
     crypto:hash(sha256, V).
 -endif.
 
--ifdef(old_hash).
+-ifndef(ERLANG_OTP_VERSION_16_FEATURES).
 md5(V) ->
     crypto:md5(V).
 -else.
 md5(V) ->
     crypto:hash(md5, V).
 -endif.
+
+-ifndef(ERLANG_OTP_VERSION_19_FEATURES).
+rand_uniform(N) ->
+    random:uniform(N).
+-else.
+rand_uniform(N) ->
+    rand:uniform(N).
+-endif.
+


### PR DESCRIPTION
* Switch to rand:uniform/1 instead of random:uniform/1 when using 19.x or higher

Please note:
* The proper dependency tag that is being used creates a hard dependency on Erlang/OTP 18.x and higher, but that can be handled by manually specifying rebar dependencies at a higher level
* This commit makes the supported Erlang/OTP versions explicit so it is easier to understand the versions supported by this dependency
