### PR TITLE
Fix a bug of erlcloud_http:url_encode/1 according to RFC 3629

### DIFF
--- a/src/erlcloud_http.erl
+++ b/src/erlcloud_http.erl
@@ -59,12 +59,12 @@ url_encode_loose([Char|String], Accum)
   when Char >=0, Char =< 255 ->
     url_encode_loose(String, [hex_char(Char rem 16), hex_char(Char div 16), $% | Accum]).
 
-utf8_encode_char(Char) when Char > 16#7FFF, Char =< 16#7FFFF ->
+utf8_encode_char(Char) when Char > 16#FFFF, Char =< 16#10FFFF ->
     encode_char(Char band 16#3F + 16#80)
       ++ encode_char((16#3F band (Char bsr 6)) + 16#80)
       ++ encode_char((16#3F band (Char bsr 12)) + 16#80)
       ++ encode_char((Char bsr 18) + 16#F0);
-utf8_encode_char(Char) when Char > 16#7FF, Char =< 16#7FFF ->
+utf8_encode_char(Char) when Char > 16#7FF, Char =< 16#FFFF ->
     encode_char(Char band 16#3F + 16#80)
       ++ encode_char((16#3F band (Char bsr 6)) + 16#80)
       ++ encode_char((Char bsr 12) + 16#E0);
@@ -72,7 +72,7 @@ utf8_encode_char(Char) when Char > 16#7F, Char =< 16#7FF ->
     encode_char(Char band 16#3F + 16#80)
       ++ encode_char((Char bsr 6) + 16#C0);
 utf8_encode_char(Char) when Char =< 16#7F ->
-  encode_char(Char).
+    encode_char(Char).
 
 encode_char(Char) ->
   [hex_char(Char rem 16), hex_char(Char div 16), $%].


### PR DESCRIPTION
According to [RFC 3629](https://tools.ietf.org/html/rfc3629):
> ```
> Char. number range  |        UTF-8 octet sequence
>    (hexadecimal)    |              (binary)
> --------------------+---------------------------------------------
> 0000 0000-0000 007F | 0xxxxxxx
> 0000 0080-0000 07FF | 110xxxxx 10xxxxxx
> 0000 0800-0000 FFFF | 1110xxxx 10xxxxxx 10xxxxxx
> 0001 0000-0010 FFFF | 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
> ```

fixed the bug reported in #296.