### PR TITLE
Adjust the branches/only property to include anything that looks like a semver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 branches:
   only:
     - master
+    - /^[0-9]+\.[0-9]+\.[0-9]+/
 install:
   - make travis-install
 script: make eunit


### PR DESCRIPTION
#314 didn't produce a Travis build when @motobob tagged it. I think this is why: the "branches" property is really refs and so Travis doesn't see the tag as a build candidate. On my other project, I don't limit to building one branch and that's the only difference I'm seeing.

Unless you want to tag another release to try again, we should just manually push 0.13.9.