### PR TITLE
Travis configuration for automatically publishing releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ otp_release:
   - 18.1
   - 19.0
 env:
+  global:
+  - MAIN_OTP = 19.0
+  matrix:
   - FORCE_REBAR2=true
   - FORCE_REBAR2=false PATH=$PATH:$PWD
 branches:
@@ -14,3 +17,10 @@ branches:
 install:
   - make travis-install
 script: make eunit
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: make travis-publish
+  on:
+    tags: true
+    condition: $FORCE_REBAR2 = false && $TRAVIS_OTP_RELEASE = $MAIN_OTP

--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,22 @@ else
 	wget https://s3.amazonaws.com/rebar3/rebar3
 	chmod a+x rebar3
 endif
+
+travis-publish:
+	@echo Create directories
+	mkdir -p ~/.hex
+	mkdir -p ~/.config/rebar3
+
+	@echo Decrypt secrets
+	@openssl aes-256-cbc -K $encrypted_9abc06b32f03_key -iv $encrypted_9abc06b32f03_iv -in hex.config.enc -out ~/.hex/hex.config -d
+
+	@echo Create global config
+	echo '{plugins, [rebar3_hex]}.' > ~/.config/rebar3/rebar.config
+
+	@echo Edit version tag in app.src
+	vi -e -c '%s/{vsn, *.*}/{vsn, "'${TRAVIS_TAG}'"}/g|w|q' src/dogstatsd.app.src
+
+	@echo Publish to Hex
+	echo 'Y' | ./vendor/rebar3 hex publish
+
+	@echo Done

--- a/hex.config.enc
+++ b/hex.config.enc
@@ -1,0 +1,1 @@
+ëb›ïaLã~‹©°3E]5+Æ!é³ºƒ›ÒÓ™ÖéÂÑ!¿Pnm6ñLfDR!P¾™‹"Ârý¶ä‰ûÃâšõZ‰"p"6y“Ó[÷Ì


### PR DESCRIPTION
When a build is tagged, after tests pass for the "main" build (Erlang 19 + Rebar3), this attmpts to publish the tag to Hex.

Hopefully this makes #313 not happen again.

This is configured to use my credentials. We can swap in someone else's or a bot's pretty easily.

I mostly copied this from another project of mine where it's working, but it's painful to debug if it doesn't work the first time (because you have to keep publishing releases).