### PR TITLE
Fix cyclic includes

### DIFF
--- a/include/erlcloud.hrl
+++ b/include/erlcloud.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_hrl).
+-define(erlcloud_hrl, 0).
+
 -type proplist() :: proplists:proplist().
 -type datetime() :: {{pos_integer(), 1..12, 1..31}, {0..23, 0..59, 0..60}}.
 -type paging_token() :: binary() | undefined.
@@ -6,3 +9,5 @@
 -type error_result() :: {error, Reason :: term()}.
 -type result_paged(ObjectType) :: success_result_paged(ObjectType) | error_result().
 -type result(ObjectType) :: {ok, [ObjectType]} | error_result().
+
+-endif.

--- a/include/erlcloud_as.hrl
+++ b/include/erlcloud_as.hrl
@@ -1,4 +1,6 @@
-%% need this include for datetime() type:
+-ifndef(erlcloud_as_hrl).
+-define(erlcloud_as_hrl, 0).
+
 -include("erlcloud.hrl").
 
 -record(aws_autoscaling_tag, {
@@ -73,3 +75,5 @@
           lifecycle_transition :: string()
          }).
 -type(aws_autoscaling_lifecycle_hook() :: #aws_autoscaling_lifecycle_hook{}).
+
+-endif.

--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_aws_hrl).
+-define(erlcloud_aws_hrl, 0).
+
 -record(aws_assume_role,{
     role_arn :: string() | undefined,
     session_name = "erlcloud" :: string(),
@@ -161,3 +164,5 @@
         }).
 -type(aws_request() :: #aws_request{}).
 -define(NEXT_TOKEN_LABEL, <<"NextToken">>).
+
+-endif.

--- a/include/erlcloud_ddb.hrl
+++ b/include/erlcloud_ddb.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_ddb).
+-define(erlcloud_ddb, 0).
+
 -record(ddb_provisioned_throughput,
         {read_capacity_units :: undefined | pos_integer(),
          write_capacity_units :: undefined | pos_integer(),
@@ -96,3 +99,4 @@
         {table_description :: undefined | #ddb_table_description{}
         }).
 
+-endif.

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_ddb2_hrl).
+-define(erlcloud_ddb2_hrl, 0).
+
 -record(ddb2_error,
         {attempt :: pos_integer(),
          error_type :: undefined | ddb | http | httpc,
@@ -204,3 +207,4 @@
         {time_to_live_specification :: undefined | #ddb2_time_to_live_specification{}
         }).
 
+-endif.

--- a/include/erlcloud_ddb_streams.hrl
+++ b/include/erlcloud_ddb_streams.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_ddb_streams_hrl).
+-define(erlcloud_ddb_streams_hrl, 0).
+
 -record(ddb_streams_stream,
         {stream_arn :: undefined | erlcloud_ddb_streams:stream_arn(),
          stream_label :: undefined | erlcloud_ddb_streams:stream_label(),
@@ -49,3 +52,5 @@
         {last_evaluated_stream_arn :: undefined | erlcloud_ddb_streams:stream_arn(),
          streams :: undefined | [#ddb_streams_stream{}]
         }).
+
+-endif.

--- a/include/erlcloud_ec2.hrl
+++ b/include/erlcloud_ec2.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_ec2_hrl).
+-define(erlcloud_ec2_hrl, 0).
+
 -type(ec2_shutdown_behavior() :: stop | terminate | undefined).
 -type(ec2_volume_size() :: 1..1024).
 
@@ -143,4 +146,4 @@
           value :: string()
          }).
 
-
+-endif.

--- a/include/erlcloud_ec2.hrl
+++ b/include/erlcloud_ec2.hrl
@@ -1,6 +1,8 @@
 -ifndef(erlcloud_ec2_hrl).
 -define(erlcloud_ec2_hrl, 0).
 
+-include("erlcloud.hrl").
+
 -type(ec2_shutdown_behavior() :: stop | terminate | undefined).
 -type(ec2_volume_size() :: 1..1024).
 

--- a/include/erlcloud_ecs.hrl
+++ b/include/erlcloud_ecs.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_ecs_hrl).
+-define(erlcloud_ecs_hrl, 0).
+
 -include("erlcloud.hrl").
 
 -define(LIMIT_MAX, 100).
@@ -304,3 +307,5 @@
     tasks :: undefined | [#ecs_task{}],
     failures :: undefined | [#ecs_failure{}]
 }).
+
+-endif.

--- a/include/erlcloud_lambda.hrl
+++ b/include/erlcloud_lambda.hrl
@@ -1,2 +1,7 @@
+-ifndef(erlcloud_lambda_hrl).
+-define(erlcloud_lambda_hrl, 0).
+
 -record(erlcloud_lambda_code, {s3Bucket, s3Key, s3ObjectVersion, zipFile}).
 -type(erlcloud_lambda_code() :: #erlcloud_lambda_code{}).
+
+-endif.

--- a/include/erlcloud_mon.hrl
+++ b/include/erlcloud_mon.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_mon_hrl).
+-define(erlcloud_mon_hrl, 0).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% File: erlcloud_mon.hrl
 %% Date: 18-Sep-2011
@@ -67,3 +70,5 @@
           value           ::undefined|float()              %% The value for the metric.
          }).
 -type metric_datum() :: #metric_datum{}.
+
+-endif.

--- a/include/erlcloud_mon.hrl
+++ b/include/erlcloud_mon.hrl
@@ -1,6 +1,8 @@
 -ifndef(erlcloud_mon_hrl).
 -define(erlcloud_mon_hrl, 0).
 
+-include("erlcloud.hrl").
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% File: erlcloud_mon.hrl
 %% Date: 18-Sep-2011

--- a/include/erlcloud_mturk.hrl
+++ b/include/erlcloud_mturk.hrl
@@ -1,6 +1,8 @@
 -ifndef(erlcloud_mturk_hrl).
 -define(erlcloud_mturk_hrl, 0).
 
+-include("erlcloud.hrl").
+
 -record(mturk_mime_type, {type=""::string(), sub_type=""::string()}).
 
 -record(mturk_binary, {

--- a/include/erlcloud_mturk.hrl
+++ b/include/erlcloud_mturk.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_mturk_hrl).
+-define(erlcloud_mturk_hrl, 0).
+
 -record(mturk_mime_type, {type=""::string(), sub_type=""::string()}).
 
 -record(mturk_binary, {
@@ -182,3 +185,5 @@
           uploaded_file_size_in_bytes::undefined|non_neg_integer(),
           uploaded_file_key::undefined|string()
          }).
+
+-endif.

--- a/include/erlcloud_waf.hrl
+++ b/include/erlcloud_waf.hrl
@@ -1,3 +1,6 @@
+-ifndef(erlcloud_waf_hrl).
+-define(erlcloud_waf_hrl, 0).
+
 -type waf_update_action() :: insert | delete.
 -type waf_text_transformation() :: none | compress_white_space | html_entity_decode | lowercase | cmd_line | url_decode.
 -type waf_positional_constraint() :: exactly | starts_with | ends_with | contains | contains_word.
@@ -139,3 +142,5 @@
         xss_match_tuple :: waf_xss_match_tuple()
 }).
 -type(waf_xss_match_set_update() :: #waf_xss_match_set_update{}).
+
+-endif.

--- a/include/erlcloud_xmerl.hrl
+++ b/include/erlcloud_xmerl.hrl
@@ -1,5 +1,10 @@
+-ifndef(erlcloud_xmerl_hrl).
+-define(erlcloud_xmerl_hrl, 0).
+
 -include_lib("xmerl/include/xmerl.hrl").
 
 -type(xmerl_xpath_doc_nodes() :: #xmlElement{} | #xmlAttribute{} | #xmlText{} | #xmlPI{} | #xmlComment{} | #xmlNsNode{}).
 -type(xmerl_xpath_node_entity() :: #xmlDocument{} | xmerl_xpath_doc_nodes()).
 -type(xmerl_xpath_doc_entity() :: #xmlDocument{} | [xmerl_xpath_doc_nodes()]).
+
+-endif.

--- a/test/erlcloud_tests.erl
+++ b/test/erlcloud_tests.erl
@@ -1,0 +1,75 @@
+-module(erlcloud_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+erlcloud_test_() ->
+    {foreach,
+        fun () ->
+            true = code:add_path(get_test_dir())
+        end,
+        [{<<"Single .hrl inclusion: check that 1 .hrl inclusion is enough, when the .hrl is required.">>,
+          fun include_one_by_one/0},
+         {<<"Full .hrl inclusion: check that -include()'ing all .hrl files is not an issue.">>,
+          fun include_all/0}]
+    }.
+
+include_one_by_one() ->
+    {ok, HRLFiles} = file:list_dir(get_include_dir()),
+
+    lists:foreach(
+        fun (HRLFileStr) ->
+            HRLFile = list_to_binary(HRLFileStr),
+            TestFileWithExtension = binary:replace(HRLFile, <<".hrl">>, <<"_include_test.erl">>, []),
+            TestFileWithoutExtension = binary:replace(TestFileWithExtension, <<".erl">>, <<"">>, []),
+            TestFileBeam = binary:replace(TestFileWithExtension, <<".erl">>, <<".beam">>, []),
+            TestFileWithoutExtensionAtom = binary_to_atom(TestFileWithoutExtension, utf8),
+            TestDir = list_to_binary(get_test_dir()),
+            TempFilePath = <<"./", TestDir/binary, "/", TestFileWithExtension/binary>>,
+            TempFilePathStr = binary_to_list(TempFilePath),
+            ok = file:write_file(TempFilePath,
+                                 <<"-module(", TestFileWithoutExtension/binary, ").\n",
+                                   "\n",
+                                   "-include(\"../include/", HRLFile/binary, "\").">>),
+            {ok, TestFileWithoutExtensionAtom} = compile:file(TempFilePathStr),
+            {module, TestFileWithoutExtensionAtom} = code:load_file(TestFileWithoutExtensionAtom),
+            ok = file:delete(TempFilePath),
+            ok = file:delete(TestFileBeam)
+        end,
+        HRLFiles),
+    ok.
+
+include_all() ->
+    {ok, HRLFiles} = file:list_dir(get_include_dir()),
+    
+    IncludeDirectivesStr = ["-include(\"../include/"++HRLFile++"\").\n"|| HRLFile <- HRLFiles],
+    IncludeDirectives = list_to_binary(IncludeDirectivesStr),
+    TestDir = list_to_binary(get_test_dir()),
+    TempFilePath = <<"./", TestDir/binary, "/ercloud_include_all_test.erl">>,
+    TempFilePathStr = binary_to_list(TempFilePath),
+    ok = file:write_file(TempFilePath,
+                         <<"-module(ercloud_include_all_test).\n",
+                           "\n",
+                           IncludeDirectives/binary>>),
+    {ok, ercloud_include_all_test} = compile:file(TempFilePathStr),
+    {module, ercloud_include_all_test} = code:load_file(ercloud_include_all_test),
+    ok = file:delete(TempFilePath),
+    ok = file:delete("ercloud_include_all_test.beam"),
+    ok.
+
+get_test_dir() ->
+    {ok, Cwd} = file:get_cwd(),
+    case filename:basename(Cwd) of
+        ".eunit" -> % rebar 2
+            "../test/";
+        "erlcloud" -> % rebar3
+            "./test/"
+    end.
+
+get_include_dir() ->
+    {ok, Cwd} = file:get_cwd(),
+    case filename:basename(Cwd) of
+        ".eunit" -> % rebar 2
+            "../include";
+        "erlcloud" -> % rebar3
+            "include"
+    end.


### PR DESCRIPTION
As per the discussion in #483...

The main goals of this PR are to:
1. allow inclusion of .hrl files without having to worry about internal -include(...)s, e.g.
`-include("erlcloud_ec2.hrl").` without having to also `-include("erlcloud.hrl").`,
2. allow inclusion of .hrl files without worrying about doing it more than once (e.g.
`-include("erlcloud_mturk.hrl").` and `-include("erlcloud_as.hrl").` in the same module with no issues; there would be issues otherwise, because both header files include "erlcloud.hrl",
3. add tests for the fixed issues.

I hope it's OK to have deleted a comment in erlcloud_as.hrl and an empty line from erlcloud_ec2.hrl.