### PR TITLE
Fixed dialyzer warnings in cloudformation, cloudtrail and elb

### DIFF
--- a/src/erlcloud_cloudformation.erl
+++ b/src/erlcloud_cloudformation.erl
@@ -338,7 +338,7 @@ get_template(StackName, Config = #aws_config{}) ->
 -spec get_template_summary(params(), string()) ->
     {ok, cloudformation_list()} | {error, error_reason()}.
 get_template_summary(Params, StackName) ->
-    get_template_summary(Params, StackName, default_config).
+    get_template_summary(Params, StackName, default_config()).
 
 -spec get_template_summary(params(), string(), aws_config()) ->
     {ok, cloudformation_list()} | {error, error_reason()}.
@@ -360,20 +360,20 @@ get_template_summary(Params, StackName, Config = #aws_config{}) ->
 -spec describe_account_limits_all() ->
     {ok, cloudformation_list()} | {error, error_reason()}.
 describe_account_limits_all() ->
-    describe_account_limits_all(default_config).
+    describe_account_limits_all(default_config()).
 
 -spec describe_account_limits_all(aws_config()) ->
     {ok, cloudformation_list()} | {error, error_reason()}.
 describe_account_limits_all(Config = #aws_config{}) ->
     list_all(fun describe_account_limits/2, [], Config, []).
 
--spec describe_account_limits(params) ->
-    {ok, cloudformation_list()} | {error, error_reason()}.
+-spec describe_account_limits(list()) ->
+    {ok, cloudformation_list(), string()} | {error, error_reason()}.
 describe_account_limits(Params) ->
     describe_account_limits(Params, default_config()).
 
--spec describe_account_limits(params, aws_config()) ->
-    {ok, cloudformation_list()} | {error, error_reason()}.
+-spec describe_account_limits(list(), aws_config()) ->
+    {ok, cloudformation_list(), string()} | {error, error_reason()}.
 describe_account_limits(Params, Config = #aws_config{}) ->
 
     RequestParams = lists:map(fun(T) -> convert_param(T) end, Params),

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -97,7 +97,8 @@ delete_trail(Trail, Config) ->
 -spec describe_trails() -> ct_return().
 describe_trails() -> describe_trails([]).
 
--spec describe_trails(aws_config()) -> ct_return().
+-spec describe_trails(aws_config()) -> ct_return();
+                     (list()) -> ct_return().
 describe_trails(Config) when is_record(Config, aws_config) ->
     describe_trails([], Config);
 
@@ -171,11 +172,6 @@ update_trail(Trail, S3BucketName, S3KeyPrefix, SnsTopicName, IncludeGlobalServic
     ct_request("UpdateTrail", Json, Config).
 
 % Json parameter must be a list of binary key/value tuples.
-ct_request(Operation, [], Config) ->
-    #aws_config{cloudtrail_scheme = Scheme, 
-                cloudtrail_host = Host} = Config,
-    request_impl(post, Scheme, Host, port_spec(Config), "/", Operation, [], "{}", Config);
-
 ct_request(Operation, Body, Config) ->
     #aws_config{cloudtrail_scheme = Scheme, 
                 cloudtrail_host = Host} = Config,

--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -108,11 +108,11 @@ delete_load_balancer(LB, Config) when is_list(LB) ->
                        [{"LoadBalancerName", LB}]).
 
 
--spec register_instance(string(), string()) -> proplist().
+-spec register_instance(string(), string()) -> ok.
 register_instance(LB, InstanceId) ->
     register_instance(LB, InstanceId, default_config()).
 
--spec register_instance(string(), string(), aws_config()) -> proplist().
+-spec register_instance(string(), string(), aws_config()) -> ok.
 register_instance(LB, InstanceId, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "RegisterInstancesWithLoadBalancer",
@@ -120,11 +120,11 @@ register_instance(LB, InstanceId, Config) when is_list(LB) ->
                         erlcloud_aws:param_list([[{"InstanceId", InstanceId}]], "Instances.member")]).
 
 
--spec deregister_instance(string(), string()) -> proplist().
+-spec deregister_instance(string(), string()) -> ok.
 deregister_instance(LB, InstanceId) ->
     deregister_instance(LB, InstanceId, default_config()).
 
--spec deregister_instance(string(), string(), aws_config()) -> proplist().
+-spec deregister_instance(string(), string(), aws_config()) -> ok.
 deregister_instance(LB, InstanceId, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "DeregisterInstancesFromLoadBalancer",
@@ -133,13 +133,13 @@ deregister_instance(LB, InstanceId, Config) when is_list(LB) ->
 
 
 
--spec configure_health_check(string(), string()) -> proplist().
+-spec configure_health_check(string(), string()) -> ok.
 configure_health_check(LB, Target) when is_list(LB),
                                         is_list(Target) ->
     configure_health_check(LB, Target, default_config()).
 
 
--spec configure_health_check(string(), string(), aws_config()) -> proplist().
+-spec configure_health_check(string(), string(), aws_config()) -> ok.
 configure_health_check(LB, Target, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "ConfigureHealthCheck",
@@ -151,7 +151,7 @@ configure_health_check(LB, Target, Config) when is_list(LB) ->
 %% specific configuration and specific balancer name. 
 %% @end
 %% --------------------------------------------------------------------
--spec describe_load_balancer(string()) -> proplist().
+-spec describe_load_balancer(string()) -> {ok | {paged, string()}, proplist()} | {error, term()}.
 describe_load_balancer(Name) ->
     describe_load_balancer(Name, default_config()).
 describe_load_balancer(Name, Config) ->


### PR DESCRIPTION
Problem:

- Modules erlcloud_cloudformation, erlcloud_cloudtrail and erlcloud_elb had 16 dialyzer warnings between them
- Module erlcloud_cloudformation had several broken functions eg. `default_config` atom was used instead of `default_config()` call

Solution:

- Fixed all dialyzer warnings in those 3 modules by correcting specs and fixing broken functions