### PR TITLE
make ecs encode_host accept empty host

### DIFF
--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -562,7 +562,9 @@ encode_load_balancers(Balancers) ->
 
 -spec encode_volume_host([{source_path, string_param()}]) -> [json_pair()].
 encode_volume_host([{source_path, Path}]) ->
-    [{source_path, to_binary(Path)}].
+    [{source_path, to_binary(Path)}];
+encode_volume_host([]) ->
+    [].
 
 -spec encode_volumes(volumes()) -> [json_pair()].
 encode_volumes(Volumes) ->


### PR DESCRIPTION
Without this fix it is not possible to register a task with an empty host description

I needed to create a volume to share Unix Domain Sockets between two containers in an ECS task and in that case the host should be like this:

```json
"volumes": [
            {
                "host": {},
                "name": "sockdir"
            }
        ]
```

The fix will allow this kind of input.

The ECS documentation states that both `name` and `host` are optional (as I read it), that does not make full sense in my head. 

One could argue that just omitting `host`  would also be a way to do this (requires a different fix) but then it becomes less obvious that `name` and `host` belong together. Seems nicer to state `host` as `{}` for this use case.