### PR TITLE
erlcloud_ddb2: fix bug in update_global_table/3

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -2615,7 +2615,7 @@ update_global_table(GlobalTableName, ReplicaUpdates) ->
 update_global_table(GlobalTableName, ReplicaUpdates, Opts) when is_list(Opts) ->
     update_global_table(GlobalTableName, ReplicaUpdates, Opts, default_config());
 update_global_table(GlobalTableName, ReplicaUpdates, Config) when is_record(Config, aws_config) ->
-    update_global_table(GlobalTableName, ReplicaUpdates, [], default_config()).
+    update_global_table(GlobalTableName, ReplicaUpdates, [], Config).
 
 %%------------------------------------------------------------------------------
 %% @doc 


### PR DESCRIPTION
Fix ignoring #aws_config{} parameter in `erlcloud_ddb2: update_global_table/3`