### PR TITLE
Allow to override default aws_config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,29 @@ EC2 = erlcloud_ec2:new(AccessKeyId, SecretAccessKey [, Hostname])
 erlcloud_ec2:describe_images(EC2).
 ```
 
+### aws_config
+[aws_config](https://github.com/erlcloud/erlcloud/blob/master/include/erlcloud_aws.hrl) record contains many valuable defaults,
+such as protocols and ports for AWS services. You can always redefine them by making new `#aws_config{}` record and
+changing particular fields, then passing the result to any erlcloud function.
+But if you want to change something in runtime this might be tedious and/or not flexible enough.
+
+Alternative approach is to set default fields within the `app.config -> erlcloud -> aws_config` section and
+rely on the config, used by all functions by default.
+
+Example of such app.config:
+
+```erlang
+[
+  {erlcloud, [
+      {aws_config, [
+          {s3_scheme, "http://"},
+          {s3_host, "s3.example.com"}
+      ]}
+  ]}
+].
+```
+
+
 ### Basic use ###
 Then you can start making api calls, like:
 ```


### PR DESCRIPTION
**Problem**
Already built service should be tweakable in order to specify AWS endpoints/ports/protocols.
Example: locally, instead of using real AWS S3 I use a mock, which provides same HTTP interface. I want to adjust app.config of my service and switch it to custom S3 URL.

It might be done differently:
  1. having an /etc/hosts alias
  2. providing custom `#aws_config{}` to each and every `erlcloud` function

Number 1 doesn't really work well, since because of strange combination of `erlcloud` default values and `lhttpc` peculiarities it always using ssl, no matter what.
Number 2 solves the problem, but it is tedious.

**Solution**
Allow to override any given field of `#aws_config{}` record produced by `erlcloud_aws:default_config()` function.

It is achievable through application variables and has such syntax:

```erlang
[
  {erlcloud, [
      {aws_config, [
          {s3_scheme, "http://"},
          {s3_host, "s3.example.com"}
      ]}
  ]}
].
``` 
After this, ` "true = http://" == (erlcloud_aws:default_config())#aws_config.s3_scheme`.