### PR TITLE
clean include_libs further

### DIFF
--- a/test/erlcloud_as_tests.erl
+++ b/test/erlcloud_as_tests.erl
@@ -1,7 +1,7 @@
 -module(erlcloud_as_tests).
 -include_lib("eunit/include/eunit.hrl").
 -include("erlcloud_as.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud_aws.hrl").
 
 %% Some simple unit tests for autoscaling functions.
 %% These mostly just test correct parsing based on the AWS sample documents.

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -1,6 +1,6 @@
 -module(erlcloud_aws_tests).
 
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud_aws.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 request_test_() ->

--- a/test/erlcloud_cloudtrail_tests.erl
+++ b/test/erlcloud_cloudtrail_tests.erl
@@ -2,7 +2,7 @@
 -module(erlcloud_cloudtrail_tests).
 -include_lib("eunit/include/eunit.hrl").
 -include("erlcloud.hrl").
--include_lib("../include/erlcloud_aws.hrl").
+-include("erlcloud_aws.hrl").
 
 %% Unit tests for cloudtrail.
 %% These tests work by using meck to mock erlcloud_httpc. 

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -2,7 +2,7 @@
 -module(erlcloud_iam_tests).
 -include_lib("eunit/include/eunit.hrl").
 -include("erlcloud.hrl").
--include_lib("../include/erlcloud_aws.hrl").
+-include("erlcloud_aws.hrl").
 
 %% Unit tests for iam.
 %% These tests work by using meck to mock erlcloud_httpc. There are two classes of test: input and output.

--- a/test/erlcloud_sns_tests.erl
+++ b/test/erlcloud_sns_tests.erl
@@ -2,7 +2,7 @@
 -module(erlcloud_sns_tests).
 -include_lib("eunit/include/eunit.hrl").
 % -include("erlcloud.hrl").
--include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include("erlcloud_aws.hrl").
 
 %% Unit tests for sns.
 %% These tests work by using meck to mock httpc. There are two classes of test: input and output.

--- a/test/erlcloud_waf_tests.erl
+++ b/test/erlcloud_waf_tests.erl
@@ -1,7 +1,7 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 -module(erlcloud_waf_tests).
 -include_lib("eunit/include/eunit.hrl").
--include_lib("include/erlcloud_waf.hrl").
+-include("erlcloud_waf.hrl").
 
 %% Unit tests for erlcloud_waf.
 %% These tests work by using meck to mock erlcloud_httpc. There are two classes of test: input and output.


### PR DESCRIPTION
follow up of #309 where more
```erlang
-include_lib("../include/erlcloud_aws.hrl").
-include_lib("erlcloud/include/erlcloud_aws.hrl").
```
found.

