### PR TITLE
fix guard for erlcloud:send_message/5

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -425,10 +425,11 @@ send_message(QueueName, MessageBody, DelaySeconds, Config) ->
     send_message(QueueName, MessageBody, DelaySeconds, [], Config).
 
 -spec send_message(string(), string(), 0..900 | none, [message_attribute()], aws_config()) -> proplist().
-send_message(QueueName, MessageBody, DelaySeconds, MessageAttributes, Config)
-  when is_list(QueueName), is_list(MessageBody), is_record(Config, aws_config),
-       (DelaySeconds >= 0 andalso DelaySeconds =< 900) orelse
-       DelaySeconds =:= none andalso is_list(MessageAttributes) ->
+send_message(QueueName, MessageBody, DelaySeconds, MessageAttributes, #aws_config{}=Config)
+  when is_list(QueueName) andalso 
+       is_list(MessageBody) andalso
+       ((DelaySeconds >= 0 andalso DelaySeconds =< 900) orelse DelaySeconds =:= none) andalso 
+       is_list(MessageAttributes) ->
     EncodedMessageAttributes = encode_message_attributes(MessageAttributes),
     Doc = sqs_xml_request(Config, QueueName, "SendMessage",
                           [{"MessageBody", MessageBody},


### PR DESCRIPTION
The logic in the guard related to `DelaySeconds` seemed wrong. 
The `orelse` as lower precedence than `andalso` so the old guard was effectively an or consisting of two ands.

Also replaced `,` with `andalso` in the guard to make it more uniform.
Plus moved the check `is_record(Config, aws_config)` into the function clause as a pattern match as that is the more common way of doing it.