### PR TITLE
Implemented 3 new describe functions in erlcloud_ec2

### DIFF
--- a/test/erlcloud_ec2_tests.erl
+++ b/test/erlcloud_ec2_tests.erl
@@ -735,6 +735,173 @@ describe_images_tests(_) ->
   %% Remaining AWS API examples return subsets of the same data
   output_tests(?_f(erlcloud_ec2:describe_images()), Tests).
 
+describe_account_attributes_test() ->
+    XML = "<DescribeAccountAttributesResponse>
+               <requestId>12345</requestId>
+               <accountAttributeSet>
+                   <item>
+                       <attributeName>attribute123</attributeName>
+                       <attributeValueSet>
+                           <item>
+                               <attributeValue>123</attributeValue>
+                           </item>
+                       </attributeValueSet>
+                   </item>
+                   <item>
+                       <attributeName>attribute456</attributeName>
+                       <attributeValueSet>
+                           <item>
+                               <attributeValue>456</attributeValue>
+                           </item>
+                       </attributeValueSet>
+                   </item>
+                   <item>
+                       <attributeName>attribute789</attributeName>
+                       <attributeValueSet>
+                           <item>
+                               <attributeValue>789</attributeValue>
+                           </item>
+                       </attributeValueSet>
+                   </item>
+               </accountAttributeSet>
+           </DescribeAccountAttributesResponse>",
+    XMERL = {ok, element(1, xmerl_scan:string(XML))},
+    ExpectedResult =
+        {ok,[
+                [{attribute_name,"attribute123"},
+                    {attribute_value_set,[[{attribute_value,"123"}]]}],
+                [{attribute_name,"attribute456"},
+                    {attribute_value_set,[[{attribute_value,"456"}]]}],
+                [{attribute_name,"attribute789"},
+                    {attribute_value_set,[[{attribute_value,"789"}]]}]
+            ]},
+    meck:new(erlcloud_aws, [passthrough]),
+    meck:expect(erlcloud_aws, aws_request_xml4,
+        fun(_,_,_,_,_,_) ->
+            XMERL
+        end),
+    Result = erlcloud_ec2:describe_account_attributes(),
+    meck:unload(erlcloud_aws),
+    ?assertEqual(ExpectedResult, Result).
+    
+describe_nat_gateways_test() ->
+    XML = "<DescribeNatGatewaysResponse>
+               <requestId>bfed02c6-dae9-47c0-86a2-example</requestId>
+               <natGatewaySet>
+                   <item>
+                       <createTime>2017-01-02T15:49:34.999Z</createTime>
+                       <deleteTime>2017-01-02T15:49:34.999Z</deleteTime>
+                       <failureCode>1234</failureCode>
+                       <failureMessage>boom</failureMessage>
+                       <natGatewayAddressSet>
+                           <item>
+                               <allocationId>allocid-123</allocationId>
+                               <networkInterfaceId>ni-56789</networkInterfaceId>
+                               <privateIp>10.0.0.0</privateIp>
+                               <publicIp>123.12.123.12</publicIp>
+                           </item>
+                       </natGatewayAddressSet>
+                       <natGatewayId>nat-04e77a5e9c34432f9</natGatewayId>
+                       <state>available</state>
+                       <subnetId>subnet-1a2a3a4a</subnetId>
+                       <vpcId>vpc-4e20d42b</vpcId>
+                   </item>
+               </natGatewaySet>
+           </DescribeNatGatewaysResponse>",
+    XMERL = {ok, element(1, xmerl_scan:string(XML))},
+    ExpectedResult =
+        {ok,
+            [
+                [
+                    {create_time, "2017-01-02T15:49:34.999Z"},
+                    {delete_time, "2017-01-02T15:49:34.999Z"},
+                    {failure_code, "1234"},
+                    {failure_message, "boom"},
+                    {nat_gateway_address_set,
+                        [
+                            [
+                                {allocation_id, "allocid-123"},
+                                {network_interface_id, "ni-56789"},
+                                {private_ip, "10.0.0.0"},
+                                {public_ip, "123.12.123.12"}
+                            ]
+                        ]
+                    },
+                    {nat_gateway_id, "nat-04e77a5e9c34432f9"},
+                    {state, "available"},
+                    {subnet_id, "subnet-1a2a3a4a"},
+                    {vpc_id, "vpc-4e20d42b"}
+                ]
+            ]
+        },
+    meck:new(erlcloud_aws, [passthrough]),
+    meck:expect(erlcloud_aws, aws_request_xml4,
+        fun(_,_,_,_,_,_) ->
+            XMERL
+        end),
+    Result = erlcloud_ec2:describe_nat_gateways(),
+    meck:unload(erlcloud_aws),
+    ?assertEqual(ExpectedResult, Result).
+
+describe_vpc_peering_connections_test() ->
+    XML = "<DescribeVpcPeeringConnectionsResponse>
+       	       <requestId>lnwadt7-8adia7r-aadu8-EXAMPLE</requestId>
+       	       <vpcPeeringConnectionSet>
+                   <item>
+       	               <expirationTime>2017.01.02 09:54:15</expirationTime>
+       	               <tagSet>
+                           <item>
+       	                       <key>key1</key>
+       	                       <value>value1</value>
+       	                   </item>
+                           <item>
+       	                       <key>key2</key>
+       	                       <value>value2</value>
+       	                   </item>
+       	                   <item>
+       	                       <key>key3</key>
+       	                       <value>value3</value>
+       	                   </item>
+       	               </tagSet>
+       	               <vpcPeeringConnectionId>pcx-123abc69</vpcPeeringConnectionId>
+       	           </item>
+               </vpcPeeringConnectionSet>
+           </DescribeVpcPeeringConnectionsResponse>",
+    XMERL = {ok, element(1, xmerl_scan:string(XML))},
+    ExpectedResult =
+        {ok,
+            [
+                [
+                    {expiration_time, "2017.01.02 09:54:15"},
+                    {tag_set,
+                        [
+                            [
+                                {key, "key1"},
+                                {value, "value1"}
+                            ],
+                            [
+                                {key, "key2"},
+                                {value, "value2"}
+                            ],
+                            [
+                                {key, "key3"},
+                                {value, "value3"}
+                            ]
+                        ]
+                    },
+                    {vpc_peering_connection_id, "pcx-123abc69"}
+                ]
+            ]
+        },
+    meck:new(erlcloud_aws, [passthrough]),
+    meck:expect(erlcloud_aws, aws_request_xml4,
+        fun(_,_,_,_,_,_) ->
+            XMERL
+        end),
+    Result = erlcloud_ec2:describe_vpc_peering_connections(),
+    meck:unload(erlcloud_aws),
+    ?assertEqual(ExpectedResult, Result).
+
 describe_instances_test() ->
     Tests = [{30,6},{22,5},{3,7},{10,10},{0,10},{0,5},{0,1000}],
     test_pagination(Tests, generate_instances_response, describe_instances, [], [[]])


### PR DESCRIPTION
Problem:

erlcloud_ec2 did not have support for the following actions:

- DescribeAccountAttributes
- DescribeNatGateways
- DescribeVpcPeeringConnections

Solution:

Implemented the functions to support those actions:

- describe_account_attributes
- describe_nat_gateways
- describe_vpc_peering_connections

Also made slight change to make names of extract functions more consistent

Reviewers: @motobob 