### PR TITLE
Fixed all dialyzer warnings in erlcloud_autoscaling and erlcloud_as modules

### DIFF
--- a/include/erlcloud_as.hrl
+++ b/include/erlcloud_as.hrl
@@ -25,7 +25,7 @@
           group_name :: string(),
           availability_zones :: list(string()),
           load_balancer_names :: list(string()),
-          tags :: list(string()),
+          tags :: list(aws_autoscaling_tag()),
           desired_capacity :: integer(),
           min_size :: integer(),
           max_size :: integer(),

--- a/src/erlcloud_autoscaling.erl
+++ b/src/erlcloud_autoscaling.erl
@@ -43,16 +43,16 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
--spec describe_autoscaling_groups() -> proplist().
+-spec describe_autoscaling_groups() -> {string(), proplist()} | {error, term()}.
 describe_autoscaling_groups() -> describe_autoscaling_groups([]).
 
--spec describe_autoscaling_groups([string()] | aws_config()) -> proplist().
+-spec describe_autoscaling_groups([string()] | aws_config()) -> {string(), proplist()} | {error, term()}.
 describe_autoscaling_groups(Config) when is_record(Config, aws_config) -> 
     describe_autoscaling_groups([], Config);
 describe_autoscaling_groups(GroupNames) ->
     describe_autoscaling_groups(GroupNames, default_config()).
 
--spec describe_autoscaling_groups([string()], aws_config()) -> proplist().
+-spec describe_autoscaling_groups([string()], aws_config()) -> {string(), proplist()} | {error, term()}.
 describe_autoscaling_groups(GroupNames, Config) 
   when is_list(GroupNames), is_record(Config, aws_config) -> 
     %case autoscaling_query(Config, "DescribeAutoScalingGroups", []) of % erlcloud_aws:param_list(GroupNames, "AutoScalingGroupNames.member")) of
@@ -64,16 +64,16 @@ describe_autoscaling_groups(GroupNames, Config)
             {error, Reason}
     end.
 
--spec describe_autoscaling_groups_all() -> proplist().
+-spec describe_autoscaling_groups_all() -> {ok, proplist()} | {error, term()}.
 describe_autoscaling_groups_all() -> describe_autoscaling_groups_all([]).
 
--spec describe_autoscaling_groups_all([string()] | aws_config()) -> proplist().
+-spec describe_autoscaling_groups_all([string()] | aws_config()) -> {ok, proplist()} | {error, term()}.
 describe_autoscaling_groups_all(Config) when is_record(Config, aws_config) -> 
     describe_autoscaling_groups_all([], Config);
 describe_autoscaling_groups_all(GroupNames) ->
     describe_autoscaling_groups_all(GroupNames, default_config()).
 
--spec describe_autoscaling_groups_all([string()], aws_config()) -> proplist().
+-spec describe_autoscaling_groups_all([string()], aws_config()) -> {ok, proplist()} | {error, term()}.
 describe_autoscaling_groups_all(GroupNames, Config)
   when is_list(GroupNames), is_record(Config, aws_config) -> 
     %case autoscaling_query(Config, "DescribeAutoScalingGroups", []) of % erlcloud_aws:param_list(GroupNames, "AutoScalingGroupNames.member")) of
@@ -85,16 +85,16 @@ describe_autoscaling_groups_all(GroupNames, Config)
             {error, Reason}
     end.
 
--spec describe_launch_configurations() -> proplist().
+-spec describe_launch_configurations() -> {string(), proplist()} | {error, term()}.
 describe_launch_configurations() -> describe_launch_configurations([]).
 
--spec describe_launch_configurations([string()] | aws_config()) -> proplist().
+-spec describe_launch_configurations([string()] | aws_config()) -> {string(), proplist()} | {error, term()}.
 describe_launch_configurations(Config) when is_record(Config, aws_config) -> 
     describe_launch_configurations([], Config);
 describe_launch_configurations(ConfiguratoinNames) ->
     describe_launch_configurations(ConfiguratoinNames, default_config()).
 
--spec describe_launch_configurations([string()], aws_config()) -> proplist().
+-spec describe_launch_configurations([string()], aws_config()) -> {string(), proplist()} | {error, term()}.
 describe_launch_configurations(ConfiguratoinNames, Config) 
   when is_list(ConfiguratoinNames), is_record(Config, aws_config) -> 
     case autoscaling_query(Config, "DescribeLaunchConfigurations", erlcloud_aws:param_list(ConfiguratoinNames, "LaunchConfigurationNames.member")) of
@@ -105,16 +105,16 @@ describe_launch_configurations(ConfiguratoinNames, Config)
             {error, Reason}  
     end.
 
--spec describe_launch_configurations_all() -> proplist().
+-spec describe_launch_configurations_all() -> {ok, proplist()} | {error, term()}.
 describe_launch_configurations_all() -> describe_launch_configurations_all([]).
 
--spec describe_launch_configurations_all([string()] | aws_config()) -> proplist().
+-spec describe_launch_configurations_all([string()] | aws_config()) -> {ok, proplist()} | {error, term()}.
 describe_launch_configurations_all(Config) when is_record(Config, aws_config) -> 
     describe_launch_configurations_all([], Config);
 describe_launch_configurations_all(ConfiguratoinNames) ->
     describe_launch_configurations_all(ConfiguratoinNames, default_config()).
 
--spec describe_launch_configurations_all([string()], aws_config()) -> proplist().
+-spec describe_launch_configurations_all([string()], aws_config()) -> {ok, proplist()} | {error, term()}.
 describe_launch_configurations_all(ConfiguratoinNames, Config)
   when is_list(ConfiguratoinNames), is_record(Config, aws_config) -> 
     case erlcloud_util:query_all_token(fun autoscaling_query/3, Config, "DescribeLaunchConfigurations", erlcloud_aws:param_list(ConfiguratoinNames, "LaunchConfigurationNames.member")) of


### PR DESCRIPTION
Problem:

- Those two modules had various dialyzer warnings caused by wrong or absent specs and wrong records. 21 warnings in total.

Solution:

- Fixed all dialyzer warnings in erlcloud_autoscaling.erl
- Fixed all dialyzer warnings in erlcloud_as.erl
- Made minor changes in both modules code