### PR TITLE
add ability to pass in the awsRegion when executing aws_request4

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -118,8 +118,9 @@
           %% Currently matches DynamoDB retry
           %% It's likely this is too many retries for other services
           retry_num=10::non_neg_integer(),
-          assume_role = #aws_assume_role{} :: aws_assume_role() %% If a role to be assumed is given
+          assume_role = #aws_assume_role{} :: aws_assume_role(), %% If a role to be assumed is given
           %% then we will try to assume the role during the update_config
+          region=undefined::string()|undefined
          }).
 -type(aws_config() :: #aws_config{}).
 
@@ -146,5 +147,3 @@
           should_retry :: boolean() | undefined
         }).
 -type(aws_request() :: #aws_request{}).
-
-

--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -120,7 +120,7 @@
           retry_num=10::non_neg_integer(),
           assume_role = #aws_assume_role{} :: aws_assume_role(), %% If a role to be assumed is given
           %% then we will try to assume the role during the update_config
-          region=undefined::string()|undefined
+          aws_region=undefined::string()|undefined
          }).
 -type(aws_config() :: #aws_config{}).
 

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -162,7 +162,7 @@ aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Headers, Confi
     end.
 
 aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service,
-                       Headers, #aws_config{region = AwsRegion} = Config) ->
+                       Headers, #aws_config{aws_region = AwsRegion} = Config) ->
     Query = erlcloud_http:make_query_string(Params),
     Region = case AwsRegion of
       undefined -> aws_region_from_host(Host);

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -4,7 +4,7 @@
          aws_request_xml/5, aws_request_xml/6, aws_request_xml/7, aws_request_xml/8,
          aws_request2/7,
          aws_request_xml2/5, aws_request_xml2/7,
-         aws_request4/8, aws_request4/9,
+         aws_request4/8, aws_request4/9, aws_request4/10,
          aws_request_xml4/6, aws_request_xml4/8,
          aws_region_from_host/1,
          aws_request_form/8,
@@ -153,18 +153,24 @@ aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) ->
     aws_request4(Method, Protocol, Host, Port, Path, Params, Service, [], Config).
 
 aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Headers, Config) ->
+    aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Headers, Config, undefined).
+
+aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Headers, Config, AwsRegion) ->
     case update_config(Config) of
         {ok, Config1} ->
             aws_request4_no_update(Method, Protocol, Host, Port, Path, Params,
-                                   Service, Headers, Config1);
+                                   Service, Headers, Config1, AwsRegion);
         {error, Reason} ->
             {error, Reason}
     end.
 
 aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service,
-                       Headers, #aws_config{} = Config) ->
+                       Headers, #aws_config{} = Config, AwsRegion) ->
     Query = erlcloud_http:make_query_string(Params),
-    Region = aws_region_from_host(Host),
+    Region = case AwsRegion of
+        undefined -> aws_region_from_host(Host);
+        _ -> AwsRegion
+    end,
     SignedHeaders = case Method of
         M when M =:= get orelse M =:= head orelse M =:= delete ->
             sign_v4(M, Path, Config, [{"host", Host}],

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -4,7 +4,7 @@
          aws_request_xml/5, aws_request_xml/6, aws_request_xml/7, aws_request_xml/8,
          aws_request2/7,
          aws_request_xml2/5, aws_request_xml2/7,
-         aws_request4/8, aws_request4/9, aws_request4/10,
+         aws_request4/8, aws_request4/9,
          aws_request_xml4/6, aws_request_xml4/8,
          aws_region_from_host/1,
          aws_request_form/8,
@@ -146,30 +146,27 @@ aws_region_from_host(Host) ->
         [_, Value, _, _ | _Rest] ->
             Value;
         _ ->
-            "us-east-1"
+            application:get_env(erlcloud, aws_region, "us-east-1")
     end.
 
 aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) ->
     aws_request4(Method, Protocol, Host, Port, Path, Params, Service, [], Config).
 
 aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Headers, Config) ->
-    aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Headers, Config, undefined).
-
-aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Headers, Config, AwsRegion) ->
     case update_config(Config) of
         {ok, Config1} ->
             aws_request4_no_update(Method, Protocol, Host, Port, Path, Params,
-                                   Service, Headers, Config1, AwsRegion);
+                                   Service, Headers, Config1);
         {error, Reason} ->
             {error, Reason}
     end.
 
 aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service,
-                       Headers, #aws_config{} = Config, AwsRegion) ->
+                       Headers, #aws_config{region = AwsRegion} = Config) ->
     Query = erlcloud_http:make_query_string(Params),
     Region = case AwsRegion of
-        undefined -> aws_region_from_host(Host);
-        _ -> AwsRegion
+      undefined -> aws_region_from_host(Host);
+      _ -> AwsRegion
     end,
     SignedHeaders = case Method of
         M when M =:= get orelse M =:= head orelse M =:= delete ->


### PR DESCRIPTION
[The assumption](https://github.com/erlcloud/erlcloud/blob/master/src/erlcloud_aws.erl#L139) that the second element in the host is an aws region is not always true.