### PR TITLE
Allow for warningless compilation

### DIFF
--- a/src/erlcloud_waf.erl
+++ b/src/erlcloud_waf.erl
@@ -53,7 +53,6 @@
 -define(LIMIT_MAX, 100).
 
 -type json_proplist() :: proplists:proplist().
--type json_binary() :: binary().
 
 %%%------------------------------------------------------------------------------
 %%% Shared types


### PR DESCRIPTION
Otherwise warnings_as_errors won't allow us to proceed