### PR TITLE
Protece auto_config/1 against default_config_region/2 returning undef…

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -457,7 +457,7 @@ auto_config( ProfileOptions ) ->
     % the result in a {ok, ...} tuple.
     case default_config_region(Cfg, default_config_get(?AWS_REGION, aws_region)) of
         undefined  ->
-            undefined
+            undefined;
         Other ->
             Other
     end.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -456,8 +456,8 @@ auto_config( ProfileOptions ) ->
     % Since default_config_region/2 can return undefined we cannot blindly wrap
     % the result in a {ok, ...} tuple.
     case default_config_region(Cfg, default_config_get(?AWS_REGION, aws_region)) of
-        undefined  ->
-            undefined;
+        #aws_config{} = Config ->
+            {ok, Config};
         Other ->
             Other
     end.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -446,11 +446,21 @@ auto_config() ->
 %% @see profile/2
 %%
 auto_config( ProfileOptions ) ->
-    {ok, Cfg } = case config_env() of
-        {ok, _Config} = Result -> Result;
-        {error, _} -> auto_config_profile( ProfileOptions )
-    end,
-    {ok, default_config_region(Cfg, default_config_get(?AWS_REGION, aws_region))}.
+    {ok, Cfg } =
+        case config_env() of
+            {ok, _Config} = Result ->
+                Result;
+            {error, _} ->
+                auto_config_profile( ProfileOptions )
+        end,
+    % Since default_config_region/2 can return undefined we cannot blindly wrap
+    % the result in a {ok, ...} tuple.
+    case default_config_region(Cfg, default_config_get(?AWS_REGION, aws_region)) of
+        undefined  ->
+            undefined
+        Other ->
+            Other
+    end.
 
 auto_config_profile( ProfileOptions ) ->
     Profile = proplists:get_value( profile, ProfileOptions, default ),


### PR DESCRIPTION
…ined

default_config_region/2 can return undefined, so we cannot blindly wrap that result in `{ok, ...}` as that would
violate the return type for auto_config/1, which is `{ok, #aws_config{}} | undefined`