### PR TITLE
erlcloud_ddb2: Add support for storing and reading empty map attributes

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -388,6 +388,9 @@ dynamize_value({bs, Value}) when is_list(Value) ->
 
 dynamize_value({l, Value}) when is_list(Value) ->
     {<<"L">>, [[dynamize_value(V)] || V <- Value]};
+dynamize_value({m, []}) ->
+    %% jsx represents empty objects as [{}]
+    {<<"M">>, [{}]};
 dynamize_value({m, Value}) when is_list(Value) ->
     {<<"M">>, [dynamize_attr(Attr) || Attr <- Value]};
 
@@ -635,6 +638,9 @@ undynamize_value({<<"BS">>, Values}, _) ->
     [base64:decode(Value) || Value <- Values];
 undynamize_value({<<"L">>, List}, Opts) ->
     [undynamize_value(Value, Opts) || [Value] <- List];
+undynamize_value({<<"M">>, [{}]}, _Opts) ->
+    %% jsx returns [{}] for empty objects
+    [];
 undynamize_value({<<"M">>, Map}, Opts) ->
     [undynamize_attr(Attr, Opts) || Attr <- Map].
 
@@ -682,6 +688,9 @@ undynamize_value_typed({<<"BS">>, Values}, _) ->
     {bs, [base64:decode(Value) || Value <- Values]};
 undynamize_value_typed({<<"L">>, List}, Opts) ->
     {l, [undynamize_value_typed(Value, Opts) || [Value] <- List]};
+undynamize_value_typed({<<"M">>, [{}]}, _Opts) ->
+    %% jsx returns [{}] for empty objects
+    {m, []};
 undynamize_value_typed({<<"M">>, Map}, Opts) ->
     {m, [undynamize_attr_typed(Attr, Opts) || Attr <- Map]}.
 

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -206,9 +206,9 @@ input_exception_test_() ->
 error_handling_tests(_) ->
     OkResponse = httpc_response(200, "
 {\"Item\":
-	{\"friends\":{\"SS\":[\"Lynda\", \"Aaron\"]},
-	 \"status\":{\"S\":\"online\"}
-	},
+    {\"friends\":{\"SS\":[\"Lynda\", \"Aaron\"]},
+     \"status\":{\"S\":\"online\"}
+    },
 \"ConsumedCapacityUnits\": 1
 }"                                   
                                   ),
@@ -2005,16 +2005,19 @@ get_item_output_tests(_) ->
          ?_ddb_test(
             {"GetItem test all attribute types", "
 {\"Item\":
-	{\"ss\":{\"SS\":[\"Lynda\", \"Aaron\"]},
-	 \"ns\":{\"NS\":[\"12\",\"13.0\",\"14.1\"]},
-	 \"bs\":{\"BS\":[\"BbY=\"]},
-	 \"es\":{\"SS\":[]},
-	 \"s\":{\"S\":\"Lynda\"},
-	 \"n\":{\"N\":\"12\"},
-	 \"f\":{\"N\":\"12.34\"},
-	 \"b\":{\"B\":\"BbY=\"},
-	 \"empty\":{\"S\":\"\"}
-	}
+    {\"ss\":{\"SS\":[\"Lynda\", \"Aaron\"]},
+     \"ns\":{\"NS\":[\"12\",\"13.0\",\"14.1\"]},
+     \"bs\":{\"BS\":[\"BbY=\"]},
+     \"es\":{\"SS\":[]},
+     \"s\":{\"S\":\"Lynda\"},
+     \"n\":{\"N\":\"12\"},
+     \"f\":{\"N\":\"12.34\"},
+     \"b\":{\"B\":\"BbY=\"},
+     \"l\":{\"L\":[{\"S\":\"Listen\"},{\"S\":\"Linda\"}]},
+     \"m\":{\"M\":{\"k\": {\"S\": \"v\"}}},
+     \"empty_string\":{\"S\":\"\"},
+     \"empty_map\":{\"M\":{}}
+    }
 }",
              {ok, #ddb2_get_item{
                      item = [{<<"ss">>, [<<"Lynda">>, <<"Aaron">>]},
@@ -2025,7 +2028,10 @@ get_item_output_tests(_) ->
                              {<<"n">>, 12},
                              {<<"f">>, 12.34},
                              {<<"b">>, <<5,182>>},
-                             {<<"empty">>, <<>>}],
+                             {<<"l">>, [<<"Listen">>, <<"Linda">>]},
+                             {<<"m">>, [{<<"k">>, <<"v">>}]},
+                             {<<"empty_string">>, <<>>},
+                             {<<"empty_map">>, []}],
                     consumed_capacity = undefined}}}),
          ?_ddb_test(
             {"GetItem item not found", 
@@ -2044,16 +2050,19 @@ get_item_output_typed_tests(_) ->
         [?_ddb_test(
             {"GetItem typed test all attribute types", "
 {\"Item\":
-	{\"ss\":{\"SS\":[\"Lynda\", \"Aaron\"]},
-	 \"ns\":{\"NS\":[\"12\",\"13.0\",\"14.1\"]},
-	 \"bs\":{\"BS\":[\"BbY=\"]},
-	 \"es\":{\"SS\":[]},
-	 \"s\":{\"S\":\"Lynda\"},
-	 \"n\":{\"N\":\"12\"},
-	 \"f\":{\"N\":\"12.34\"},
-	 \"b\":{\"B\":\"BbY=\"},
-	 \"empty\":{\"S\":\"\"}
-	}
+    {\"ss\":{\"SS\":[\"Lynda\", \"Aaron\"]},
+     \"ns\":{\"NS\":[\"12\",\"13.0\",\"14.1\"]},
+     \"bs\":{\"BS\":[\"BbY=\"]},
+     \"es\":{\"SS\":[]},
+     \"s\":{\"S\":\"Lynda\"},
+     \"n\":{\"N\":\"12\"},
+     \"f\":{\"N\":\"12.34\"},
+     \"b\":{\"B\":\"BbY=\"},
+     \"l\":{\"L\":[{\"S\":\"Listen\"},{\"S\":\"Linda\"}]},
+     \"m\":{\"M\":{\"k\": {\"S\": \"v\"}}},
+     \"empty_string\":{\"S\":\"\"},
+     \"empty_map\":{\"M\":{}}
+    }
 }",
              {ok, #ddb2_get_item{
                      item = [{<<"ss">>, {ss, [<<"Lynda">>, <<"Aaron">>]}},
@@ -2064,7 +2073,10 @@ get_item_output_typed_tests(_) ->
                              {<<"n">>, {n, 12}},
                              {<<"f">>, {n, 12.34}},
                              {<<"b">>, {b, <<5,182>>}},
-                             {<<"empty">>, {s, <<>>}}],
+                             {<<"l">>, {l, [{s, <<"Listen">>}, {s, <<"Linda">>}]}},
+                             {<<"m">>, {m, [{<<"k">>, {s, <<"v">>}}]}},
+                             {<<"empty_string">>, {s, <<>>}},
+                             {<<"empty_map">>, {m, []}}],
                     consumed_capacity = undefined}}})
         ],
     
@@ -2237,7 +2249,8 @@ put_item_input_tests(_) ->
                                         {<<"map_value">>, {m, [
                                             {<<"key1">>, "value1"},
                                             {<<"key2">>, {l, ["list_string1", "list_string2"]}}
-                                        ]}}
+                                        ]}},
+                                        {<<"empty_map_value">>, {m, []}}
                                        ])), "
 {
     \"TableName\": \"Table\",
@@ -2258,7 +2271,8 @@ put_item_input_tests(_) ->
                 {\"S\": \"list_string1\"},
                 {\"S\": \"list_string2\"}
             ]}
-        }}
+        }},
+        \"empty_map_value\": {\"M\": {}}
     }
 }"
             })
@@ -2349,7 +2363,8 @@ put_item_output_tests(_) ->
                 {\"S\": \"list_string1\"},
                 {\"S\": \"list_string2\"}
             ]}
-        }}
+        }},
+        \"empty_map_value\": {\"M\": {}}
     }
 }",
 
@@ -2361,7 +2376,8 @@ put_item_output_tests(_) ->
                                    {<<"map_value">>, [
                                        {<<"key1">>, <<"value1">>},
                                        {<<"key2">>, [<<"list_string1">>, <<"list_string2">>]}
-                                   ]}
+                                   ]},
+                                   {<<"empty_map_value">>, []}
                                   ]
                      }}})
         ],
@@ -2561,23 +2577,23 @@ q_output_tests(_) ->
     \"ScannedCount\": 3
 }",
              {ok, #ddb2_q{count = 3,
-                         items = [[{<<"LastPostedBy">>, <<"fred@example.com">>},
-                                   {<<"ForumName">>, <<"Amazon DynamoDB">>},
-                                   {<<"LastPostDateTime">>, <<"20130102054211">>},
-                                   {<<"Tags">>, [<<"Problem">>,<<"Question">>]}],
-                                  [{<<"LastPostedBy">>, <<"alice@example.com">>},
-                                   {<<"ForumName">>, <<"Amazon DynamoDB">>},
-                                   {<<"LastPostDateTime">>, <<"20130105111307">>},
-                                   {<<"Tags">>, [<<"Idea">>]}],
-                                  [{<<"LastPostedBy">>, <<"bob@example.com">>},
-                                   {<<"ForumName">>, <<"Amazon DynamoDB">>},
-                                   {<<"LastPostDateTime">>, <<"20130108094417">>},
-                                   {<<"Tags">>, [<<"AppDesign">>, <<"HelpMe">>]}]],
-                         consumed_capacity =
-                             #ddb2_consumed_capacity{
-                                capacity_units = 2,
-                                table_name = <<"Thread">>},
-		                 scanned_count = 3}}}),
+                          items = [[{<<"LastPostedBy">>, <<"fred@example.com">>},
+                                    {<<"ForumName">>, <<"Amazon DynamoDB">>},
+                                    {<<"LastPostDateTime">>, <<"20130102054211">>},
+                                    {<<"Tags">>, [<<"Problem">>,<<"Question">>]}],
+                                   [{<<"LastPostedBy">>, <<"alice@example.com">>},
+                                    {<<"ForumName">>, <<"Amazon DynamoDB">>},
+                                    {<<"LastPostDateTime">>, <<"20130105111307">>},
+                                    {<<"Tags">>, [<<"Idea">>]}],
+                                   [{<<"LastPostedBy">>, <<"bob@example.com">>},
+                                    {<<"ForumName">>, <<"Amazon DynamoDB">>},
+                                    {<<"LastPostDateTime">>, <<"20130108094417">>},
+                                    {<<"Tags">>, [<<"AppDesign">>, <<"HelpMe">>]}]],
+                          consumed_capacity =
+                              #ddb2_consumed_capacity{
+                                 capacity_units = 2,
+                                 table_name = <<"Thread">>},
+                          scanned_count = 3}}}),
          ?_ddb_test(
             {"Query example 2 response", "
 {


### PR DESCRIPTION
This is a remake of erlcloud/erlcloud#321

It solves the problem per @smilerlee’s suggestion, along with an amendment to cover the cases in the unit tests.

A live example:
```erlang
1> application:ensure_all_started(erlcloud).
{ok,[xmerl,eini,jsx,lhttpc,erlcloud]}
2> rr("include/erlcloud_ddb2.hrl").
[ddb2_batch_get_item,ddb2_batch_get_item_response,
 ddb2_batch_write_item,ddb2_consumed_capacity,
 ddb2_create_table,ddb2_delete_item,ddb2_delete_table,
 ddb2_describe_limits,ddb2_describe_table,ddb2_error,
 ddb2_get_item,ddb2_global_secondary_index_description,
 ddb2_item_collection_metrics,ddb2_list_tables,
 ddb2_local_secondary_index_description,
 ddb2_provisioned_throughput_description,ddb2_put_item,
 ddb2_q,ddb2_scan,ddb2_table_description,ddb2_update_item,
 ddb2_update_table]
3>
3> Table = <<"nlundgaard-test-table">>.
<<"nlundgaard-test-table">>
4> erlcloud_ddb2:create_table(Table, [{<<"name">>, s}], <<"name">>, 2, 2).
{ok,#ddb2_table_description{
        attribute_definitions = [{<<"name">>,s}],
        creation_date_time = 1475891256.495,
        global_secondary_indexes = undefined,item_count = 0,
        key_schema = <<"name">>,latest_stream_arn = undefined,
        latest_stream_label = undefined,
        local_secondary_indexes = undefined,
        provisioned_throughput =
            #ddb2_provisioned_throughput_description{
                last_decrease_date_time = undefined,
                last_increase_date_time = undefined,
                number_of_decreases_today = 0,read_capacity_units = 2,
                write_capacity_units = 2},
        stream_specification = undefined,
        table_arn =
            <<"arn:aws:dynamodb:us-east-1:948063967832:table/nlundgaard-tes"...>>,
        table_name = <<"nlundgaard-test-table">>,
        table_size_bytes = 0,table_status = creating}}
5> erlcloud_ddb2:put_item(Table, [{<<"name">>, <<"map_test">>}, {<<"map">>, {m, []}}]).
{ok,[]}
6> erlcloud_ddb2:get_item(Table, [{<<"name">>, <<"map_test">>}]).
{ok,[{<<"name">>,<<"map_test">>},{<<"map">>,[]}]}
7> erlcloud_ddb2:get_item(Table, [{<<"name">>, <<"map_test">>}], [{out, typed_record}]).
{ok,#ddb2_get_item{item = [{<<"name">>,{s,<<"map_test">>}},
                           {<<"map">>,{m,[]}}],
                   consumed_capacity = undefined}}
```