### PR TITLE
erlcloud_ddb2: add support for SSE in DynamoDB

### DIFF
--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -51,6 +51,7 @@
          latest_stream_label :: binary(),
          local_secondary_indexes :: [#ddb2_local_secondary_index_description{}],
          provisioned_throughput :: #ddb2_provisioned_throughput_description{},
+         sse_description :: undefined | erlcloud_ddb2:sse_description(),
          stream_specification :: erlcloud_ddb2:stream_specification(),
          table_arn :: binary(),
          table_name :: binary(),


### PR DESCRIPTION
AWS recently added [Encryption at Rest](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html) (SSE) support to DynamoDB. This change adds support for turning it on in [CreateTable](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html) and checking it in [DescribeTable](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html)