### PR TITLE
Add application dep on new base16 component

### DIFF
--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -14,6 +14,7 @@
                   inets,
                   jsx,
                   eini,
+                  base16,
                   %% hackney,
                   lhttpc]},
   {modules, []},


### PR DESCRIPTION
Without this relx packaging does not pick up the base16 application
and therefore erlcloud is not packaged completely.