### PR TITLE
(#439) : fix environment variable at auto_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can provide your amazon credentials in OS environmental variables
 ```
 export AWS_ACCESS_KEY_ID=<Your AWS Access Key>
 export AWS_SECRET_ACCESS_KEY=<Your AWS Secret Access Key>
-export AWS_SECURITY_TOKEN=<Your AWS Security Token>
+export AWS_SESSION_TOKEN=<Your AWS Security Token>
 export AWS_REGION=<Your region>
 ```
 If you did not provide your amazon credentials in the OS environmental variables, then you need to provide configuration read from your profile:
@@ -114,7 +114,7 @@ Or you can provide them via `erlcloud` application environment variables.
 ```erlang
 application:set_env(erlcloud, aws_access_key_id, "your key"),
 application:set_env(erlcloud, aws_secret_access_key, "your secret key"),
-application:set_env(erlcloud, aws_security_token, "your token"),
+application:set_env(erlcloud, aws_session_token, "your token"),
 application:set_env(erlcloud, aws_region, "your region"),
 ```
 ### Using Access Key ###

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can provide your amazon credentials in OS environmental variables
 export AWS_ACCESS_KEY_ID=<Your AWS Access Key>
 export AWS_SECRET_ACCESS_KEY=<Your AWS Secret Access Key>
 export AWS_SESSION_TOKEN=<Your AWS Security Token>
-export AWS_REGION=<Your region>
+export AWS_DEFAULT_REGION=<Your region>
 ```
 If you did not provide your amazon credentials in the OS environmental variables, then you need to provide configuration read from your profile:
 ```
@@ -114,7 +114,7 @@ Or you can provide them via `erlcloud` application environment variables.
 ```erlang
 application:set_env(erlcloud, aws_access_key_id, "your key"),
 application:set_env(erlcloud, aws_secret_access_key, "your secret key"),
-application:set_env(erlcloud, aws_session_token, "your token"),
+application:set_env(erlcloud, aws_security_token, "your token"),
 application:set_env(erlcloud, aws_region, "your region"),
 ```
 ### Using Access Key ###

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -323,7 +323,7 @@ default_config() ->
 default_config_wrap() ->
     Id = default_config_get(?AWS_ACCESS, aws_access_key_id),
     Key = default_config_get(?AWS_SECRET, aws_secret_access_key),
-    Token = default_config_get(?AWS_SESSION, aws_session_token),
+    Token = default_config_get(?AWS_SESSION, aws_security_token),
     Region = default_config_get(?AWS_REGION, aws_region),
     default_config_region(default_config_assert(Id, Key, Token), Region).
 


### PR DESCRIPTION
__WHY__
See the bug #439
See the official doc http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html

__WHAT__
* Support old and new version of variable names at config phase
* Make unit test for auto_config