### PR TITLE
Another try at automatic Hex deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ otp_release:
   - 19.0
 env:
   global:
-  - MAIN_OTP = 19.0
+  - MAIN_OTP=19.0
   matrix:
   - FORCE_REBAR2=true
   - FORCE_REBAR2=false PATH=$PATH:$PWD


### PR DESCRIPTION
It was close to working already, but the spaces around the `=` in environment variable assignment made Travis skip deploying on _all_ branches when I'd only meant to skip everything but 19.0.