### PR TITLE
read AWS region from env/appenv

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -319,7 +319,7 @@ default_config_wrap() ->
 %% return undefined
 default_config_get(OsVar, EnvVar) ->
     case {os:getenv(OsVar), application:get_env(erlcloud, EnvVar)} of
-        {OsVal,  _} when OsVal /= undefined -> OsVal;
+        {OsVal,  _} when OsVal /= false -> OsVal;
         {_, {ok, EnvVal}} -> EnvVal;
         _ -> undefined
     end.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -305,14 +305,14 @@ default_config() ->
     end.
 
 default_config_wrap() ->
-    #{id:=Id, key:=Key, token:=Token, region:=Region} = default_config_get(),
+    {Id, Key, Token, Region} = default_config_get(),
     default_config_region(default_config_assert(Id, Key, Token), Region).
 
 default_config_get() ->
-    #{id=>default_config_get("AWS_ACCESS_KEY_ID", aws_access_key_id),
-      key=>default_config_get("AWS_SECRET_ACCESS_KEY", aws_secret_access_key),
-      token=>default_config_get("AWS_SECURITY_TOKEN", aws_security_token),
-      region=>default_config_get("AWS_REGION", aws_region)}.
+    {default_config_get("AWS_ACCESS_KEY_ID", aws_access_key_id),
+     default_config_get("AWS_SECRET_ACCESS_KEY", aws_secret_access_key),
+     default_config_get("AWS_SECURITY_TOKEN", aws_security_token),
+     default_config_get("AWS_REGION", aws_region)}.
 
 %% try to get config value from OS env, failing that try app env, else
 %% return undefined

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -294,8 +294,12 @@ format_timestamp({{Yr, Mo, Da}, {H, M, S}}) ->
 %% "AWS_SECRET_ACCESS_KEY", "AWS_SECURITY_TOKEN", and "AWS_REGION",
 %% respectively. If no value is found, we look at the erlcloud application
 %% environment for the keys aws_access_key_id, aws_secret_access_key,
-%% aws_security_token, and aws_region, respectively. Otherwise, the value
-%% will be 'undefined'.
+%% aws_security_token, and aws_region, respectively. If still no value is
+%% found, it will default to 'undefined'.
+%% Id, Key, and Token will be set in #aws_config{}, in the fields
+%% access_key_id, secret_access_key, and security_token, respectively.
+%% If Region is set, we will attempt to set the appropriate URL for this
+%% region for each service.
 
 %% check the cache
 default_config() ->


### PR DESCRIPTION
This patch automatically changes the default AWS config to reflect the AWS region. It does this by checking for the existence of the OS environment variable "AWS_REGION" and the 'erlcloud' application env 'aws_region'; if neither exists this patch does nothing.