### PR TITLE
Implement STS GetCallerIdentity

### DIFF
--- a/src/erlcloud_sts.erl
+++ b/src/erlcloud_sts.erl
@@ -9,6 +9,7 @@
 -endif.
 
 -export([assume_role/4, assume_role/5,
+         get_caller_identity/1,
          get_federation_token/3,
          get_federation_token/4]).
 
@@ -59,6 +60,25 @@ assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds, ExternalId)
         },
 
     {AssumedConfig, Creds}.
+
+
+
+%% @doc Retrieve identity information
+%%
+%% @see http://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
+-type caller_identity_prop() :: {account, string()}
+                              | {arn, string()}
+                              | {userId, string()}.
+-spec get_caller_identity(#aws_config{}) -> {ok, [caller_identity_prop()]}.
+get_caller_identity(AwsConfig) ->
+    Xml = sts_query(AwsConfig, "GetCallerIdentity", []),
+    Proplists = erlcloud_xml:decode(
+        [
+         {account, "GetCallerIdentityResult/Account", text},
+         {arn, "GetCallerIdentityResult/Arn", text},
+         {userId, "GetCallerIdentityResult/UserId", text}
+        ], Xml),
+    {ok, Proplists}.
 
 
 get_federation_token(AwsConfig, DurationSeconds, Name) ->


### PR DESCRIPTION
```
1> application:ensure_all_started(erlcloud).
{ok,[xmerl,jsx,eini,base16,lhttpc,erlcloud]}
2> {ok, Config} = erlcloud_aws:profile().
{ok,{aws_config,"autoscaling.amazonaws.com",
                "ec2.amazonaws.com","iam.amazonaws.com","sts.amazonaws.com",
                "https://","s3.amazonaws.com",80,false,2,vhost,false,
                "sdb.amazonaws.com","elasticloadbalancing.amazonaws.com",
                "rds.us-east-1.amazonaws.com",
                "email.us-east-1.amazonaws.com","queue.amazonaws.com",
                undefined,undefined,"https://",
                "elasticmapreduce.us-east-1.amazonaws.com",undefined,
                "http://","sns.amazonaws.com",
                "mechanicalturk.amazonaws.com","monitoring.amazonaws.com",
                undefined,...}}
3> erlcloud_sts:get_caller_identity(Config).
{ok,[{account,"468472511111"},
     {arn,"arn:aws:sts::468472511111:assumed-role/centralized-users/erlcloud"},
     {userId,"AROAIARCB7OKPBAAAAAAA:erlcloud"}]}
```