### PR TITLE
Add KMS to `erlcloud_aws:service_config/3`

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -453,6 +453,9 @@ service_config( <<"iam">>, _Region, Config ) -> Config;
 service_config( <<"kinesis">> = Service, Region, Config ) ->
     Host = service_host( Service, Region ),
     Config#aws_config{ kinesis_host = Host };
+service_config( <<"kms">> = Service, Region, Config ) ->
+    Host = service_host( Service, Region ),
+    Config#aws_config{ kms_host = Host };
 service_config( <<"lambda">> = Service, Region, Config ) ->
     Host = service_host( Service, Region ),
     Config#aws_config{ lambda_host = Host };


### PR DESCRIPTION
Add support for AWS KMS endpoint configuration now that we support
the KMS API.