### PR TITLE
avoid that aws:auto_config/0 returns {ok, undefined}

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -415,7 +415,12 @@ default_config_region_services() ->
 %% return <code>undefined</code>.
 %%
 auto_config() ->
-    auto_config( [] ).
+    case auto_config( [] ) of
+        {ok, #aws_config{}} = Res ->
+            Res;
+        _ ->
+            undefined
+    end.
 
 
 %%%---------------------------------------------------------------------------


### PR DESCRIPTION
If you call erlcloud_aws:auto_config/0 without the correct environment variables it
returns `{ok, undefined}`, which is a violation of its spec.

A deeper fix would be to fix the underlying problem in either auto_config_profile,
default_config_region or default_config_get.

This solution allows usage of the function in a fail-fast manner, which is good enough
for starters.