### PR TITLE
Cloudwatch logs

### DIFF
--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -31,6 +31,15 @@
 
 -type log_group() :: jsx:json_term().
 
+-type log_group_name() :: binary().
+-type log_stream_name() :: binary().
+-type sequence_token() :: binary().
+-type log_event() :: #{message => binary(), timestamp => integer()}.
+
+-type log_events() :: [log_event()].
+-type log_put_result() :: #{nextSequenceToken => binary(),
+                            rejectedLogEventsInfo => map()}.
+
 
 %% Library initialization
 -export([
@@ -49,7 +58,9 @@
     describe_log_groups/2,
     describe_log_groups/3,
     describe_log_groups/4,
-    create_log_stream/3
+    create_log_stream/3,
+    put_log_events/4,
+    put_log_events/5
 ]).
 
 
@@ -155,12 +166,61 @@ describe_log_groups(LogGroupNamePrefix, Limit, PrevToken, Config) ->
             {error, Reason}
     end.
 
-
+-spec create_log_stream(
+    log_group_name(),
+    log_stream_name(),
+    aws_config()
+) -> ok|error_result().
 create_log_stream(LogGroupName, LogStreamName, Config) ->
     cw_request(Config, "CreateLogStream", [
       {<<"logGroupName">>, LogGroupName},
       {<<"logStreamName">>, LogStreamName}
     ]).
+
+
+-spec put_log_events(
+    log_group_name(),
+    log_stream_name(),
+    log_events(),
+    aws_config()
+) -> ok|error_result().
+put_log_events(LogGroupName, LogStreamName, 
+               LogEvents, Config) when is_binary(LogGroupName),
+                                       is_binary(LogStreamName), 
+                                       is_list(LogEvents) ->
+  Events = make_log_events(LogEvents),
+  cw_prepared_request(Config, "PutLogEvents", [
+    {<<"logGroupName">>, LogGroupName},
+    {<<"logStreamName">>, LogStreamName},
+    {<<"logEvents">>, Events}
+  ],  _ReturnMap = true).
+
+-spec put_log_events(
+    log_group_name(),
+    log_stream_name(),
+    sequence_token(),
+    log_events(),
+    aws_config()
+) -> {ok, log_put_result()}| error_result().
+put_log_events(LogGroupName, LogStreamName, SequenceToken, 
+               LogEvents, Config) when is_binary(LogGroupName),
+                                       is_binary(LogStreamName), 
+                                       is_list(LogEvents),
+                                       is_binary(SequenceToken) ->
+  Events = make_log_events(LogEvents),
+  cw_prepared_request(Config, "PutLogEvents", [
+    {<<"logGroupName">>, LogGroupName},
+    {<<"logStreamName">>, LogStreamName},
+    {<<"sequenceToken">>, SequenceToken},
+    {<<"logEvents">>, Events}
+  ],  _ReturnMap = true ).
+
+make_log_events([]) ->
+  [];
+make_log_events([#{message := Message, 
+                   timestamp := Timestamp}|R]) when is_binary(Message),
+                                                    is_integer(Timestamp) ->
+  [[{<<"message">>, Message}, {<<"timestamp">>, Timestamp}]|make_log_events(R)].
 
 %%==============================================================================
 %% Internal functions
@@ -170,13 +230,27 @@ create_log_stream(LogGroupName, LogStreamName, Config) ->
 default_config() ->
     erlcloud_aws:default_config().
 
+b(B) when is_binary(B) ->
+  B;
+b(L) when is_list(L) ->
+  list_to_binary(L).
 
 cw_request(Config, Action, Params) ->
+    %% Filter out params without values
+    %% Perform list to binary conversion
+    PreparedParams = prepare_request_params(Params),
+    cw_prepared_request(Config, b(Action), PreparedParams, _ReturnMap = false).
+    
+cw_prepared_request(Config, Action, BodyParams, ReturnMap) when is_list(BodyParams) ->    
+    JSXReturnOptions = case ReturnMap of
+        true -> [{labels, atom},return_maps];
+        false -> []
+    end,
     case erlcloud_aws:update_config(Config) of
         {ok, NewConfig} ->
-            RequestBody = make_request_body(
-                Action, Params
-            ),
+            JSXBody = [{<<"Action">>, b(Action)}, 
+                       {<<"Version">>, b(?API_VERSION)} | BodyParams],
+            RequestBody = jsx:encode(JSXBody),
             RequestHeaders = make_request_headers(
                 NewConfig, Action, RequestBody
             ),
@@ -193,7 +267,7 @@ cw_request(Config, Action, Params) ->
                 {ok, <<>>} ->
                     ok;
                 {ok, ResponseBody} ->
-                    {ok, jsx:decode(ResponseBody)};
+                    {ok, jsx:decode(ResponseBody, JSXReturnOptions)};
                 {error, Reason} ->
                     {error, Reason}
             end;
@@ -212,13 +286,6 @@ make_signed_headers(Config, Action, Body) ->
     Headers = [{"host", Host}, {"x-amz-target", Target}],
     Region = erlcloud_aws:aws_region_from_host(Host),
     erlcloud_aws:sign_v4_headers(Config, Headers, Body, Region, ?SERVICE_NAME).
-
-
-make_request_body(Action, RequestParams) ->
-    DefaultParams = [{<<"Action">>, Action}, {<<"Version">>, ?API_VERSION}],
-    Params = lists:append(DefaultParams, RequestParams),
-    jsx:encode(prepare_request_params(Params)).
-
 
 prepare_request_params(Params) ->
     lists:filtermap(fun prepare_request_param/1, Params).

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -37,7 +37,8 @@
     configure/2,
     configure/3,
     new/2,
-    new/3
+    new/3,
+    set_cloudwatch_host/2
 ]).
 
 
@@ -47,7 +48,8 @@
     describe_log_groups/1,
     describe_log_groups/2,
     describe_log_groups/3,
-    describe_log_groups/4
+    describe_log_groups/4,
+    create_log_stream/3
 ]).
 
 
@@ -84,7 +86,11 @@ new(AccessKeyID, SecretAccessKey, Host) ->
         cloudwatch_logs_host = Host
     }.
 
-
+-spec set_cloudwatch_host(cw_host(), aws_config()) -> aws_config().
+set_cloudwatch_host(Host, AwsConfig) ->
+    AwsConfig#aws_config{
+        cloudwatch_logs_host = Host
+    }.
 %%==============================================================================
 %% CloudWatch API
 %%==============================================================================
@@ -150,6 +156,12 @@ describe_log_groups(LogGroupNamePrefix, Limit, PrevToken, Config) ->
     end.
 
 
+create_log_stream(LogGroupName, LogStreamName, Config) ->
+    cw_request(Config, "CreateLogStream", [
+      {<<"logGroupName">>, LogGroupName},
+      {<<"logStreamName">>, LogStreamName}
+    ]).
+
 %%==============================================================================
 %% Internal functions
 %%==============================================================================
@@ -178,6 +190,8 @@ cw_request(Config, Action, Params) ->
                 RequestHeaders,
                 NewConfig
             ) of
+                {ok, <<>>} ->
+                    ok;
                 {ok, ResponseBody} ->
                     {ok, jsx:decode(ResponseBody)};
                 {error, Reason} ->

--- a/test/erlcloud_cloudwatch_logs_tests.erl
+++ b/test/erlcloud_cloudwatch_logs_tests.erl
@@ -38,17 +38,18 @@
 -define(LOG_GROUP_NAME_PREFIX, <<"/aws/apigateway/welcome">>).
 -define(PAGING_TOKEN, <<"arn:aws:logs:us-east-1:352773894028:log-group:/aws/apigateway/welcome:*">>).
 
+-define(LOG_GROUP_NAME, ?LOG_GROUP_NAME_PREFIX).
 
 -define(LOG_GROUP, [
     {<<"arn">>, <<"arn:aws:logs:us-east-1:352773894028:log-group:/aws/apigateway/welcome:*">>},
     {<<"creationTime">>, 1476283527335},
-    {<<"logGroupName">>, <<"/aws/apigateway/welcome">>},
+    {<<"logGroupName">>, ?LOG_GROUP_NAME},
     {<<"metricFilterCount">>, 0},
     {<<"retentionInDays">>, 10},
     {<<"storedBytes">>, 85}
 ]).
 
-
+-define(LOG_STREAM_NAME, <<"logstream">>).
 %%==============================================================================
 %% Test generator functions
 %%==============================================================================
@@ -57,7 +58,8 @@
 erlcloud_cloudwatch_test_() ->
     {foreach, fun start/0, fun stop/1, [
         fun describe_log_groups_input_tests/1,
-        fun describe_log_groups_output_tests/1
+        fun describe_log_groups_output_tests/1,
+        fun create_log_stream_input_tests/1
     ]}.
 
 
@@ -158,6 +160,23 @@ describe_log_groups_output_tests(_) ->
              {ok, [?LOG_GROUP], undefined}}
         )
     ]).
+
+
+create_log_stream_input_tests(_) ->
+    input_tests(<<>>, [
+        ?_cloudwatch_test(
+            {"Tests describing log groups with custom AWS config provided",
+             ?_f(erlcloud_cloudwatch_logs:create_log_stream(
+                 ?LOG_GROUP_NAME,
+                 ?LOG_STREAM_NAME,
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"CreateLogStream">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME},
+              {<<"logStreamName">>, ?LOG_STREAM_NAME}]}
+        )
+      ]).
 
 
 %%==============================================================================

--- a/test/erlcloud_cloudwatch_logs_tests.erl
+++ b/test/erlcloud_cloudwatch_logs_tests.erl
@@ -50,6 +50,7 @@
 ]).
 
 -define(LOG_STREAM_NAME, <<"logstream">>).
+-define(SEQUENCE_TOKEN, <<"49574602524945087512519741869202665284478508564977029746">>).
 %%==============================================================================
 %% Test generator functions
 %%==============================================================================
@@ -59,7 +60,8 @@ erlcloud_cloudwatch_test_() ->
     {foreach, fun start/0, fun stop/1, [
         fun describe_log_groups_input_tests/1,
         fun describe_log_groups_output_tests/1,
-        fun create_log_stream_input_tests/1
+        fun create_log_stream_input_tests/1,
+        fun put_log_events_input_tests/1
     ]}.
 
 
@@ -165,7 +167,7 @@ describe_log_groups_output_tests(_) ->
 create_log_stream_input_tests(_) ->
     input_tests(<<>>, [
         ?_cloudwatch_test(
-            {"Tests describing log groups with custom AWS config provided",
+            {"Tests creating a log stream",
              ?_f(erlcloud_cloudwatch_logs:create_log_stream(
                  ?LOG_GROUP_NAME,
                  ?LOG_STREAM_NAME,
@@ -178,6 +180,44 @@ create_log_stream_input_tests(_) ->
         )
       ]).
 
+put_log_events_input_tests(_) ->
+    input_tests(<<>>, [
+        ?_cloudwatch_test(
+            {"Tests put log events into a stream without a sequence token",
+             ?_f(erlcloud_cloudwatch_logs:put_log_events(
+                 ?LOG_GROUP_NAME,
+                 ?LOG_STREAM_NAME,
+                 [#{message=><<"aaaa">>, timestamp=>11}],
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"PutLogEvents">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"logEvents">>,[
+                                 [{<<"message">>,<<"aaaa">>},{<<"timestamp">>,11}]
+                               ]},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME},
+              {<<"logStreamName">>, ?LOG_STREAM_NAME}]}
+        ),
+        ?_cloudwatch_test(
+            {"Tests put log events into a stream with a sequence token",
+             ?_f(erlcloud_cloudwatch_logs:put_log_events(
+                 ?LOG_GROUP_NAME,
+                 ?LOG_STREAM_NAME,
+                 ?SEQUENCE_TOKEN,
+                 [#{message=><<"aaaa">>, timestamp=>11}],
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"PutLogEvents">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"logEvents">>,[
+                                 [{<<"message">>,<<"aaaa">>},{<<"timestamp">>,11}]
+                               ]},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME},
+              {<<"logStreamName">>, ?LOG_STREAM_NAME},
+              {<<"sequenceToken">>, <<"49574602524945087512519741869202665284478508564977029746">>}
+              ]}
+        )
+      ]).
 
 %%==============================================================================
 %% Internal functions


### PR DESCRIPTION
@motobob I've created two functions that are needed to send log events into cloudwatch. I've had to change the way the `cw_request` function works somewhat, as it didn't support complex requests such as the nested log events. So now it supports returning a map or a list (as it used to do). 

The `put_log_events` function returns a map of the AWS response:
```
erlcloud_cloudwatch_logs:put_log_events(_LogGroup = <<"loggroup">>,
                                        _LogStream = <<"logstream">>,
                                        _SequenceToken = <<"49574602524945087512519741331171438190807382809047470706">>,
                                        _Events = [#{message=><<"aaaa">>, timestamp=>11}],Config).
{ok,#{nextSequenceToken =>
          <<"49574602524945087512519741869202665284478508564977029746">>,
      rejectedLogEventsInfo => #{tooOldLogEventEndIndex => 1}}}
```