### PR TITLE
IMPORTANT: update on proposed library roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,75 @@
-# erlcloud: Cloud Computing APIs For Erlang #
+# erlcloud: AWS APIs library for Erlang #
 
 [![Build Status](https://secure.travis-ci.org/erlcloud/erlcloud.png?branch=master)](http://travis-ci.org/erlcloud/erlcloud)
 
-Service APIs implemented:
+This library is not developed or maintained by AWS thus lots of functionality is still missing comparing to [aws-cli](https://aws.amazon.com/cli/) or [boto](https://github.com/boto/boto).
+Required functionality is being added upon request.
 
+Service APIs implemented:
 - Amazon Elastic Compute Cloud (EC2)
 - Amazon Simple Storage Service (S3)
 - Amazon Simple Queue Service (SQS)
-- Amazon SimpleDB
-- Amazon Mechanical Turk
-- Amazon CloudWatch (MON)
-- Amazon DynamoDB (ddb2) 
+- Amazon DynamoDB & DDB streams (ddb2)
+- Amazon Autoscalling(as)
+- Amazon CloudTrail (CT)
+- Cloud Formation (CFN)
+- ElasticLoadBalancing (ELB)
+- Identity and Access Management (IAM)
+- Kinesis
+- CloudWatch
+- MechanicalTurk
+- Simple DB (SDB)
+- Relational Data Service (RDS)
+- Simple Email Service (SES)
+- Short Token Service (STS)
+- Simple Notification Service (SNS)
+- Web Application Firewall (WAF)
+- and more to come
 
-All API functions have been implemented.  Not all functions have been thoroughly tested, so exercise care when integrating this library into production code.  Please send bug reports and patches.
+Majority of API functions have been implemented.
+Not all functions have been thoroughly tested, so exercise care when integrating this library into production code.
+Please send issues and patches.
 
-The libraries can be used two ways: either you can specify configuration parameters in the process dictionary, or you can create a configuration object and pass that to each request as the final parameter.
+The libraries can be used two ways:
+- either you can specify configuration parameters in the process dictionary. Useful for simple tasks
+- you can create a configuration object and pass that to each request as the final parameter. Useful for Cross AWS Account access
+
+## Roadmap ##
+
+Below is the proposed library roadmap update along with regular features and fixes.
+
+- 0.13.10
+ * Existing code
+
+- 2.0.X
+ * Going further we would like to merge in [Alert Logic](https://github.com/alertlogic/erlcloud/tree/v1.2.3) fork into upstream.
+ This is a major version bump which contains lots of new features and functionality.
+ Unfortunately, it also contains quite a number of low level APIs incompatibilities since the fork diverged for a long while.
+ Making it backward compatible does not seem feasible and valuable at the moment.
+ * No APIs have been removed and it's on branched of 0.13.10 at the moment. Any minor version delta added during notice time will be compensated before the merge.
+ * intentionally jumping to 2.0.X as AL fork has v1.0.X
+
+- 2.1.X
+ * fix dialyzer findings and make it mandatory for the library
+ * make full support of Mix/HEX
+
+- 2.2.X
+  * Further deprecation of legacy functionality
+  * remove R14/R15 support.
+  * Only SigV4 signing and generalised in one module. Keep SigV2 in SBD section only
+  * TBD: no more `erlang:error()` use and use of regular tuples as error API.
+
+### Major API compatability changes between 0.13.X and 2.0.x
+ - ELB APIs
+ - ... list to be filled shortly
 
 ## Getting started ##
-You need to clone the repository and download rebar (if it's not already available in your path).
-
+You need to clone the repository and download rebar/rebar3 (if it's not already available in your path).
 ```
 git clone https://github.com/erlcloud/erlcloud.git
 cd erlcloud
-wget http://cloud.github.com/downloads/basho/rebar/rebar && chmod u+x rebar
-```
-
-You can provide your amazon credentials in environmental variables.
-
-```
-export AWS_ACCESS_KEY_ID=<Your AWS Access Key>
-export AWS_SECRET_ACCESS_KEY=<Your AWS Secret Access Key>
+wget https://s3.amazonaws.com/rebar3/rebar3
+chmod a+x rebar3
 ```
 To compile and run erlcloud
 ```
@@ -37,39 +77,62 @@ make
 make run
 ```
 
-If you're using erlcloud in your application, add it as a dependency in your application's configuration file.  To use erlcloud in the shell, you can start it by calling:
+If you're using erlcloud in your application, add it as a dependency in your application's configuration file.
+To use erlcloud in the shell, you can start it by calling:
 
 ```
-ssl:start().
-erlcloud:start().
+application:ensure_all_started(erlcloud).
 ```
+### Using Temporary Security Credentials
 
+The access to AWS resource might be managed through [third-party identity provider](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp.html).
+The access is managed using [temporary security credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).
 
+You can provide your amazon credentials in environmental variables
+
+```
+export AWS_ACCESS_KEY_ID=<Your AWS Access Key>
+export AWS_SECRET_ACCESS_KEY=<Your AWS Secret Access Key>
+export AWS_SECURITY_TOKEN=<Your AWS Security Token>
+```
+If you did not provide your amazon credentials in the environmental variables, then you need to provide configuration read from your profile:
+```
+{ok, Conf} = erlcloud_aws:profile().
+erlcloud_s3:list_buckets(Conf).
+```
+### Using Access Key ###
+You can provide your amazon credentials in environmental variables.
+```
+export AWS_ACCESS_KEY_ID=<Your AWS Access Key>
+export AWS_SECRET_ACCESS_KEY=<Your AWS Secret Access Key>
+```
 If you did not provide your amazon credentials in the environmental variables, then you need to provide the per-process configuration:
-
 ```
 erlcloud_ec2:configure(AccessKeyId, SecretAccessKey [, Hostname]).
 ```
-
-Hostname defaults to "ec2.amazonaws.com".
-
-
-Then you can start making api calls, like:
-
-```
-erlcloud_ec2:describe_images().
-erlcloud_s3:list_buckets().
-```
+Hostname defaults to non-existing `"ec2.amazonaws.com"` intentionally to avoid mix with US-East-1
+Refer to [aws_config](https://github.com/erlcloud/erlcloud/blob/master/include/erlcloud_aws.hrl) for full description of all services configuration.
 
 Configuration object usage:
-
 ```
 EC2 = erlcloud_ec2:new(AccessKeyId, SecretAccessKey [, Hostname])
 erlcloud_ec2:describe_images(EC2).
 ```
 
-Creating an EC2 instance may look like this:
+### Basic use ###
+Then you can start making api calls, like:
 ```
+erlcloud_ec2:describe_images().
+% list buckets of Account stored in config in process dict
+% of of the account you are running in.
+erlcloud_s3:list_buckets().
+erlcloud_s3:list_buckets(erlcloud_aws:default_cfg()).
+% List buckets on 3d Account from Conf
+erlcloud_s3:list_buckets(Conf).
+```
+
+Creating an EC2 instance may look like this:
+```erlang
 start_instance(Ami, KeyPair, UserData, Type, Zone) ->
     Config = #aws_config{
             access_key_id = application:get_env(aws_key),
@@ -84,43 +147,14 @@ start_instance(Ami, KeyPair, UserData, Type, Zone) ->
     erlcloud_ec2:run_instances(InstanceSpec, Config).
 ```
 
-For usage information, consult the source code and refer to the API reference at:
+For usage information, consult the source code and https://hexdocs.pm/erlcloud.
+For detailed API description refer to the AWS references at:
 
 - http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html
 - http://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html
-- http://docs.amazonwebservices.com/AmazonSimpleDB/latest/DeveloperGuide/
-
-### Using Temporary Security Credentials
-
-The access to AWS resource might be managed through [third-party identity provider](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp.html). The access is managed using [temporary security credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).  
-
-You can provide your amazon credentials in environmental variables.
-
-```
-export AWS_ACCESS_KEY_ID=<Your AWS Access Key>
-export AWS_SECRET_ACCESS_KEY=<Your AWS Secret Access Key>
-export AWS_SECURITY_TOKEN=<Your AWS Security Token>
-```
-
-
-If you did not provide your amazon credentials in the environmental variables, then you need to provide configuration read from your profile:
-
-```
-{ok, Conf} = erlcloud_aws:profile().
-erlcloud_s3:list_buckets(Conf).
-```
-
-## Roadmap ##
-
-v0.8.0
-* Existing code
-
-v0.9.0
-* Make unit tests useful and improve documentation
-
-v1.0.0
-* Refactored code for better return values (issue #7)
+- and other services https://aws.amazon.com/documentation/
 
 ## Notes ##
 
-Indentation in contributions should follow indentation style of surrounding text. In general it follows default indentation rules of official erlang-mode as provided by OTP team.
+Indentation in contributions should follow indentation style of surrounding text.
+In general it follows default indentation rules of official erlang-mode as provided by OTP team.

--- a/package.exs
+++ b/package.exs
@@ -1,5 +1,5 @@
 Expm.Package.new(name: "erlcloud", description: "Cloud Computing library for Erlang (Amazon EC2, S3, SQS, SimpleDB, Mechanical Turk, ELB) ",
-                 version: "0.13.1", keywords: ["cloud", "api", "amazon", "ec2", "s3", "sqs"],
+                 version: "0.13.9", keywords: ["cloud", "api", "amazon", "ec2", "s3", "sqs"],
                  maintainers: [[name: "Gleb Peregud",
                                 email: "gleber.p@gmail.com"]],
-                 repositories: [[github: "gleber/erlcloud"]])
+                 repositories: [[github: "erlcloud/erlcloud"]])


### PR DESCRIPTION
Hello Erlcloud community, 

The library has significantly diverged between the forks and we would like to fix this situation especially given the fact that upstream is missing quite a number or major functionality.

It's not a secret that upstream and Alert Logic forks are mostly maintained by the same set of people. Therefore, we would like to propose a library major revision update which will be basically almost as FF merge to https://github.com/alertlogic/erlcloud 
Please refer to Roadmap section of Readme for details.

This will bring lots of stuff (Initial attempt was back at #215 ):
- Full support for SigV4 across all modules. According to AWS, all services support SigV4 in all regions and only a few still have SigV2 therefore SigV2 funs were not removed if smb still needs them
- S3 follow redirect option was added
- KMS update, basically reworked #182
- DirectConnect described APIs added
- RDS APIs added
- Redshift API
- Route53 added
- erlcloud_autoscalling added along with some edits erlcloud_as to have backward compatibility
- Large number of maintenance defect fixes here and there
- enhancements to DDB2, EC2 (adding all the gateways) and Kinesis
- enriching ELB APIs
- Adding AWS Inspector API
- adding more testing

**Note**: 
- No API modules or functions were removed, our fork only adds or updates the APIs. 
- Several APIs, like ELB have minor incompatibilities.

@smilerlee @waisbrot @nalundgaard @ptrakhtman @okeuday @ddosia @fogfish please weigh in.

Unless I hear back extremely negative feedback with detailed explanation of blockers, I'll perform this in by Oct20, IMO two weeks warning should be enough. 

P.S: "my application is pinned to master branch" is not accepted as a reasonable excuse for not progressing the library further. 