### PR TITLE
uri encode path before sign_v4

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -165,12 +165,13 @@ aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service,
                        Headers, #aws_config{} = Config) ->
     Query = erlcloud_http:make_query_string(Params),
     Region = aws_region_from_host(Host),
+    Uri = erlcloud_http:url_encode_loose(Path),
     SignedHeaders = case Method of
         M when M =:= get orelse M =:= head orelse M =:= delete ->
-            sign_v4(M, Path, Config, [{"host", Host}],
+            sign_v4(M, Uri, Config, [{"host", Host}],
                     [], Region, Service, Params);
         _ ->
-            sign_v4(Method, Path, Config,
+            sign_v4(Method, Uri, Config,
                     [{"host", Host}], list_to_binary(Query),
                     Region, Service, [])
     end,


### PR DESCRIPTION
if path contains any special characters, it needs to be uri encoded before calculating the signature, otherwise the signature will do not match with the one calculated by aws.

NOTE: we can't pass the uri encoded path to the `aws_request4` method, because it will be uri encoded second time (while making the actual request). 
example: 
instead of `:` -> `%3`, we'll get `:` -> `%3` -> `%253` 