### PR TITLE
Use an explicit version

### DIFF
--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -3,7 +3,7 @@
 
 {application, erlcloud,
  [{description, "Erlang cloud computing library"},
-  {vsn, git},
+  {vsn, "0.13.4"},
   {registered, []},
   {applications, [stdlib,
                   kernel,


### PR DESCRIPTION
There are a few reasons for this change (mentioned earlier at https://github.com/erlcloud/erlcloud/pull/279#issuecomment-219836003):

1.  The use of the atom `git` is not valid .app file syntax (http://erlang.org/doc/man/app.html).
1.  Using the atom `git` instead of an explicit version string makes it more difficult to understand the version within the commit history, when examining commits.  While you can argue that as long as you know how to use git, you should be able to see what tag relates to what source code, the problem becomes more complex when the source code exists outside of this source code repository, when the tags may not be present.
1.  Having a direct relationship between the version a hex package represents and the source code repository represents is important.  So, updating the .app.src file at the same time as a hex package is created can help make sure both copies of the source code are used interchangeably at the same version, with no risk of extra changes that would defeat the purpose of having a dependable release process.
1.  Using explicit version numbers makes it easier to track the version of erlcloud being used, without random characters as a suffix.  That makes the erlcloud application look more dependable, since it should obviously have a dependable release process, if it has a dependable version number that can be referred back to within its commit history, within any copy of the source code.
1.  Requiring the .app.src file to change for a release encourages a release process, which will help to avoid incomplete changes and will promote cooperation to avoid causing errors or bugs.

Versioning is very important to make sure anything is reliable, whether it be in source code, a protocol, a schema, documentation, etc., so lets make sure the version is done in a dependable way.