### PR TITLE
fix: if response has empty map({})

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -640,7 +640,9 @@ undynamize_value({<<"M">>, Map}, Opts) ->
 
 -spec undynamize_attr(json_attr(), undynamize_opts()) -> out_attr().
 undynamize_attr({Name, [ValueJson]}, Opts) ->
-    {Name, undynamize_value(ValueJson, Opts)}.
+    {Name, undynamize_value(ValueJson, Opts)};
+undynamize_attr({}, _) ->
+    {}.
 
 -spec undynamize_object(fun((json_pair(), undynamize_opts()) -> A), 
                         [json_pair()] | [{}], undynamize_opts()) -> [A].


### PR DESCRIPTION
Example:

```json
[
  {
    "a": {
      "b": {
        "c": 0,
        "d": 0,
        "e": 1
      }
    }
  },
  {
    "a": {} //here
  }
]
```