### PR TITLE
Filter clause for cloudfront service_config

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -530,6 +530,7 @@ service_config( <<"cloudformation">> = Service, Region, Config ) ->
     Config#aws_config{ cloudformation_host = Host };
 service_config( <<"cfn">>, Region, Config ) ->
     service_config( <<"cloudformation">>, Region, Config );
+service_config( <<"cloudfront">>, _Region, Config ) -> Config;
 service_config( <<"cloudsearch">> = Service, Region, Config ) ->
     Host = service_host( Service, Region ),
     Config#aws_config{ cloudsearch_host = Host };


### PR DESCRIPTION
Apparently CloudFront PR https://github.com/erlcloud/erlcloud/pull/388 broke `default_config` function.
Fixes: https://github.com/erlcloud/erlcloud/issues/398

Filter is required, because cloudfront endpoint is agnostic to region (http://docs.aws.amazon.com/general/latest/gr/rande.html#cf_region).