### PR TITLE
Fix bug #347 missing parameters in the describe_stacks_all result

### DIFF
--- a/src/erlcloud_cloudformation.erl
+++ b/src/erlcloud_cloudformation.erl
@@ -525,7 +525,19 @@ extract_described_stack(XmlNode) ->
             {creation_time, "CreationTime", optional_text},
             {stack_status, "StackStatus", optional_text},
             {disable_rollback, "DisableRollback", optional_text},
+            {parameters, "Parameters", {map, fun extract_parameters/1}},
             {outputs, "Outputs", {map, fun extract_resource_outputs/1}}
+        ], XmlNode).
+
+extract_parameters(XmlNode) ->
+    erlcloud_xml:decode([
+            {member, "member", {map, fun extract_parameter/1}}
+         ], XmlNode).
+
+extract_parameter(XmlNode) ->
+    erlcloud_xml:decode([
+            {parameter_key, "ParameterKey", optional_text},
+            {parameter_value, "ParameterValue", optional_text}
         ], XmlNode).
 
 extract_resource_outputs(XmlNode) ->
@@ -535,6 +547,7 @@ extract_resource_outputs(XmlNode) ->
 
 extract_resource_output(XmlNode) ->
     erlcloud_xml:decode([
+            {description, "Description", optional_text},
             {output_key, "OutputKey", optional_text},
             {output_value, "OutputValue", optional_text}
         ], XmlNode).

--- a/test/erlcloud_cloudformation_tests.erl
+++ b/test/erlcloud_cloudformation_tests.erl
@@ -401,8 +401,15 @@ describe_stacks_output_tests(_) ->
                     <CreationTime>Not Today</CreationTime>
                     <StackStatus>status</StackStatus>
                     <DisableRollback>false</DisableRollback>
+                    <Parameters>
+                      <member>
+                        <ParameterKey>Some Key</ParameterKey>
+                        <ParameterValue>Parameter</ParameterValue>
+                      </member>
+                    </Parameters>
                     <Outputs>
                       <member>
+                        <Description>Some Description</Description>
                         <OutputKey>Some Key</OutputKey>
                         <OutputValue>Output</OutputValue>
                       </member>
@@ -421,8 +428,15 @@ describe_stacks_output_tests(_) ->
                            {creation_time, "Not Today"},
                            {stack_status, "status"},
                            {disable_rollback, "false"},
+                           {parameters, [[
+                                {member, [[
+                                    {parameter_key, "Some Key"},
+                                    {parameter_value, "Parameter"}
+                                ]]}
+                            ]]},
                            {outputs, [[
                                 {member, [[
+                                    {description, "Some Description"},
                                     {output_key, "Some Key"},
                                     {output_value, "Output"}
                                 ]]}


### PR DESCRIPTION
- Returning paramters
- Outputs are returning also Description