### PR TITLE
cleanup couple gaps of previous merges

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -9,6 +9,6 @@ case erlang:function_exported(rebar3, main, 1) of
                  {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
                  %% {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.2.0"}}},
                  {eini, ".*", {git, "https://github.com/erlcloud/eini.git", {tag, "1.2.3"}}},
-                 {lhttpc, ".*", {git, "git://github.com/talko/lhttpc", {tag, "1.4.0"}}}]}
+                 {lhttpc, ".*", {git, "git://github.com/erlcloud/lhttpc", {tag, "1.4.0"}}}]}
          | lists:keydelete(deps, 1, CONFIG)]
 end.

--- a/src/erlcloud_ec2_meta.erl
+++ b/src/erlcloud_ec2_meta.erl
@@ -1,7 +1,7 @@
 -module(erlcloud_ec2_meta).
 
 -include("erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud_aws.hrl").
 
 -export([get_instance_metadata/0, get_instance_metadata/1, get_instance_metadata/2,
         get_instance_user_data/0, get_instance_user_data/1,


### PR DESCRIPTION
Problem:
- rebar3 uses our fork , rebar2 still tries to use talk. they are identical but we need to be consistent.
- include_lib from one PRs

Solution:
just fix it. 

@nalundgaard @waisbrot fyi.  this is cosmetics but still