### PR TITLE
fix erlcloud_aws:default_config_region()

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -698,7 +698,10 @@ service_config( <<"athena">> = Service, Region, Config ) ->
 service_config(<<"cloudwatch_logs">>, Region, Config)->
     Host = service_host(<<"logs">>, Region),
     Config#aws_config{cloudwatch_logs_host = Host};
-service_config( <<"waf">>, _Region, Config ) -> Config.
+service_config( <<"waf">>, _Region, Config ) -> Config;
+service_config( <<"cur">>, Region, Config ) ->
+    Host = service_host(<<"cur">>, Region),
+    Config#aws_config{cur_host = Host}.
 
 %%%---------------------------------------------------------------------------
 -spec service_host( Service :: binary(),

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -360,6 +360,10 @@ profiles_assume_cleanup(P) ->
     profiles_test_cleanup(P),
     meck:unload( erlcloud_sts ).
 
+default_config_region_sunny_test() ->
+    Region = <<"ca-central-1">>,
+    ?assertMatch(#aws_config{},
+        erlcloud_aws:default_config_region(#aws_config{}, Region)).
 
 service_config_autoscaling_test() ->
     Service = <<"autoscaling">>,


### PR DESCRIPTION
## Problem:
https://github.com/erlcloud/erlcloud/pull/476 broke `erlcloud_aws:default_config_region()`

## Solution: 
add `cur` service to `erlcloud_aws:service_config()`

@motobob please take a look
@alexturkin FYI