### PR TITLE
Match 'US' and 'EU' S3 locations to us-east-1 and eu-west-1

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -550,9 +550,9 @@ get_bucket_attribute(BucketName, AttributeName, Config)
             case erlcloud_xml:get_text("/LocationConstraint", Doc) of
                 %% logic according to http://s3tools.org/s3cmd
                 %% s3cmd-1.5.2/S3/S3.py : line 342 (function get_bucket_location)
-                [] -> "us-east-1";
-                ["US"] -> "us-east-1";
-                ["EU"] -> "eu-west-1";
+                "" -> "us-east-1";
+                "US" -> "us-east-1";
+                "EU" -> "eu-west-1";
                 Loc -> Loc
             end;
         logging ->


### PR DESCRIPTION
**Problem**

S3 bucket location attributes of "", "US" and "EU" do not map correctly to "us-east-1" and "eu-west-1".

**Solution**

Add "/LocationConstraint" attribute handling to erlcloud_s3.erl for "", "US" (maps to "us-east-1") and "EU" (maps to "eu-west-1").  
