### PR TITLE
allow option to return all headers from put_object

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -959,7 +959,7 @@ put_object(BucketName, Key, Value, Options, HTTPHeaders, Config)
     POSTData = iolist_to_binary(Value),
     {Headers, _Body} = s3_request(Config, put, BucketName, [$/|Key], "", [],
                                   POSTData, RequestHeaders),
-     [{version_id, proplists:get_value("x-amz-version-id", Headers, "null")} | Headers].
+    [{version_id, proplists:get_value("x-amz-version-id", Headers, "null")} | Headers].
 
 -spec set_object_acl(string(), string(), proplist()) -> ok.
 

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -959,7 +959,10 @@ put_object(BucketName, Key, Value, Options, HTTPHeaders, Config)
     POSTData = iolist_to_binary(Value),
     {Headers, _Body} = s3_request(Config, put, BucketName, [$/|Key], "", [],
                                   POSTData, RequestHeaders),
-    [{version_id, proplists:get_value("x-amz-version-id", Headers, "null")}].
+    case proplists:is_defined(return_all_headers, Options) of
+        true -> Headers;
+        false -> [{version_id, proplists:get_value("x-amz-version-id", Headers, "null")}]
+    end.
 
 -spec set_object_acl(string(), string(), proplist()) -> ok.
 

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -959,10 +959,7 @@ put_object(BucketName, Key, Value, Options, HTTPHeaders, Config)
     POSTData = iolist_to_binary(Value),
     {Headers, _Body} = s3_request(Config, put, BucketName, [$/|Key], "", [],
                                   POSTData, RequestHeaders),
-    case proplists:is_defined(return_all_headers, Options) of
-        true -> Headers;
-        false -> [{version_id, proplists:get_value("x-amz-version-id", Headers, "null")}]
-    end.
+     [{version_id, proplists:get_value("x-amz-version-id", Headers, "null")} | Headers].
 
 -spec set_object_acl(string(), string(), proplist()) -> ok.
 

--- a/test/erlcloud_s3_tests.erl
+++ b/test/erlcloud_s3_tests.erl
@@ -194,7 +194,9 @@ put_object_tests(_) ->
     Response = {ok, {{200, "OK"}, [{"x-amz-version-id", "version_id"}], <<>>}},
     meck:expect(erlcloud_httpc, request, httpc_expect(put, Response)),
     Result = erlcloud_s3:put_object("BucketName", "Key", "Data", config()),
-    ?_assertEqual([{version_id, "version_id"} | _], Result).
+    ?_assertEqual([{version_id, "version_id"}
+                  ,{"x-amz-version-id", "version_id"}
+                  ], Result).
 
 dns_compliant_name_tests(_) ->
     [?_assertEqual(true,  erlcloud_util:is_dns_compliant_name("goodname123")),

--- a/test/erlcloud_s3_tests.erl
+++ b/test/erlcloud_s3_tests.erl
@@ -194,7 +194,7 @@ put_object_tests(_) ->
     Response = {ok, {{200, "OK"}, [{"x-amz-version-id", "version_id"}], <<>>}},
     meck:expect(erlcloud_httpc, request, httpc_expect(put, Response)),
     Result = erlcloud_s3:put_object("BucketName", "Key", "Data", config()),
-    ?_assertEqual([{version_id, "version_id"}], Result).
+    ?_assertEqual([{version_id, "version_id"} | _], Result).
 
 dns_compliant_name_tests(_) ->
     [?_assertEqual(true,  erlcloud_util:is_dns_compliant_name("goodname123")),


### PR DESCRIPTION

we have the need to collect other metadata
