### PR TITLE
Add 'pool_ensure' option if lhttpc_pool does not exists

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -100,7 +100,10 @@
           cloudtrail_raw_result=false::boolean(),
           http_client=lhttpc::erlcloud_httpc:request_fun(), %% If using hackney, ensure that it is started.
           hackney_pool=default::atom(), %% The name of the http request pool hackney should use.
-          lhttpc_pool=undefined::atom(), %% The name of the http request pool lhttpc should use.
+          %% The name of the http request pool lhttpc should use
+          %% Note: If the lhttpc pool does not exists it will be created one with the lhttpc
+          %%  default settings [{connection_timeout,300000},{pool_size,1000}]
+          lhttpc_pool=undefined::atom(),
           %% Default to not retry failures (for backwards compatability).
           %% Recommended to be set to default_retry to provide recommended retry behavior.
           %% Currently only affects S3 and service modules which use erlcloud_aws

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -46,7 +46,8 @@ request(URL, Method, Hdrs, Body, Timeout,
 request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{lhttpc_pool = undefined}) ->
     lhttpc:request(URL, Method, Hdrs, Body, Timeout, []);
 request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{lhttpc_pool = Pool}) ->
-    lhttpc:request(URL, Method, Hdrs, Body, Timeout, [{pool, Pool}]).
+    LHttpcOpts = [{pool, Pool}, {pool_ensure, true}],
+    lhttpc:request(URL, Method, Hdrs, Body, Timeout, LHttpcOpts).
 
 %% Guard clause protects against empty bodied requests from being
 %% unable to find a matching httpc:request call.


### PR DESCRIPTION
- Add the pool_ensure option
- Add comments in the aws_config record definition

This solves the issue #380 