### PR TITLE
[sqs-batch-entry-spec-error]: Fixup batch_entry() type.

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -45,7 +45,7 @@
                                     created_timestamp | last_modified_timestamp | policy |
                                     queue_arn).
 
--type(batch_entry() :: [{string(), string()}]).
+-type(batch_entry() :: {string(), string()}).
 
 -spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->


### PR DESCRIPTION
It appears that the batch_entry() type has been doubly wrapped in a list
type, as all usages of the type are also wrapped in a list. From the
naming, I assume the intent was for the type to be singular.

Found while attempting to type check usage of
erlcloud_sqs:delete_message_batch, but problem appears to be general to
all usages of erlcloud_sqs:batch_entry().