### PR TITLE
fix ecs host volume encoding

### DIFF
--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -562,7 +562,7 @@ encode_load_balancers(Balancers) ->
 
 -spec encode_volume_host([{source_path, string_param()}]) -> [json_pair()].
 encode_volume_host([{source_path, Path}]) ->
-    [{source_path, to_binary(Path)}];
+    [{<<"sourcePath">>, to_binary(Path)}];
 encode_volume_host([]) ->
     [].
 


### PR DESCRIPTION
ECS host volumes were not being properly encoded when the source_path option was specified. This corrects it to the JSON value AWS expects.
