### PR TITLE
Custom datatypes in message attributes

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -361,11 +361,11 @@ decode_message_attribute(Attributes) ->
     F = fun(Attr) ->
                 Name = erlcloud_xml:get_text("Name", Attr),
                 DataType = erlcloud_xml:get_text("Value/DataType", Attr),
-                Value = case string:find(DataType, "Binary") of
-                            nomatch ->
-                                erlcloud_xml:get_text("Value/StringValue", Attr);
+                Value = case string:rstr(DataType, "Binary") of
+                            1 ->
+                                erlcloud_xml:get_text("Value/BinaryValue", Attr);
                             _ ->
-                                erlcloud_xml:get_text("Value/BinaryValue", Attr)
+                                erlcloud_xml:get_text("Value/StringValue", Attr)
                         end,
                 {Name, DataType, Value}
         end,

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -358,21 +358,37 @@ decode_message_attributes(Attributes) ->
         {Name, DataType, StringValue} <- decode_message_attribute(Attributes)].
 
 decode_message_attribute(Attributes) ->
-    [{erlcloud_xml:get_text("Name", Attr),
-      erlcloud_xml:get_text("Value/DataType", Attr),
-      erlcloud_xml:get_text("Value/StringValue", Attr)} || Attr <- Attributes].
+    F = fun(Attr) ->
+                Name = erlcloud_xml:get_text("Name", Attr),
+                DataType = erlcloud_xml:get_text("Value/DataType", Attr),
+                Value = case string:find(DataType, "Binary") of
+                            nomatch ->
+                                erlcloud_xml:get_text("Value/StringValue", Attr);
+                            _ ->
+                                erlcloud_xml:get_text("Value/BinaryValue", Attr)
+                        end,
+                {Name, DataType, Value}
+        end,
+    [F(Attr) || Attr <- Attributes].
 
-decode_message_attribute_value("Number", Value) ->
-    case lists:member($., Value) of
-        true ->
-            list_to_float(Value);
-        false ->
-            list_to_integer(Value)
-    end;
-decode_message_attribute_value("Binary", Value) ->
+decode_message_attribute_value(["Number", "int"], Value) ->
+    list_to_integer(Value);
+decode_message_attribute_value(["Number", "int", CustomType], Value) ->
+    {CustomType, list_to_integer(Value)};
+decode_message_attribute_value(["Number", "float"], Value) ->
+    list_to_float(Value);
+decode_message_attribute_value(["Number", "float", CustomType], Value) ->
+    {CustomType, list_to_float(Value)};
+decode_message_attribute_value(["String"], Value) ->
+    Value;
+decode_message_attribute_value(["String", CustomType], Value) ->
+    {CustomType, Value};
+decode_message_attribute_value(["Binary"], Value) ->
     list_to_binary(Value);
-decode_message_attribute_value("String", Value) ->
-    Value.
+decode_message_attribute_value(["Binary", CustomType], Value) ->
+    {CustomType, list_to_binary(Value)};
+decode_message_attribute_value(DataType, Value) ->
+    decode_message_attribute_value(string:split(DataType, "."), Value).
 
 decode_msg_attributes(Attrs)  ->
     [{decode_msg_attribute_name(Name),
@@ -607,23 +623,37 @@ encode_message_attributes(Attributes) ->
 encode_message_attribute({Key, Value}) ->
     [
       {"Value.DataType", encode_message_attribute_type(Value)},
-      {"Value.StringValue", encode_message_attribute_value(Value)},
+     encode_message_attribute_value(Value),
       {"Name", Key}
     ].
 
+encode_message_attribute_value({_CustomType, Value}) ->
+    encode_message_attribute_value(Value);
 encode_message_attribute_value(Value) when is_integer(Value) ->
-    integer_to_list(Value);
+    {"Value.StringValue", integer_to_list(Value)};
 encode_message_attribute_value(Value) when is_float(Value) ->
-    float_to_list(Value, [{decimals, 12}, compact]);
+    {"Value.StringValue", float_to_list(Value, [{decimals, 12}, compact])};
 encode_message_attribute_value(Value) when is_list(Value) ->
-    Value;
+    {"Value.StringValue", Value};
 encode_message_attribute_value(Value) when is_binary(Value) ->
-    binary_to_list(Value).
+    {"Value.BinaryValue", binary_to_list(Value)}.
 
+encode_message_attribute_type({CustomType, Value})
+  when is_list(CustomType) andalso is_integer(Value) ->
+    ["Number.int.", CustomType];
+encode_message_attribute_type({CustomType, Value})
+  when is_list(CustomType) andalso is_float(Value) ->
+    ["Number.float.", CustomType];
+encode_message_attribute_type({CustomType, Value})
+  when is_list(CustomType) andalso is_list(Value) ->
+    ["String.", CustomType];
+encode_message_attribute_type({CustomType, Value})
+  when is_list(CustomType) andalso is_binary(Value) ->
+    ["Binary.", CustomType];
 encode_message_attribute_type(Value) when is_integer(Value) ->
-    "Number";
+    "Number.int";
 encode_message_attribute_type(Value) when is_float(Value) ->
-    "Number";
+    "Number.float";
 encode_message_attribute_type(Value) when is_list(Value) ->
     "String";
 encode_message_attribute_type(Value) when is_binary(Value) ->

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -388,7 +388,7 @@ decode_message_attribute_value(["Binary"], Value) ->
 decode_message_attribute_value(["Binary", CustomType], Value) ->
     {CustomType, list_to_binary(Value)};
 decode_message_attribute_value(DataType, Value) ->
-    decode_message_attribute_value(string:split(DataType, "."), Value).
+    decode_message_attribute_value(string:tokens(DataType, "."), Value).
 
 decode_msg_attributes(Attrs)  ->
     [{decode_msg_attribute_name(Name),

--- a/test/erlcloud_sqs_tests.erl
+++ b/test/erlcloud_sqs_tests.erl
@@ -140,7 +140,8 @@ send_message_with_message_attributes(_) ->
     MessageAttributes = [{"first", "value"},
                          {"second", 1},
                          {"third", 3.14159265359},
-                         {"fourth", <<"binary">>}],
+                         {"fourth", <<"binary">>},
+                         {"uuid", {"uuid", <<"db3bf1fc-0cac-4cf8-8d2c-5c307ad4ac3a">>}}],
     Expected = [
                 {"Action", "SendMessage"},
                 {"MessageAttribute.1.Name", "first"},
@@ -148,13 +149,16 @@ send_message_with_message_attributes(_) ->
                 {"MessageAttribute.1.Value.DataType", "String"},
                 {"MessageAttribute.2.Name", "second"},
                 {"MessageAttribute.2.Value.StringValue", "1"},
-                {"MessageAttribute.2.Value.DataType", "Number"},
+                {"MessageAttribute.2.Value.DataType", "Number.int"},
                 {"MessageAttribute.3.Name", "third"},
                 {"MessageAttribute.3.Value.StringValue", "3.14159265359"},
-                {"MessageAttribute.3.Value.DataType", "Number"},
+                {"MessageAttribute.3.Value.DataType", "Number.float"},
                 {"MessageAttribute.4.Name", "fourth"},
-                {"MessageAttribute.4.Value.StringValue", "binary"},
+                {"MessageAttribute.4.Value.BinaryValue", "binary"},
                 {"MessageAttribute.4.Value.DataType", "Binary"},
+                {"MessageAttribute.5.Name", "uuid"},
+                {"MessageAttribute.5.Value.DataType", "Binary.uuid"},
+                {"MessageAttribute.5.Value.BinaryValue", "db3bf1fc-0cac-4cf8-8d2c-5c307ad4ac3a"},
                 {"MessageBody", MessageBody}
                ],
     Tests =
@@ -220,14 +224,14 @@ receive_messages_with_message_attributes(_) ->
       <MessageAttribute>
         <Name>float</Name>
         <Value>
-          <DataType>Number</DataType>
+          <DataType>Number.float</DataType>
           <StringValue>3.1415926</StringValue>
         </Value>
       </MessageAttribute>
       <MessageAttribute>
         <Name>integer</Name>
         <Value>
-          <DataType>Number</DataType>
+          <DataType>Number.int</DataType>
           <StringValue>42</StringValue>
         </Value>
       </MessageAttribute>
@@ -235,7 +239,14 @@ receive_messages_with_message_attributes(_) ->
         <Name>binary</Name>
         <Value>
           <DataType>Binary</DataType>
-          <StringValue>Binary string</StringValue>
+          <BinaryValue>Binary string</BinaryValue>
+        </Value>
+      </MessageAttribute>
+      <MessageAttribute>
+        <Name>uuid</Name>
+        <Value>
+          <DataType>Binary.uuid</DataType>
+          <BinaryValue>db3bf1fc-0cac-4cf8-8d2c-5c307ad4ac3a</BinaryValue>
         </Value>
       </MessageAttribute>
     </Message>
@@ -259,7 +270,8 @@ receive_messages_with_message_attributes(_) ->
                                                    {"content-type", "application/json"},
                                                    {"float", 3.1415926},
                                                    {"integer", 42},
-                                                   {"binary", <<"Binary string">>}
+                                                   {"binary", <<"Binary string">>},
+                                                   {"uuid", {"uuid", <<"db3bf1fc-0cac-4cf8-8d2c-5c307ad4ac3a">>}}
                                                   ]}
                             ]]}],
     Tests =


### PR DESCRIPTION
Here we have added support for custom message attribute data types for
SQS messages based on the documentation found
http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-data-types-validation.

We have also encoded Float and Integer types using custom data types
since the SQS API only supports a generic Number type. When we receive
a message with a Number attribute we don't know whether it is expected
to be represented as a float or an integer. Previously, we would parse
the data attribute string value for the presence of a `$.`.