### PR TITLE
profile fix

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -164,7 +164,6 @@ aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Headers, Confi
 aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service,
                        Headers, #aws_config{aws_region = AwsRegion} = Config) ->
     Query = erlcloud_http:make_query_string(Params),
-    Region = aws_region_from_host(Host),
     Uri = erlcloud_http:url_encode_loose(Path),
     Region = case AwsRegion of
       undefined -> aws_region_from_host(Host);
@@ -458,7 +457,7 @@ config_env() ->
 
 -spec config_metadata(task_credentials | instance_metadata) -> {ok, #metadata_credentials{}} | {error, atom()}.
 config_metadata(Source) ->
-    Config = default_config(),
+    Config = #aws_config{},
     case get_metadata_credentials( Source, Config ) of
         {ok, #metadata_credentials{
                 access_key_id = Id,
@@ -1203,7 +1202,7 @@ profiles_credentials( Keys, SourceProfile ) ->
     {cont, SourceProfile, RoleArn, ExternalId}.
 
 profiles_assume( Credential, undefined, __ExternalId, _Options ) ->
-    Config = config_credential(Credential, default_config()),
+    Config = config_credential(Credential, #aws_config{}),
     {ok, Config};
 profiles_assume( Credential, Role, ExternalId,
                  #profile_options{ session_name = Name,
@@ -1212,7 +1211,7 @@ profiles_assume( Credential, Role, ExternalId,
     ExtId = if ExternalId =/= undefined -> ExternalId;
                ExternalId =:= undefined -> DefaultExternalId
             end,
-    Config = config_credential(Credential, default_config()),
+    Config = config_credential(Credential, #aws_config{}),
     {AssumedConfig, _Creds} =
         erlcloud_sts:assume_role( Config, Role, Name, Duration, ExtId ),
     {ok, AssumedConfig}.


### PR DESCRIPTION
Problem:
#432 

Solution:
it appears that [merge](https://github.com/erlcloud/erlcloud/blob/a0e95dfedb68c3878ae3e60ef8e7390f7cb0d6db/src/erlcloud_aws.erl#L167) was bad and that is really cause of #430 
original PR has L167 [removed](https://github.com/knyastasia/erlcloud/blob/0e2fe3589c4b64956f491f721966282d4fa5edff/src/erlcloud_aws.erl#L167-L170)
With changes #431, ``default_config()`` builds ``aws_config`` based on environment variables which is not fine for building ``profile`` from scratch using ``assume_role`` (fix has been validated)
It also seems that we don't need ``default_config()`` for calling meta as meta IP are hardcoded although I did not check that

Reviewers:
@motobob or @kkuzmin  