### PR TITLE
Feature/support sts use

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -92,7 +92,9 @@
           retry=fun erlcloud_retry:no_retry/1::erlcloud_retry:retry_fun(),
           %% Currently matches DynamoDB retry
           %% It's likely this is too many retries for other services
-          retry_num=10::non_neg_integer()
+          retry_num=10::non_neg_integer(),
+          assume_role = [] :: proplists:proplist() %% If a role to be assumed is given
+          %% then we will try to assume the role during the update_config
          }).
 -type(aws_config() :: #aws_config{}).
 

--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -1,3 +1,12 @@
+-record(aws_assume_role,{
+    role_arn :: string() | undefined,
+    session_name = "erlcloud" :: string(),
+    duration_secs =  900 :: 900..3600,
+    external_id :: string() | undefined
+}).
+
+-type(aws_assume_role() :: #aws_assume_role{}).
+
 -record(aws_config, {
           as_host="autoscaling.amazonaws.com"::string(),
           ec2_host="ec2.amazonaws.com"::string(),
@@ -93,7 +102,7 @@
           %% Currently matches DynamoDB retry
           %% It's likely this is too many retries for other services
           retry_num=10::non_neg_integer(),
-          assume_role = [] :: proplists:proplist() %% If a role to be assumed is given
+          assume_role = #aws_assume_role{} :: aws_assume_role() %% If a role to be assumed is given
           %% then we will try to assume the role during the update_config
          }).
 -type(aws_config() :: #aws_config{}).
@@ -121,3 +130,5 @@
           should_retry :: boolean() | undefined
         }).
 -type(aws_request() :: #aws_request{}).
+
+

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -613,12 +613,14 @@ get_credentials_from_role(#aws_config{assume_role = AssumeRoleOptions} = Config)
                                       "erlcloud"),
     SessionExpiration = proplists:get_value(session_expiration,
                                             AssumeRoleOptions, 900),
+    ExternalId = proplists:get_value(external_id, AssumeRoleOptions,
+                                      undefined),
     %% We have to remove the assume role options to make sure we do not
     %% enter in a infinite loop because erlcloud_sts:assume_role also calls
     %% update_config deep inside when makes the request
     case catch erlcloud_sts:assume_role(Config#aws_config{assume_role = []},
                                         RoleArn, SessionName,
-                                        SessionExpiration) of
+                                        SessionExpiration, ExternalId) of
         {#aws_config{}=_NewConfig, Creds} ->
             ExpireAt = calendar:datetime_to_gregorian_seconds(
                 proplists:get_value(expiration, Creds)),


### PR DESCRIPTION
- This feature allow to configure an assume_role setting to use when update_config
- We just need to fill `aws_config` record with `assume_role` options: 
```erlang
#aws_config{
...
assume_role = [
       {role_arn, "arn:aws:iam::123456789012:role/marketingadmin"}, %% Required
       {session_name, "asessionname"}, %% Optional with default: "erlcloud"
       {session_expiration, 900}, %% Optional with default:900
]}
` 