### PR TITLE
add security token to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ For usage information, consult the source code and refer to the API reference at
 - http://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html
 - http://docs.amazonwebservices.com/AmazonSimpleDB/latest/DeveloperGuide/
 
+### Using Temporary Security Credentials
+
+The access to AWS resource might be managed through [third-party identity provider](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp.html). The access is managed using [temporary security credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).  
+
+You can provide your amazon credentials in environmental variables.
+
+```
+export AWS_ACCESS_KEY_ID=<Your AWS Access Key>
+export AWS_SECRET_ACCESS_KEY=<Your AWS Secret Access Key>
+export AWS_SECURITY_TOKEN=<Your AWS Security Token>
+```
+
+If you did not provide your amazon credentials in the environmental variables, then you need to provide the per-process configuration:
+
+```
+erlcloud_ec2:configure(AccessKeyId, SecretAccessKey [, Hostname]).
+erlcloud:configure(AccessKeyId, SecretAccessKey, SecurityToken).
+```
+
 ## Roadmap ##
 
 v0.8.0

--- a/src/erlcloud.erl
+++ b/src/erlcloud.erl
@@ -1,6 +1,12 @@
 -module(erlcloud).
 -export([start/0]).
 
+-export([
+    new/2, new/3,
+    configure/2, configure/3
+]).
+
+-include("erlcloud_aws.hrl").
 -define(APP, erlcloud).
 
 start() ->
@@ -8,3 +14,62 @@ start() ->
     {ok, Apps} = application:get_key(?APP, applications),
     [application:start(App) || App <- Apps],
     application:start(?APP).
+
+
+%%
+%% create new erlcloud configuration 
+-spec new(string(), string()) -> aws_config().
+
+new(AccessKeyID, SecretAccessKey) ->
+    #aws_config{
+       access_key_id=AccessKeyID,
+       secret_access_key=SecretAccessKey
+      }.
+
+-spec new(string(), string(), string()) -> aws_config().
+
+new(AccessKeyID, SecretAccessKey, SecurityToken) ->
+    #aws_config{
+       access_key_id=AccessKeyID,
+       secret_access_key=SecretAccessKey,
+       security_token=SecurityToken
+      }.
+
+%%
+%% global erlcloud configuration
+-spec configure(string(), string()) -> ok.
+
+configure(AccessKeyID, SecretAccessKey) ->
+    case get(aws_config) of
+        undefined ->
+            put(aws_config, new(AccessKeyID, SecretAccessKey)),
+            ok;
+        #aws_config{} = Conf ->
+            put(aws_config, 
+                Conf#aws_config{
+                    access_key_id=AccessKeyID,
+                    secret_access_key=SecretAccessKey
+                }
+            ),
+            ok
+    end.
+
+-spec configure(string(), string(), string()) -> ok.
+
+configure(AccessKeyID, SecretAccessKey, SecurityToken) ->
+    case get(aws_config) of
+        undefined ->
+            put(aws_config, new(AccessKeyID, SecretAccessKey, SecurityToken)),
+            ok;
+        #aws_config{} = Conf ->
+            put(aws_config, 
+                Conf#aws_config{
+                    access_key_id=AccessKeyID,
+                    secret_access_key=SecretAccessKey,
+                    security_token=SecurityToken
+                }
+            ),
+            ok
+    end.
+
+

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -233,8 +233,13 @@ default_config() ->
                                   false -> undefined;
                                   SAC -> SAC
                               end,
+            SecurityToken = case os:getenv("AWS_SECURITY_TOKEN") of
+                                false -> undefined;
+                                SeT -> SeT
+                            end,
             #aws_config{access_key_id = AccessKeyId,
-                        secret_access_key = SecretAccessKey};
+                        secret_access_key = SecretAccessKey,
+                        security_token = SecurityToken};
         Config ->
             Config
     end.


### PR DESCRIPTION
_WHY_

The access to AWS resource might be managed through [third-party identity provider](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp.html). The access is managed using [temporary security credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html). 

`erlcloud_aws:update_config(...)` is capable to update `access_key_id`, `secret_access_key` and `security_token` using instance meta-data. However, instance meta-data might not be available at development environments (outside of AWS).

We need to support API to define `AccessKeyID`, `SecretAccessKey` and  `SecurityToken` programmatically. 

_WHAT_

1. The support of `AWS_SECURITY_TOKEN` environment variable is added.

2. The `#aws_config{}` declaration is defined at `erlcloud` that provides a "service" agnostic definition of keys. This api allows also rotation of keys stored at process dictionary. 

