### PR TITLE
Add support for DDB Backups in the erlcloud_ddb2 module

### DIFF
--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -17,13 +17,14 @@
 -type date_time() :: number().
 -type global_table_status() :: creating | active | deleting | updating.
 -type table_status() :: creating | updating | deleting | active.
--type backup_status() :: creating | deleted | avaliable.
+-type backup_status() :: creating | deleted | available.
 -type index_status() :: creating | updating | deleting | active.
 -type continuous_backups_status() :: enabled | disabled.
 -type point_in_time_recovery_status() :: enabling | enabled | disabled.
 
 -record(ddb2_replica_description,
-        {region_name :: undefined | binary()}).
+        {region_name :: undefined | binary()
+        }).
 
 -record(ddb2_global_table_description,
         {creation_date_time :: undefined | number(),
@@ -34,7 +35,8 @@
         }).
 
 -record(ddb2_replica,
-        {region_name :: undefined | binary()}).
+        {region_name :: undefined | binary()
+        }).
 
 -record(ddb2_global_table,
         {global_table_name :: undefined | erlcloud_ddb2:table_name(),

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -255,7 +255,7 @@
          backup_creation_date_time :: undefined | date_time(),
          backup_name:: undefined | binary(),
          backup_size_Bytes :: undefined | pos_integer(),
-         backup_status:: undefined | binary()
+         backup_status:: undefined | backup_status()
         }).
 
 -record(ddb2_create_backup,

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -207,4 +207,106 @@
         {time_to_live_specification :: undefined | #ddb2_time_to_live_specification{}
         }).
 
+-record(ddb2_backup_summaries,
+        {backup_arn:: undefined | binary(),
+         backup_creation_date_time :: undefined | date_time(),
+         backup_name:: undefined | binary(),
+         backup_size_bytes :: undefined | pos_integer(),
+         backup_status:: undefined | binary(),
+         table_arn:: undefined | binary(),
+         table_id:: undefined | binary(),
+         table_name:: undefined | binary()
+        }).
+
+
+-record(ddb2_list_backups,
+        {backup_summaries :: undefined | [#ddb2_backup_summaries{}],
+         last_evaluated_backup_arn :: undefined | erlcloud_ddb2:table_name()
+        }).
+
+-record(ddb2_backup_details,
+        {backup_arn:: undefined | binary(),
+         backup_creation_date_time :: undefined | date_time(),
+         backup_name:: undefined | binary(),
+         backup_size_Bytes :: undefined | pos_integer(),
+         backup_status:: undefined | binary()
+        }).
+
+
+-record(ddb2_create_backup,
+        {backup_details :: undefined | #ddb2_backup_details{}
+        }).
+
+
+
+-record(ddb2_provisioned_throughput,
+        {read_capacity_units :: undefined | pos_integer(),
+         write_capacity_units :: undefined | pos_integer()
+        }).
+
+-record(ddb2_source_table_details,
+        {item_count :: undefined | integer(),
+         key_schema :: undefined | erlcloud_ddb2:key_schema(),
+         provisioned_throughput :: undefined | #ddb2_provisioned_throughput{},
+         table_arn :: undefined | binary(),
+         table_creation_date_time :: undefined | number(),
+         table_id :: undefined | number(),
+         table_name :: undefined | binary(),
+         table_size_bytes :: undefined | integer()
+        }).
+
+-record(ddb2_global_secondary_index_info,
+        {index_name :: undefined | erlcloud_ddb2:index_name(),
+         key_schema :: undefined | erlcloud_ddb2:key_schema(),
+         projection :: undefined | erlcloud_ddb2:projection(),
+         provisioned_throughput :: undefined | #ddb2_provisioned_throughput{}
+        }).
+
+-record(ddb2_local_secondary_index_info,
+        {index_name :: undefined | erlcloud_ddb2:index_name(),
+         key_schema :: undefined | erlcloud_ddb2:key_schema(),
+         projection :: undefined | erlcloud_ddb2:projection()
+        }).
+
+-record(ddb2_stream_description,
+        {stream_enabled :: undefined | boolean(),
+         stream_view_type :: undefined | erlcloud_ddb2:stream_view_type()
+        }).
+
+-record(ddb2_source_table_feature_details,
+        {global_secondary_indexes :: undefined | [#ddb2_global_secondary_index_info{}],
+         local_secondary_indexes  :: undefined | [#ddb2_local_secondary_index_info{}],
+         sse_description :: undefined | erlcloud_ddb2:sse_description(),
+         stream_description :: undefined | #ddb2_stream_description{},
+         time_to_live_description :: undefined | #ddb2_time_to_live_description{}
+        }).
+
+-record(ddb2_delete_backup_record,
+        {dackup_details :: undefined | #ddb2_backup_details{},
+         source_table_details :: undefined | #ddb2_source_table_details{},
+         source_table_feature_details :: undefined | #ddb2_source_table_feature_details{}
+        }).
+
+
+-record(ddb2_delete_backup,
+        {backup_description :: undefined | #ddb2_delete_backup_record{}
+        }).
+
+
+-record(point_in_time_recovery_description,
+        {earliest_restorable_date_time :: undefined | number(),
+         latest_restorable_date_time :: undefined | number(),
+         point_in_time_recovery_status :: undefined | binary()
+        }).
+
+
+-record(continuous_backups_description,
+        {continuous_backups_status :: undefined | binary(),
+         point_in_time_recovery_description :: undefined | #point_in_time_recovery_description{}
+        }).
+
+-record(ddb2_continuous_backups_record,
+        {continuous_backups_description :: undefined | #continuous_backups_description{}
+        }).
+
 -endif.

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -17,7 +17,10 @@
 -type date_time() :: number().
 -type global_table_status() :: creating | active | deleting | updating.
 -type table_status() :: creating | updating | deleting | active.
+-type backup_status() :: creating | deleted | avaliable.
 -type index_status() :: creating | updating | deleting | active.
+-type continuous_backups_status() :: enabled | disabled.
+-type point_in_time_recovery_status() :: enabling | enabled | disabled.
 
 -record(ddb2_replica_description,
         {region_name :: undefined | binary()}).
@@ -67,6 +70,13 @@
          projection :: undefined | erlcloud_ddb2:projection()
         }).
 
+-record(ddb2_restore_summary,
+        {restore_date_time ::undefined | date_time(),
+         restore_in_progress :: undefined | boolean(),
+         source_backup_arn :: undefined | binary(),
+         source_table_arn :: undefined | binary()
+        }).
+
 -record(ddb2_table_description,
         {attribute_definitions :: undefined | erlcloud_ddb2:attr_defs(),
          creation_date_time :: undefined | number(),
@@ -77,6 +87,7 @@
          latest_stream_label :: undefined | binary(),
          local_secondary_indexes :: undefined | [#ddb2_local_secondary_index_description{}],
          provisioned_throughput :: undefined | #ddb2_provisioned_throughput_description{},
+         restore_summary :: undefined | #ddb2_restore_summary{},
          sse_description :: undefined | erlcloud_ddb2:sse_description(),
          stream_specification :: undefined | erlcloud_ddb2:stream_specification(),
          table_arn :: undefined | binary(),
@@ -217,19 +228,19 @@
         {time_to_live_specification :: undefined | #ddb2_time_to_live_specification{}
         }).
 
--record(ddb2_backup_summaries,
+-record(ddb2_backup_summary,
         {backup_arn:: undefined | binary(),
          backup_creation_date_time :: undefined | date_time(),
          backup_name:: undefined | binary(),
          backup_size_bytes :: undefined | pos_integer(),
-         backup_status:: undefined | binary(),
+         backup_status:: undefined | backup_status(),
          table_arn:: undefined | binary(),
          table_id:: undefined | binary(),
          table_name:: undefined | binary()
         }).
 
 -record(ddb2_list_backups,
-        {backup_summaries :: undefined | [#ddb2_backup_summaries{}],
+        {backup_summaries :: undefined | [#ddb2_backup_summary{}],
          last_evaluated_backup_arn :: undefined | erlcloud_ddb2:table_name()
         }).
 
@@ -287,29 +298,40 @@
          time_to_live_description :: undefined | #ddb2_time_to_live_description{}
         }).
 
--record(ddb2_delete_backup_record,
-        {dackup_details :: undefined | #ddb2_backup_details{},
+-record(ddb2_backup_description,
+        {backup_details :: undefined | #ddb2_backup_details{},
          source_table_details :: undefined | #ddb2_source_table_details{},
          source_table_feature_details :: undefined | #ddb2_source_table_feature_details{}
         }).
 
 -record(ddb2_delete_backup,
-        {backup_description :: undefined | #ddb2_delete_backup_record{}
+        {backup_description :: undefined | #ddb2_backup_description{}
         }).
 
--record(point_in_time_recovery_description,
+-record(ddb2_describe_backup,
+        {backup_description :: undefined | #ddb2_backup_description{}
+        }).
+
+-record(ddb2_point_in_time_recovery_description,
         {earliest_restorable_date_time :: undefined | number(),
          latest_restorable_date_time :: undefined | number(),
-         point_in_time_recovery_status :: undefined | binary()
+         point_in_time_recovery_status :: undefined | point_in_time_recovery_status()
         }).
 
--record(continuous_backups_description,
-        {continuous_backups_status :: undefined | binary(),
-         point_in_time_recovery_description :: undefined | #point_in_time_recovery_description{}
+-record(ddb2_continuous_backups_description,
+        {continuous_backups_status :: undefined | continuous_backups_status(),
+         point_in_time_recovery_description :: undefined | #ddb2_point_in_time_recovery_description{}
         }).
 
--record(ddb2_continuous_backups_record,
-        {continuous_backups_description :: undefined | #continuous_backups_description{}
+-record(ddb2_describe_continuous_backups,
+        {continuous_backups_description :: undefined | #ddb2_continuous_backups_description{}
         }).
 
+-record(ddb2_restore_table_from_backup,
+        {table_description :: undefined | #ddb2_table_description{}
+        }).
+
+-record(ddb2_restore_table_to_point_in_time,
+       {table_description :: undefined | #ddb2_table_description{}
+       }).
 -endif.

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -21,6 +21,7 @@
 
 -record(ddb2_replica_description,
         {region_name :: undefined | binary()}).
+
 -record(ddb2_global_table_description,
         {creation_date_time :: undefined | number(),
          global_table_arn :: undefined | binary(),
@@ -28,12 +29,15 @@
          global_table_status :: undefined | global_table_status(),
          replication_group :: undefined | [#ddb2_replica_description{}]
         }).
+
 -record(ddb2_replica,
         {region_name :: undefined | binary()}).
+
 -record(ddb2_global_table,
         {global_table_name :: undefined | erlcloud_ddb2:table_name(),
          replication_group :: undefined | [#ddb2_replica{}]
         }).
+
 -record(ddb2_provisioned_throughput_description,
         {last_decrease_date_time :: undefined | date_time(),
          last_increase_date_time :: undefined | date_time(),
@@ -41,6 +45,7 @@
          read_capacity_units :: undefined | pos_integer(),
          write_capacity_units :: undefined | pos_integer()
         }).
+
 -record(ddb2_global_secondary_index_description,
         {backfilling :: undefined | boolean(),
          index_arn :: undefined | binary(),
@@ -52,6 +57,7 @@
          projection :: undefined | erlcloud_ddb2:projection(),
          provisioned_throughput :: undefined | #ddb2_provisioned_throughput_description{}
         }).
+
 -record(ddb2_local_secondary_index_description,
         {index_arn :: undefined | binary(),
          index_name :: undefined | erlcloud_ddb2:index_name(),
@@ -60,6 +66,7 @@
          key_schema :: undefined | erlcloud_ddb2:key_schema(),
          projection :: undefined | erlcloud_ddb2:projection()
         }).
+
 -record(ddb2_table_description,
         {attribute_definitions :: undefined | erlcloud_ddb2:attr_defs(),
          creation_date_time :: undefined | number(),
@@ -77,6 +84,7 @@
          table_size_bytes :: undefined | integer(),
          table_status :: undefined | table_status()
         }).
+
 -record(ddb2_consumed_capacity,
         {capacity_units :: undefined | number(),
          global_secondary_indexes :: undefined | [{erlcloud_ddb2:index_name(), number()}],
@@ -84,6 +92,7 @@
          table :: undefined | number(),
          table_name :: undefined | erlcloud_ddb2:table_name()
         }).
+
 -record(ddb2_item_collection_metrics,
         {item_collection_key :: erlcloud_ddb2:out_attr_value(),
          size_estimate_range_gb :: undefined | {number(), number()}
@@ -93,6 +102,7 @@
         {table :: erlcloud_ddb2:table_name(),
          items :: [erlcloud_ddb2:out_item()]
         }).
+
 -record(ddb2_batch_get_item,
         {consumed_capacity :: undefined | [#ddb2_consumed_capacity{}],
          responses :: undefined | [#ddb2_batch_get_item_response{}],
@@ -218,7 +228,6 @@
          table_name:: undefined | binary()
         }).
 
-
 -record(ddb2_list_backups,
         {backup_summaries :: undefined | [#ddb2_backup_summaries{}],
          last_evaluated_backup_arn :: undefined | erlcloud_ddb2:table_name()
@@ -232,12 +241,9 @@
          backup_status:: undefined | binary()
         }).
 
-
 -record(ddb2_create_backup,
         {backup_details :: undefined | #ddb2_backup_details{}
         }).
-
-
 
 -record(ddb2_provisioned_throughput,
         {read_capacity_units :: undefined | pos_integer(),
@@ -287,18 +293,15 @@
          source_table_feature_details :: undefined | #ddb2_source_table_feature_details{}
         }).
 
-
 -record(ddb2_delete_backup,
         {backup_description :: undefined | #ddb2_delete_backup_record{}
         }).
-
 
 -record(point_in_time_recovery_description,
         {earliest_restorable_date_time :: undefined | number(),
          latest_restorable_date_time :: undefined | number(),
          point_in_time_recovery_status :: undefined | binary()
         }).
-
 
 -record(continuous_backups_description,
         {continuous_backups_status :: undefined | binary(),

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -89,27 +89,29 @@
 %%% DynamoDB API
 -export([batch_get_item/1, batch_get_item/2, batch_get_item/3,
          batch_write_item/1, batch_write_item/2, batch_write_item/3,
-         create_backup/2, create_backup/3,
+         create_backup/2, create_backup/3, create_backup/4,
          create_global_table/2, create_global_table/3, create_global_table/4,
          create_table/5, create_table/6, create_table/7,
-         delete_backup/1, delete_backup/2,
+         delete_backup/1, delete_backup/2, delete_backup/3,
          delete_item/2, delete_item/3, delete_item/4,
          delete_table/1, delete_table/2, delete_table/3,
          describe_backup/1, describe_backup/2, describe_backup/3,
-         describe_continuous_backups/1,describe_continuous_backups/2,describe_continuous_backups/3,
+         describe_continuous_backups/1, describe_continuous_backups/2, describe_continuous_backups/3,
          describe_global_table/1, describe_global_table/2, describe_global_table/3,
          describe_limits/0, describe_limits/1, describe_limits/2,
          describe_table/1, describe_table/2, describe_table/3,
          describe_time_to_live/1, describe_time_to_live/2, describe_time_to_live/3,
          get_item/2, get_item/3, get_item/4,
-         list_backups/0,list_backups/1,list_backups/2,
+         list_backups/0, list_backups/1, list_backups/2,
          list_global_tables/0, list_global_tables/1, list_global_tables/2,
          list_tables/0, list_tables/1, list_tables/2,
          put_item/2, put_item/3, put_item/4,
          %% Note that query is a Erlang reserved word, so we use q instead
          q/2, q/3, q/4,
-         restore_table_from_backup/2,restore_table_from_backup/3,restore_table_from_backup/4,
+         restore_table_from_backup/2, restore_table_from_backup/3, restore_table_from_backup/4,
+         restore_table_to_point_in_time/2,restore_table_to_point_in_time/3,restore_table_to_point_in_time/4,
          scan/1, scan/2, scan/3,
+         update_continuous_backups/2,update_continuous_backups/3,update_continuous_backups/4,
          update_item/3, update_item/4, update_item/5,
          update_global_table/2, update_global_table/3, update_global_table/4,
          update_table/2, update_table/3, update_table/4, update_table/5,
@@ -811,7 +813,21 @@ undynamize_table_status(<<"CREATING">>, _) -> creating;
 undynamize_table_status(<<"UPDATING">>, _) -> updating;
 undynamize_table_status(<<"DELETING">>, _) -> deleting;
 undynamize_table_status(<<"ACTIVE">>, _)   -> active.
-    
+
+-spec undynamize_continuous_backups_status(binary(), undynamize_opts()) -> continuous_backups_status().
+undynamize_continuous_backups_status(<<"ENABLED">>, _) -> enabled;
+undynamize_continuous_backups_status(<<"DISABLED">>, _) -> disabled.
+
+-spec undynamize_point_in_time_recovery_status(binary(), undynamize_opts()) -> point_in_time_recovery_status().
+undynamize_point_in_time_recovery_status(<<"ENABLING">>, _) -> enabling;
+undynamize_point_in_time_recovery_status(<<"ENABLED">>, _) -> enabled;
+undynamize_point_in_time_recovery_status(<<"DISABLED">>, _) -> disabled.
+
+-spec undynamize_backup_status(binary(), undynamize_opts()) -> backup_status().
+undynamize_backup_status(<<"CREATING">>, _) -> creating;
+undynamize_backup_status(<<"AVAILABLE">>, _) -> avaliable;
+undynamize_backup_status(<<"DELETED">>, _) -> deleted.
+
 -type field_table() :: [{binary(), pos_integer(), 
                          fun((jsx:json_term(), undynamize_opts()) -> term())}].
 
@@ -1166,6 +1182,15 @@ global_table_record() ->
       {<<"ReplicationGroup">>,  #ddb2_global_table.replication_group, fun undynamize_replicas/2}
     ]}.
 
+-spec restore_summary_record() -> record_desc().
+restore_summary_record() ->
+  {#ddb2_restore_summary{},
+    [{<<"RestoreDateTime">>, #ddb2_restore_summary.restore_date_time, fun id/2},
+      {<<"RestoreInProgress">>,  #ddb2_restore_summary.restore_in_progress, fun id/2},
+      {<<"SourceBackupArn">>,  #ddb2_restore_summary.source_backup_arn, fun id/2},
+      {<<"SourceTableArn">>,  #ddb2_restore_summary.source_table_arn, fun id/2}
+    ]}.
+
 -spec table_description_record() -> record_desc().
 table_description_record() ->
     {#ddb2_table_description{},
@@ -1469,12 +1494,6 @@ batch_write_item(RequestItems, Opts, Config) ->
 %% @end
 %%-------------------------------------------------------------------------------
 
--spec create_backup_opts() -> opt_table().
-create_backup_opts() ->
-    [{backup_name, <<"BackupName">>, fun id/1},
-     {table_name, <<"TableName">>, fun id/1}
-    ].
-
 -spec undynamize_backup_details() -> record_desc().
 undynamize_backup_details() ->
     {#ddb2_backup_details{},
@@ -1482,10 +1501,10 @@ undynamize_backup_details() ->
       {<<"BackupCreationDateTime">>, #ddb2_backup_details.backup_creation_date_time, fun id/2},
       {<<"BackupName">>, #ddb2_backup_details.backup_name, fun id/2},
       {<<"BackupSizeBytes">>, #ddb2_backup_details.backup_size_Bytes, fun id/2},
-      {<<"BackupStatus">>, #ddb2_backup_details.backup_status, fun id/2}
+      {<<"BackupStatus">>, #ddb2_backup_details.backup_status, fun undynamize_backup_status/2}
      ]}.
 
--spec undynamize_create_backup(jsx:json_term(), undynamize_opts()) -> [#ddb2_backup_details{}].
+-spec undynamize_create_backup(jsx:json_term(), undynamize_opts())  -> record_desc().
 undynamize_create_backup(BackupInfo, Opts) ->
     undynamize_record(undynamize_backup_details(), BackupInfo, Opts).
 
@@ -1498,23 +1517,23 @@ create_backup_record() ->
 
 -spec create_backup(binary(), table_name()) -> create_backup_return().
 create_backup(BackupName, TableName)
-    when is_bitstring(BackupName), is_bitstring(TableName) ->
+    when is_binary(BackupName), is_binary(TableName) ->
     create_backup(BackupName, TableName,[], default_config()).
 
 -spec create_backup(binary(), table_name(), ddb_opts()) -> create_backup_return().
 create_backup(BackupName, TableName, Opts)
-    when is_bitstring(BackupName), is_bitstring(TableName) ->
+    when is_binary(BackupName), is_binary(TableName) ->
     create_backup(BackupName, TableName, Opts, default_config()).
 
 -spec create_backup(binary(), table_name(), ddb_opts(), aws_config()) -> create_backup_return().
 create_backup(BackupName, TableName, Opts, Config)
-    when is_bitstring(BackupName), is_bitstring(TableName) ->
-    {AwsOpts, DdbOpts} = opts(create_backup_opts(), Opts),
+    when is_binary(BackupName), is_binary(TableName) ->
+    {_AwsOpts, DdbOpts} = opts([], Opts),
     Return = erlcloud_ddb_impl:request(
      Config,
      "DynamoDB_20120810.CreateBackup",
      [{<<"TableName">>, TableName},
-      {<<"BackupName">>, BackupName}] ++ AwsOpts),
+      {<<"BackupName">>, BackupName}]),
     out(Return, fun(Json, UOpts) -> undynamize_record(create_backup_record(), Json, UOpts) end,
      DdbOpts, #ddb2_create_backup.backup_details).
 
@@ -1704,11 +1723,6 @@ create_table(Table, AttrDefs, KeySchema, ReadUnits, WriteUnits, Opts, Config) ->
 %% '
 %% @end
 %%-------------------------------------------------------------------------------
-
--spec delete_backup_opts() -> opt_table().
-delete_backup_opts() ->
-    [{backup_arn, <<"BackupArn">>, fun id/1}].
-
 -spec provisioned_throughput_description() -> record_desc().
 provisioned_throughput_description() ->
     {#ddb2_provisioned_throughput{},
@@ -1763,14 +1777,14 @@ undynamize_source_table_feature_details() ->
        fun(V, Opts) -> undynamize_record(time_to_live_description_record(), V, Opts) end}
      ]}.
 
--spec undynamize_delete_backup_record() -> record_desc().
-undynamize_delete_backup_record() ->
-    {#ddb2_delete_backup_record{},
-     [{<<"BackupDetails">>, #ddb2_delete_backup_record.dackup_details,
+-spec undynamize_backup_description() -> record_desc().
+undynamize_backup_description() ->
+    {#ddb2_backup_description{},
+     [{<<"BackupDetails">>, #ddb2_backup_description.backup_details,
       fun(V, Opts) -> undynamize_record(undynamize_backup_details(), V, Opts) end},
-      {<<"SourceTableDetails">>, #ddb2_delete_backup_record.source_table_details,
+      {<<"SourceTableDetails">>, #ddb2_backup_description.source_table_details,
        fun(V, Opts) -> undynamize_record(undynamize_source_table_details(), V, Opts) end},
-      {<<"SourceTableFeatureDetails">>, #ddb2_delete_backup_record.source_table_feature_details,
+      {<<"SourceTableFeatureDetails">>, #ddb2_backup_description.source_table_feature_details,
        fun(V, Opts) -> undynamize_record(undynamize_source_table_feature_details(), V, Opts) end}
      ]}.
 
@@ -1778,29 +1792,29 @@ undynamize_delete_backup_record() ->
 delete_backup_record() ->
     {#ddb2_delete_backup{},
      [{<<"BackupDescription">>, #ddb2_delete_backup.backup_description,
-      fun(V, Opts) -> undynamize_record(undynamize_delete_backup_record(), V, Opts) end}
+      fun(V, Opts) -> undynamize_record(undynamize_backup_description(), V, Opts) end}
      ]}.
 
--type delete_backup_return() :: ddb_return(#ddb2_delete_backup{}, #ddb2_delete_backup_record{}).
+-type delete_backup_return() :: ddb_return(#ddb2_delete_backup{}, #ddb2_backup_description{}).
 
 -spec delete_backup(binary()) -> delete_backup_return().
 delete_backup(BackupArn)
-    when is_bitstring(BackupArn) ->
+    when is_binary(BackupArn) ->
     delete_backup(BackupArn,[], default_config()).
 
 -spec delete_backup(binary(), ddb_opts()) -> delete_backup_return().
 delete_backup(BackupArn, Opts)
-    when is_bitstring(BackupArn) ->
+    when is_binary(BackupArn) ->
     delete_backup(BackupArn, Opts, default_config()).
 
 -spec delete_backup(binary(), ddb_opts(), aws_config()) -> delete_backup_return().
 delete_backup(BackupArn, Opts, Config)
-    when is_bitstring(BackupArn) ->
-    {AwsOpts, DdbOpts} = opts(delete_backup_opts(), Opts),
+    when is_binary(BackupArn) ->
+    {_AwsOpts, DdbOpts} = opts([], Opts),
     Return = erlcloud_ddb_impl:request(
      Config,
      "DynamoDB_20120810.DeleteBackup",
-     [{<<"BackupArn">>, BackupArn}] ++ AwsOpts),
+     [{<<"BackupArn">>, BackupArn}]),
     out(Return, fun(Json, UOpts) -> undynamize_record(delete_backup_record(), Json, UOpts) end,
      DdbOpts, #ddb2_delete_backup.backup_description).
 
@@ -1959,32 +1973,35 @@ delete_table(Table, Opts, Config) ->
 %% @end
 %%-------------------------------------------------------------------------------
 
--spec describe_backup_opts() -> opt_table().
-describe_backup_opts() ->
-    [{backup_arn, <<"BackupArn">>, fun id/1}].
+-type describe_backup_return() :: ddb_return(#ddb2_describe_backup{}, #ddb2_backup_description{}).
 
--type describe_backup_return() :: ddb_return(#ddb2_delete_backup{}, #ddb2_delete_backup_record{}).
+-spec describe_backup_record() -> record_desc().
+describe_backup_record() ->
+  {#ddb2_describe_backup{},
+    [{<<"BackupDescription">>, #ddb2_describe_backup.backup_description,
+      fun(V, Opts) -> undynamize_record(undynamize_backup_description(), V, Opts) end}
+    ]}.
 
 -spec describe_backup(binary()) -> describe_backup_return().
 describe_backup(BackupArn)
-    when is_bitstring(BackupArn) ->
+    when is_binary(BackupArn) ->
     describe_backup(BackupArn,[], default_config()).
 
 -spec describe_backup(binary(), ddb_opts()) -> describe_backup_return().
 describe_backup(BackupArn, Opts)
-    when is_bitstring(BackupArn) ->
+    when is_binary(BackupArn) ->
     describe_backup(BackupArn, Opts, default_config()).
 
 -spec describe_backup(binary(), ddb_opts(), aws_config()) -> describe_backup_return().
 describe_backup(BackupArn, Opts, Config)
-    when is_bitstring(BackupArn) ->
-    {AwsOpts, DdbOpts} = opts(describe_backup_opts(), Opts),
+    when is_binary(BackupArn) ->
+    {_AwsOpts, DdbOpts} = opts([], Opts),
     Return = erlcloud_ddb_impl:request(
      Config,
      "DynamoDB_20120810.DescribeBackup",
-     [{<<"BackupArn">>, BackupArn}] ++ AwsOpts),
-    out(Return, fun(Json, UOpts) -> undynamize_record(delete_backup_record(), Json, UOpts) end,
-     DdbOpts, #ddb2_delete_backup.backup_description).
+     [{<<"BackupArn">>, BackupArn}]),
+    out(Return, fun(Json, UOpts) -> undynamize_record(describe_backup_record(), Json, UOpts) end,
+     DdbOpts, #ddb2_describe_backup.backup_description).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -2002,55 +2019,51 @@ describe_backup(BackupArn, Opts, Config)
 %% @end
 %%-------------------------------------------------------------------------------
 
--spec  describe_continuous_backup_opts() -> opt_table().
-describe_continuous_backup_opts() ->
-    [{table_name, <<"TableName">>, fun id/1}].
-
--spec  point_in_time_recovery_description() -> record_desc().
-point_in_time_recovery_description() ->
-    {#point_in_time_recovery_description{},
-     [{<<"EarliestRestorableDateTime">>, #point_in_time_recovery_description.earliest_restorable_date_time, fun id/2},
-      {<<"LatestRestorableDateTime">>, #point_in_time_recovery_description.latest_restorable_date_time, fun id/2},
-      {<<"PointInTimeRecoveryStatus">>, #point_in_time_recovery_description.point_in_time_recovery_status, fun id/2}
+-spec  ddb2_point_in_time_recovery_description() -> record_desc().
+ddb2_point_in_time_recovery_description() ->
+    {#ddb2_point_in_time_recovery_description{},
+     [{<<"EarliestRestorableDateTime">>, #ddb2_point_in_time_recovery_description.earliest_restorable_date_time, fun id/2},
+      {<<"LatestRestorableDateTime">>, #ddb2_point_in_time_recovery_description.latest_restorable_date_time, fun id/2},
+      {<<"PointInTimeRecoveryStatus">>, #ddb2_point_in_time_recovery_description.point_in_time_recovery_status, fun undynamize_point_in_time_recovery_status/2}
      ]}.
 
--spec continuous_backups_description() -> record_desc().
-continuous_backups_description() ->
-    {#continuous_backups_description{},
-     [{<<"ContinuousBackupsStatus">>, #continuous_backups_description.continuous_backups_status, fun id/2},
-      {<<"PointInTimeRecoveryDescription">>, #continuous_backups_description.point_in_time_recovery_description,
-       fun(V, Opts) -> undynamize_record(point_in_time_recovery_description(), V, Opts) end}
+-spec ddb2_continuous_backups_description() -> record_desc().
+ddb2_continuous_backups_description() ->
+    {#ddb2_continuous_backups_description{},
+     [{<<"ContinuousBackupsStatus">>, #ddb2_continuous_backups_description.continuous_backups_status, fun undynamize_continuous_backups_status/2},
+      {<<"PointInTimeRecoveryDescription">>, #ddb2_continuous_backups_description.point_in_time_recovery_description,
+       fun(V, Opts) -> undynamize_record(ddb2_point_in_time_recovery_description(), V, Opts) end}
      ]}.
 
 -spec continuous_backups_record() -> record_desc().
 continuous_backups_record() ->
-    {#ddb2_continuous_backups_record{},
-     [{<<"ContinuousBackupsDescription">>, #ddb2_continuous_backups_record.continuous_backups_description,
-      fun(V, Opts) -> undynamize_record(continuous_backups_description(), V, Opts) end}
+    {#ddb2_describe_continuous_backups{},
+     [{<<"ContinuousBackupsDescription">>, #ddb2_describe_continuous_backups.continuous_backups_description,
+      fun(V, Opts) -> undynamize_record(ddb2_continuous_backups_description(), V, Opts) end}
      ]}.
 
--type  describe_continuous_backup_return() :: ddb_return(#ddb2_create_backup{}, [table_name()]).
+-type  describe_continuous_backup_return() :: ddb_return(#ddb2_describe_continuous_backups{}, #ddb2_continuous_backups_description{}).
 
--spec  describe_continuous_backups(table_name()) -> list_backups_return().
+-spec  describe_continuous_backups(table_name()) -> describe_continuous_backup_return().
 describe_continuous_backups(TableName)
-    when is_bitstring(TableName) ->
+    when is_binary(TableName) ->
     describe_continuous_backups(TableName,[], default_config()).
 
 -spec  describe_continuous_backups(table_name(), ddb_opts()) -> describe_continuous_backup_return().
 describe_continuous_backups(TableName, Opts)
-    when is_bitstring(TableName) ->
+    when is_binary(TableName) ->
     describe_continuous_backups(TableName, Opts, default_config()).
 
 -spec  describe_continuous_backups(table_name(), ddb_opts(), aws_config()) -> describe_continuous_backup_return().
 describe_continuous_backups(TableName, Opts, Config)
-    when is_bitstring(TableName) ->
-    {AwsOpts, DdbOpts} = opts(describe_continuous_backup_opts(), Opts),
+    when is_binary(TableName) ->
+    {_AwsOpts, DdbOpts} = opts([], Opts),
     Return = erlcloud_ddb_impl:request(
      Config,
      "DynamoDB_20120810.DescribeContinuousBackups",
-     [{<<"TableName">>, TableName}] ++ AwsOpts),
+     [{<<"TableName">>, TableName}]),
     out(Return, fun(Json, UOpts) -> undynamize_record(continuous_backups_record(), Json, UOpts) end,
-     DdbOpts, #ddb2_continuous_backups_record.continuous_backups_description).
+     DdbOpts, #ddb2_describe_continuous_backups.continuous_backups_description).
 
 %%%------------------------------------------------------------------------------
 %%% DescribeGlobalTable
@@ -2352,10 +2365,11 @@ get_item(Table, Key, Opts, Config) ->
 %% '
 %% @end
 %%------------------------------------------------------------------------------
--type list_backups_opt() :: {limit, pos_integer() | undefined} |
-{exclusive_start_backup_arn, binary() | undefined } | {table_name, table_name() | undefined} |
-{time_range_lower_bound,  number() | undefined} | {time_range_upper_bound,  number() | undefined}.
--type list_backups_opts() :: [list_backups_opt()].
+-type list_backups_opt() :: {limit, pos_integer()} |
+                            {exclusive_start_backup_arn, binary()} |
+                            {table_name, table_name()} |
+                            {time_range_lower_bound,  number()} |
+                            {time_range_upper_bound,  number()}.
 
 -spec list_backups_opts() -> opt_table().
 list_backups_opts() ->
@@ -2368,17 +2382,16 @@ list_backups_opts() ->
 
 -spec backup_record() -> record_desc().
 backup_record() ->
-    {#ddb2_backup_summaries{},
-     [{<<"BackupArn">>, #ddb2_backup_summaries.backup_arn, fun id/2},
-      {<<"BackupCreationDateTime">>, #ddb2_backup_summaries.backup_creation_date_time, fun id/2},
-      {<<"BackupName">>, #ddb2_backup_summaries.backup_name, fun id/2},
-      {<<"BackupSizeBytes">>, #ddb2_backup_summaries.backup_size_bytes, fun id/2},
-      {<<"BackupStatus">>, #ddb2_backup_summaries.backup_status, fun id/2},
-      {<<"TableArn">>, #ddb2_backup_summaries.table_arn, fun id/2},
-      {<<"TableId">>, #ddb2_backup_summaries.table_id, fun id/2},
-      {<<"TableName">>, #ddb2_backup_summaries.table_name, fun id/2}
+    {#ddb2_backup_summary{},
+     [{<<"BackupArn">>, #ddb2_backup_summary.backup_arn, fun id/2},
+      {<<"BackupCreationDateTime">>, #ddb2_backup_summary.backup_creation_date_time, fun id/2},
+      {<<"BackupName">>, #ddb2_backup_summary.backup_name, fun id/2},
+      {<<"BackupSizeBytes">>, #ddb2_backup_summary.backup_size_bytes, fun id/2},
+      {<<"BackupStatus">>, #ddb2_backup_summary.backup_status, fun id/2},
+      {<<"TableArn">>, #ddb2_backup_summary.table_arn, fun id/2},
+      {<<"TableId">>, #ddb2_backup_summary.table_id, fun id/2},
+      {<<"TableName">>, #ddb2_backup_summary.table_name, fun id/2}
      ]}.
-
 
 -spec undynamize_list_backups(jsx:json_term(), undynamize_opts()) -> [#ddb2_list_backups{}].
 undynamize_list_backups(BackupSummaries, Opts) ->
@@ -2391,17 +2404,17 @@ list_backups_record() ->
       {<<"LastEvaluatedBackupArn">>, #ddb2_list_backups.last_evaluated_backup_arn, fun id/2}
      ]}.
 
--type list_backups_return() :: ddb_return(#ddb2_list_backups{}, #ddb2_backup_summaries{}).
+-type list_backups_return() :: ddb_return(#ddb2_list_backups{}, #ddb2_backup_summary{}).
 
 -spec list_backups() -> list_backups_return().
 list_backups() ->
     list_backups([], default_config()).
 
--spec list_backups(list_backups_opts()) -> list_backups_return().
+-spec list_backups([list_backups_opt()]) -> list_backups_return().
 list_backups(Opts) ->
     list_backups(Opts, default_config()).
 
--spec list_backups(list_backups_opts(), aws_config()) -> list_backups_return().
+-spec list_backups([list_backups_opt()], aws_config()) -> list_backups_return().
 list_backups(Opts, Config) ->
     {AwsOpts, DdbOpts} = opts(list_backups_opts(), Opts),
     Return = erlcloud_ddb_impl:request(
@@ -2764,36 +2777,116 @@ q(Table, KeyConditionsOrExpression, Opts, Config) ->
 %% '
 %% @end
 %%-------------------------------------------------------------------------------
+-type restore_table_from_backup_return() :: ddb_return(#ddb2_restore_table_from_backup{}, #ddb2_table_description{}).
 
--spec restore_table_from_backup_opts() -> opt_table().
-restore_table_from_backup_opts() ->
-    [{backup_arn, <<"BackupArn">>, fun id/1},
-     {target_table_name, <<"TargetTableName">>, fun id/1}
-    ].
+-spec table_description_with_restore_summary_record() -> record_desc().
+table_description_with_restore_summary_record() ->
+    {#ddb2_table_description{},
+     [{<<"AttributeDefinitions">>, #ddb2_table_description.attribute_definitions, fun undynamize_attr_defs/2},
+      {<<"CreationDateTime">>, #ddb2_table_description.creation_date_time, fun id/2},
+      {<<"GlobalSecondaryIndexes">>, #ddb2_table_description.global_secondary_indexes,
+       fun(V, Opts) -> [undynamize_record(global_secondary_index_description_record(), I, Opts) || I <- V] end},
+      {<<"ItemCount">>, #ddb2_table_description.item_count, fun id/2},
+      {<<"KeySchema">>, #ddb2_table_description.key_schema, fun undynamize_key_schema/2},
+      {<<"LatestStreamArn">>, #ddb2_table_description.latest_stream_arn, fun id/2},
+      {<<"LatestStreamLabel">>, #ddb2_table_description.latest_stream_label, fun id/2},
+      {<<"LocalSecondaryIndexes">>, #ddb2_table_description.local_secondary_indexes,
+       fun(V, Opts) -> [undynamize_record(local_secondary_index_description_record(), I, Opts) || I <- V] end},
+      {<<"ProvisionedThroughput">>, #ddb2_table_description.provisioned_throughput,
+       fun(V, Opts) -> undynamize_record(provisioned_throughput_description_record(), V, Opts) end},
+      {<<"RestoreSummary">>, #ddb2_table_description.restore_summary,
+       fun(V, Opts) -> undynamize_record(restore_summary_record(), V, Opts) end},
+      {<<"SSEDescription">>, #ddb2_table_description.sse_description, fun undynamize_sse_description/2},
+      {<<"StreamSpecification">>, #ddb2_table_description.stream_specification, fun undynamize_stream_specification/2},
+      {<<"TableArn">>, #ddb2_table_description.table_arn, fun id/2},
+      {<<"TableName">>, #ddb2_table_description.table_name, fun id/2},
+      {<<"TableSizeBytes">>, #ddb2_table_description.table_size_bytes, fun id/2},
+      {<<"TableStatus">>, #ddb2_table_description.table_status, fun undynamize_table_status/2}
+     ]}.
 
--type restore_table_from_backup_return() :: ddb_return(#ddb2_create_table{}, #ddb2_table_description{}).
+-spec restore_table_from_backup_record() -> record_desc().
+restore_table_from_backup_record() ->
+    {#ddb2_restore_table_from_backup{},
+      [{<<"TableDescription">>, #ddb2_restore_table_from_backup.table_description,
+        fun(V, Opts) -> undynamize_record(table_description_with_restore_summary_record(), V, Opts) end}
+      ]}.
 
 -spec restore_table_from_backup(binary(), table_name()) -> restore_table_from_backup_return().
 restore_table_from_backup(BackupArn, TargetTableName)
-    when is_bitstring(BackupArn), is_bitstring(TargetTableName) ->
-    restore_table_from_backup(BackupArn, TargetTableName,[], default_config()).
+    when is_binary(BackupArn), is_binary(TargetTableName) ->
+    restore_table_from_backup(BackupArn, TargetTableName, [], default_config()).
 
 -spec restore_table_from_backup(binary(), table_name(), ddb_opts()) -> restore_table_from_backup_return().
 restore_table_from_backup(BackupArn, TargetTableName, Opts)
-    when is_bitstring(BackupArn), is_bitstring(TargetTableName) ->
+    when is_binary(BackupArn), is_binary(TargetTableName) ->
     restore_table_from_backup(BackupArn, TargetTableName, Opts, default_config()).
 
 -spec restore_table_from_backup(binary(), table_name(), ddb_opts(), aws_config()) -> restore_table_from_backup_return().
 restore_table_from_backup(BackupArn, TargetTableName, Opts, Config)
-    when is_bitstring(BackupArn), is_bitstring(TargetTableName) ->
-    {AwsOpts, DdbOpts} = opts(restore_table_from_backup_opts(), Opts),
+    when is_binary(BackupArn), is_binary(TargetTableName) ->
+    {_AwsOpts, DdbOpts} = opts([], Opts),
     Return = erlcloud_ddb_impl:request(
      Config,
      "DynamoDB_20120810.RestoreTableFromBackup",
      [{<<"BackupArn">>, BackupArn},
-      {<<"TargetTableName">>, TargetTableName}] ++ AwsOpts),
-    out(Return, fun(Json, UOpts) -> undynamize_record(create_table_record(), Json, UOpts) end,
-     DdbOpts, #ddb2_create_table.table_description).
+      {<<"TargetTableName">>, TargetTableName}]),
+    out(Return, fun(Json, UOpts) -> undynamize_record(restore_table_from_backup_record(), Json, UOpts) end,
+     DdbOpts, #ddb2_restore_table_from_backup.table_description).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% DynamoDB API:
+%% [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableToPointInTime.html]
+%%
+%% ===Example===
+%%
+%% Restores the specified table to the specified point in time within EarliestRestorableDateTime and LatestRestorableDateTime.
+%%
+%% `
+%% {ok, Table} =
+%%     erlcloud_ddb2:restore_table_to_point_in_time(<<"Thread">>, <<"ThreadTo">>, [{restore_date_time, 1522926603.688}, {use_latest_restorable_time, false}]),
+%% '
+%% @end
+%%-------------------------------------------------------------------------------
+-type restore_table_to_point_in_time_opt() :: {restore_date_time, date_time()} |
+                                              {use_latest_restorable_time, boolean()}.
+
+-spec restore_table_to_point_in_time_opts() -> opt_table().
+restore_table_to_point_in_time_opts() ->
+    [{restore_date_time, <<"RestoreDateTime">>, fun id/1},
+     {use_latest_restorable_time, <<"UseLatestRestorableTime">>, fun id/1}
+    ].
+
+-type restore_table_to_point_in_time_return() :: ddb_return(#ddb2_restore_table_to_point_in_time{}, #ddb2_table_description{}).
+
+-spec restore_table_to_point_in_time() -> record_desc().
+restore_table_to_point_in_time() ->
+    {#ddb2_restore_table_to_point_in_time{},
+      [{<<"TableDescription">>, #ddb2_restore_table_to_point_in_time.table_description,
+        fun(V, Opts) -> undynamize_record(table_description_with_restore_summary_record(), V, Opts) end}
+      ]}.
+
+-spec restore_table_to_point_in_time(table_name(), table_name()) -> restore_table_to_point_in_time_return().
+restore_table_to_point_in_time(SourceTableName, TargetTableName)
+    when is_binary(SourceTableName), is_binary(TargetTableName) ->
+    restore_table_to_point_in_time(SourceTableName, TargetTableName, [], default_config()).
+
+-spec restore_table_to_point_in_time(table_name(), table_name(), [restore_table_to_point_in_time_opt()]) -> restore_table_to_point_in_time_return().
+restore_table_to_point_in_time(SourceTableName, TargetTableName, Opts)
+    when is_binary(SourceTableName), is_binary(TargetTableName) ->
+    restore_table_to_point_in_time(SourceTableName, TargetTableName, Opts, default_config()).
+
+-spec restore_table_to_point_in_time(table_name(), table_name(), [restore_table_to_point_in_time_opt()], aws_config()) -> restore_table_to_point_in_time_return().
+restore_table_to_point_in_time(SourceTableName, TargetTableName, Opts, Config)
+    when is_binary(SourceTableName), is_binary(TargetTableName) ->
+    {AwsOpts, DdbOpts} = opts(restore_table_to_point_in_time_opts(), Opts),
+    Return = erlcloud_ddb_impl:request(
+      Config,
+      "DynamoDB_20120810.RestoreTableToPointInTime",
+      [{<<"SourceTableName">>, SourceTableName},
+        {<<"TargetTableName">>, TargetTableName}] ++ AwsOpts),
+    out(Return, fun(Json, UOpts) -> undynamize_record(restore_table_to_point_in_time(), Json, UOpts) end,
+      DdbOpts, #ddb2_restore_table_to_point_in_time.table_description).
 
 %%%------------------------------------------------------------------------------
 %%% Scan
@@ -2884,6 +2977,53 @@ scan(Table, Opts, Config) ->
                ++ AwsOpts),
     out(Return, fun(Json, UOpts) -> undynamize_record(scan_record(), Json, UOpts) end, DdbOpts, 
         #ddb2_scan.items, {ok, []}).
+
+%%%------------------------------------------------------------------------------
+%%% UpdateContinuousBackups
+%%%------------------------------------------------------------------------------
+%%------------------------------------------------------------------------------
+%% @doc
+%% DynamoDB API:
+%% [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateContinuousBackups.html]
+%%
+%% ===Example===
+%%
+%% Enables or disables point in time recovery for the specified table.
+%%
+%% `
+%% {ok, Record} =
+%%     erlcloud_ddb2:update_continuous_backups(<<"Thread">>,true),
+%% '
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec dynamize_point_in_time_recovery_enabled(boolean()) -> jsx:json_term().
+dynamize_point_in_time_recovery_enabled(Value) ->
+   [{<<"PointInTimeRecoveryEnabled">>, Value}].
+
+-type update_continuous_backups_return() :: ddb_return(#ddb2_describe_continuous_backups{}, #ddb2_continuous_backups_description{}).
+
+-spec update_continuous_backups(table_name(), boolean()) -> update_continuous_backups_return().
+update_continuous_backups(TableName, PointInTimeRecoverySpecification)
+    when is_binary(TableName), is_boolean(PointInTimeRecoverySpecification) ->
+    update_continuous_backups(TableName, PointInTimeRecoverySpecification, [], default_config()).
+
+-spec update_continuous_backups(table_name(), boolean(), ddb_opts()) -> update_continuous_backups_return().
+update_continuous_backups(TableName, PointInTimeRecoverySpecification, Opts)
+    when is_binary(TableName), is_boolean(PointInTimeRecoverySpecification) ->
+    update_continuous_backups(TableName, PointInTimeRecoverySpecification, Opts, default_config()).
+
+-spec update_continuous_backups(table_name(), boolean(), ddb_opts(), aws_config()) -> update_continuous_backups_return().
+update_continuous_backups(TableName, PointInTimeRecoveryEnabled, Opts, Config)
+    when is_binary(TableName), is_boolean(PointInTimeRecoveryEnabled) ->
+    {_AwsOpts, DdbOpts} = opts([], Opts),
+    Return = erlcloud_ddb_impl:request(
+      Config,
+      "DynamoDB_20120810.UpdateContinuousBackups",
+      [{<<"TableName">>, TableName},
+       {<<"PointInTimeRecoverySpecification">>, dynamize_point_in_time_recovery_enabled(PointInTimeRecoveryEnabled)}]),
+    out(Return, fun(Json, UOpts) -> undynamize_record(continuous_backups_record(), Json, UOpts) end,
+      DdbOpts, #ddb2_describe_continuous_backups.continuous_backups_description).
 
 %%%------------------------------------------------------------------------------
 %%% UpdateItem

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -114,7 +114,7 @@
          scan/1, scan/2, scan/3,
          tag_resource/2, tag_resource/3,
          update_continuous_backups/2,update_continuous_backups/3,update_continuous_backups/4,
-         untag_reource/2, untag_resource/3
+         untag_resource/2, untag_resource/3,
          update_item/3, update_item/4, update_item/5,
          update_global_table/2, update_global_table/3, update_global_table/4,
          update_table/2, update_table/3, update_table/4, update_table/5,

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -107,7 +107,11 @@
          update_item/3, update_item/4, update_item/5,
          update_global_table/2, update_global_table/3, update_global_table/4,
          update_table/2, update_table/3, update_table/4, update_table/5,
-         update_time_to_live/2, update_time_to_live/3, update_time_to_live/4
+         update_time_to_live/2, update_time_to_live/3, update_time_to_live/4,
+         list_backups/0,list_backups/1,list_backups/2, create_backup/2, create_backup/3,
+         delete_backup/1, delete_backup/2, describe_backup/1, describe_backup/2, describe_backup/3,
+         describe_continuous_backups/1,describe_continuous_backups/2,describe_continuous_backups/3,
+         restore_table_from_backup/2,restore_table_from_backup/3,restore_table_from_backup/4
         ]).
 
 -export_type(
@@ -2825,3 +2829,425 @@ to_binary(X) when is_list(X) ->
     list_to_binary(X);
 to_binary(X) when is_integer(X) ->
     integer_to_binary(X).
+
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% DynamoDB API:
+%% [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListBackups.html]
+%%
+%% ===Example===
+%%
+%% Get the table backups.
+%% `
+%% {ok, Tables} =
+%%     erlcloud_ddb2:list_backups(),
+%% '
+%% Get the last 4 table backups for "Forum" table between April 5, 2018 and April 6, 2018.
+%% `
+%% {ok, Tables} =
+%%     erlcloud_ddb2:list_backups(
+%%       [{limit, 4},
+%%        {table_name, <<"Forum">>},
+%%        {time_range_lower_bound,1522926603.688},
+%%        {time_range_upper_bound,1523022454.098}]),
+%% '
+%% @end
+%%------------------------------------------------------------------------------
+-type list_backups_opt() :: {limit, pos_integer() | undefined} |
+{exclusive_start_backup_arn, undefined } | {table_name, table_name() | undefined} |
+{time_range_lower_bound,  number() | undefined} | {time_range_upper_bound,  number() | undefined}.
+-type list_backups_opts() :: [list_backups_opt()].
+
+-spec list_backups_opts() -> opt_table().
+list_backups_opts() ->
+    [{limit, <<"Limit">>, fun id/1},
+     {exclusive_start_backup_arn, <<"ExclusiveStartBackupArn">>, fun id/1},
+     {table_name, <<"TableName">>, fun id/1},
+     {time_range_lower_bound, <<"TimeRangeLowerBound">>, fun id/1},
+     {time_range_upper_bound, <<"TimeRangeUpperBound">>, fun id/1}
+    ].
+
+-spec backup_record() -> record_desc().
+backup_record() ->
+    {#ddb2_backup_summaries{},
+     [{<<"BackupArn">>, #ddb2_backup_summaries.backup_arn, fun id/2},
+      {<<"BackupCreationDateTime">>, #ddb2_backup_summaries.backup_creation_date_time, fun id/2},
+      {<<"BackupName">>, #ddb2_backup_summaries.backup_name, fun id/2},
+      {<<"BackupSizeBytes">>, #ddb2_backup_summaries.backup_size_bytes, fun id/2},
+      {<<"BackupStatus">>, #ddb2_backup_summaries.backup_status, fun id/2},
+      {<<"TableArn">>, #ddb2_backup_summaries.table_arn, fun id/2},
+      {<<"TableId">>, #ddb2_backup_summaries.table_id, fun id/2},
+      {<<"TableName">>, #ddb2_backup_summaries.table_name, fun id/2}
+     ]}.
+
+
+-spec undynamize_list_backups(jsx:json_term(), undynamize_opts()) -> [#ddb2_list_backups{}].
+undynamize_list_backups(BackupSummaries, Opts) ->
+    [undynamize_record(backup_record(), T, Opts) || T <- BackupSummaries].
+
+-spec list_backups_record() -> record_desc().
+list_backups_record() ->
+    {#ddb2_list_backups{},
+     [{<<"BackupSummaries">>, #ddb2_list_backups.backup_summaries, fun undynamize_list_backups/2},
+      {<<"LastEvaluatedBackupArn">>, #ddb2_list_backups.last_evaluated_backup_arn, fun id/2}
+     ]}.
+
+-type list_backups_return() :: ddb_return(#ddb2_list_backups{}, #ddb2_backup_summaries{}).
+
+-spec list_backups() -> list_backups_return().
+list_backups() ->
+    list_backups([], default_config()).
+
+-spec list_backups(list_backups_opts()) -> list_backups_return().
+list_backups(Opts) ->
+    list_backups(Opts, default_config()).
+
+-spec list_backups(list_backups_opts(), aws_config()) -> list_backups_return().
+list_backups(Opts, Config) ->
+    {AwsOpts, DdbOpts} = opts(list_backups_opts(), Opts),
+    Return = erlcloud_ddb_impl:request(
+        Config,
+        "DynamoDB_20120810.ListBackups",
+        AwsOpts),
+    out(Return, fun(Json, UOpts) -> undynamize_record(list_backups_record(), Json, UOpts) end,
+        DdbOpts, #ddb2_list_backups.backup_summaries).
+
+
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% DynamoDB API:
+%% [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateBackup.html]
+%%
+%% ===Example===
+%%
+%% Creates a backup for an existing table.
+%%
+%% `
+%% {ok, BackupDetails} =
+%%     erlcloud_ddb2:create_backup(<<"Forum_Backup">>,<<"Forum">>),
+%% '
+%% @end
+%%-------------------------------------------------------------------------------
+
+-spec create_backup_opts() -> opt_table().
+create_backup_opts() ->
+    [{backup_name, <<"BackupName">>, fun id/1},
+     {table_name, <<"TableName">>, fun id/1}
+    ].
+
+-spec undynamize_backup_details() -> record_desc().
+undynamize_backup_details() ->
+    {#ddb2_backup_details{},
+     [{<<"BackupArn">>, #ddb2_backup_details.backup_arn, fun id/2},
+      {<<"BackupCreationDateTime">>, #ddb2_backup_details.backup_creation_date_time, fun id/2},
+      {<<"BackupName">>, #ddb2_backup_details.backup_name, fun id/2},
+      {<<"BackupSizeBytes">>, #ddb2_backup_details.backup_size_Bytes, fun id/2},
+      {<<"BackupStatus">>, #ddb2_backup_details.backup_status, fun id/2}
+     ]}.
+
+
+-spec undynamize_create_backup(jsx:json_term(), undynamize_opts()) -> [#ddb2_backup_details{}].
+undynamize_create_backup(BackupInfo, Opts) ->
+    undynamize_record(undynamize_backup_details(), BackupInfo, Opts).
+
+-spec create_backup_record() -> record_desc().
+create_backup_record() ->
+    {#ddb2_create_backup{},
+     [{<<"BackupDetails">>, #ddb2_create_backup.backup_details, fun undynamize_create_backup/2}]}.
+
+-type create_backup_return() :: ddb_return(#ddb2_create_backup{}, #ddb2_backup_details{}).
+
+-spec create_backup(binary(), table_name()) -> create_backup_return().
+create_backup(BackupName, TableName)
+    when is_bitstring(BackupName), is_bitstring(TableName) ->
+    create_backup(BackupName, TableName,[], default_config()).
+
+-spec create_backup(binary(), table_name(), ddb_opts()) -> create_backup_return().
+create_backup(BackupName, TableName, Opts)
+    when is_bitstring(BackupName), is_bitstring(TableName) ->
+    create_backup(BackupName, TableName, Opts, default_config()).
+
+-spec create_backup(binary(), table_name(), ddb_opts(), aws_config()) -> create_backup_return().
+create_backup(BackupName, TableName, Opts, Config)
+    when is_bitstring(BackupName), is_bitstring(TableName) ->
+    {AwsOpts, DdbOpts} = opts(create_backup_opts(), Opts),
+    Return = erlcloud_ddb_impl:request(
+        Config,
+        "DynamoDB_20120810.CreateBackup",
+        [{<<"TableName">>, TableName},
+        {<<"BackupName">>, BackupName}] ++ AwsOpts),
+    out(Return, fun(Json, UOpts) -> undynamize_record(create_backup_record(), Json, UOpts) end,
+        DdbOpts, #ddb2_create_backup.backup_details).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% DynamoDB API:
+%% [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteBackup.html]
+%%
+%% ===Example===
+%%
+%% Deletes an existing backup of a table.
+%%
+%% `
+%% {ok, BackupDescription} =
+%%     erlcloud_ddb2:delete_backup(<<"BackupArn">>),
+%% '
+%% @end
+%%-------------------------------------------------------------------------------
+
+-spec delete_backup_opts() -> opt_table().
+delete_backup_opts() ->
+    [{backup_arn, <<"BackupArn">>, fun id/1}].
+
+-spec provisioned_throughput_description() -> record_desc().
+provisioned_throughput_description() ->
+    {#ddb2_provisioned_throughput{},
+     [
+      {<<"ReadCapacityUnits">>, #ddb2_provisioned_throughput.read_capacity_units, fun id/2},
+      {<<"WriteCapacityUnits">>, #ddb2_provisioned_throughput.write_capacity_units, fun id/2}
+     ]}.
+
+-spec undynamize_source_table_details() -> record_desc().
+undynamize_source_table_details() ->
+    {#ddb2_source_table_details{},
+     [{<<"ItemCount">>, #ddb2_source_table_details.item_count, fun id/2},
+      {<<"KeySchema">>, #ddb2_source_table_details.key_schema, fun undynamize_key_schema/2},
+      {<<"ProvisionedThroughput">>, #ddb2_source_table_details.provisioned_throughput,
+       fun(V, Opts) -> undynamize_record(provisioned_throughput_description(), V, Opts) end},
+      {<<"TableId">>, #ddb2_source_table_details.table_id, fun id/2},
+      {<<"TableCreationDateTime">>, #ddb2_source_table_details.table_creation_date_time, fun id/2},
+      {<<"TableArn">>, #ddb2_source_table_details.table_arn, fun id/2},
+      {<<"TableName">>, #ddb2_source_table_details.table_name, fun id/2},
+      {<<"TableSizeBytes">>, #ddb2_source_table_details.table_size_bytes, fun id/2}
+     ]}.
+
+-spec undynamize_global_secondary_index_info() -> record_desc().
+undynamize_global_secondary_index_info() ->
+    {#ddb2_global_secondary_index_info{},
+     [{<<"IndexName">>, #ddb2_global_secondary_index_info.index_name, fun id/2},
+      {<<"KeySchema">>, #ddb2_global_secondary_index_info.key_schema, fun undynamize_key_schema/2},
+      {<<"Projection">>, #ddb2_global_secondary_index_info.projection, fun undynamize_projection/2},
+      {<<"ProvisionedThroughput">>, #ddb2_global_secondary_index_info.provisioned_throughput,
+       fun(V, Opts) -> undynamize_record(provisioned_throughput_description(), V, Opts) end}
+     ]}.
+
+-spec undynamize_local_secondary_index_info() -> record_desc().
+undynamize_local_secondary_index_info() ->
+    {#ddb2_local_secondary_index_info{},
+     [{<<"IndexName">>, #ddb2_local_secondary_index_info.index_name, fun id/2},
+      {<<"KeySchema">>, #ddb2_local_secondary_index_info.key_schema, fun undynamize_key_schema/2},
+      {<<"Projection">>, #ddb2_local_secondary_index_info.projection, fun undynamize_projection/2}
+     ]}.
+
+-spec undynamize_source_table_feature_details() -> record_desc().
+undynamize_source_table_feature_details() ->
+    {#ddb2_source_table_feature_details{},
+     [{<<"GlobalSecondaryIndexes">>, #ddb2_source_table_feature_details.global_secondary_indexes,
+      fun(V, Opts) -> [undynamize_record(undynamize_global_secondary_index_info(), I, Opts) || I <- V] end},
+      {<<"LocalSecondaryIndexes">>, #ddb2_source_table_feature_details.local_secondary_indexes,
+       fun(V, Opts) -> [undynamize_record(undynamize_local_secondary_index_info(), I, Opts) || I <- V] end},
+      {<<"SSEDescription">>, #ddb2_source_table_feature_details.sse_description, fun undynamize_sse_description/2},
+      {<<"StreamDescription">>, #ddb2_source_table_feature_details.stream_description,
+       fun undynamize_stream_specification/2},
+      {<<"TimeToLiveDescription">>, #ddb2_source_table_feature_details.time_to_live_description,
+       fun(V, Opts) -> undynamize_record(time_to_live_description_record(), V, Opts) end}
+     ]}.
+
+-spec undynamize_delete_backup_record() -> record_desc().
+undynamize_delete_backup_record() ->
+    {#ddb2_delete_backup_record{},
+     [{<<"BackupDetails">>, #ddb2_delete_backup_record.dackup_details,
+      fun(V, Opts) -> undynamize_record(undynamize_backup_details(), V, Opts) end},
+       {<<"SourceTableDetails">>, #ddb2_delete_backup_record.source_table_details,
+      fun(V, Opts) -> undynamize_record(undynamize_source_table_details(), V, Opts) end},
+       {<<"SourceTableFeatureDetails">>, #ddb2_delete_backup_record.source_table_feature_details,
+      fun(V, Opts) -> undynamize_record(undynamize_source_table_feature_details(), V, Opts) end}
+     ]}.
+
+-spec delete_backup_record() -> record_desc().
+delete_backup_record() ->
+    {#ddb2_delete_backup{},
+     [{<<"BackupDescription">>, #ddb2_delete_backup.backup_description,
+      fun(V, Opts) -> undynamize_record(undynamize_delete_backup_record(), V, Opts) end}
+     ]}.
+
+-type delete_backup_return() :: ddb_return(#ddb2_delete_backup{}, #ddb2_delete_backup_record{}).
+
+-spec delete_backup(binary()) -> delete_backup_return().
+delete_backup(BackupArn)
+    when is_bitstring(BackupArn) ->
+    delete_backup(BackupArn,[], default_config()).
+
+-spec delete_backup(binary(), ddb_opts()) -> delete_backup_return().
+delete_backup(BackupArn, Opts)
+    when is_bitstring(BackupArn) ->
+    delete_backup(BackupArn, Opts, default_config()).
+
+-spec delete_backup(binary(), ddb_opts(), aws_config()) -> delete_backup_return().
+delete_backup(BackupArn, Opts, Config)
+    when is_bitstring(BackupArn) ->
+    {AwsOpts, DdbOpts} = opts(delete_backup_opts(), Opts),
+    Return = erlcloud_ddb_impl:request(
+        Config,
+        "DynamoDB_20120810.DeleteBackup",
+        [{<<"BackupArn">>, BackupArn}] ++ AwsOpts),
+    out(Return, fun(Json, UOpts) -> undynamize_record(delete_backup_record(), Json, UOpts) end,
+        DdbOpts, #ddb2_delete_backup.backup_description).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% DynamoDB API:
+%% [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeBackup.html]
+%%
+%% ===Example===
+%%
+%% Describes an existing backup of a table.
+%%
+%% `
+%% {ok, BackupDescription} =
+%%     erlcloud_ddb2:describe_backup(<<"BackupArn">>),
+%% '
+%% @end
+%%-------------------------------------------------------------------------------
+
+-spec describe_backup_opts() -> opt_table().
+describe_backup_opts() ->
+    [{backup_arn, <<"BackupArn">>, fun id/1}].
+
+-type describe_backup_return() :: ddb_return(#ddb2_delete_backup{}, #ddb2_delete_backup_record{}).
+
+-spec describe_backup(binary()) -> describe_backup_return().
+describe_backup(BackupArn)
+    when is_bitstring(BackupArn) ->
+    describe_backup(BackupArn,[], default_config()).
+
+-spec describe_backup(binary(), ddb_opts()) -> describe_backup_return().
+describe_backup(BackupArn, Opts)
+    when is_bitstring(BackupArn) ->
+    describe_backup(BackupArn, Opts, default_config()).
+
+-spec describe_backup(binary(), ddb_opts(), aws_config()) -> describe_backup_return().
+describe_backup(BackupArn, Opts, Config)
+    when is_bitstring(BackupArn) ->
+    {AwsOpts, DdbOpts} = opts(describe_backup_opts(), Opts),
+    Return = erlcloud_ddb_impl:request(
+        Config,
+        "DynamoDB_20120810.DescribeBackup",
+        [{<<"BackupArn">>, BackupArn}] ++ AwsOpts),
+    out(Return, fun(Json, UOpts) -> undynamize_record(delete_backup_record(), Json, UOpts) end,
+        DdbOpts, #ddb2_delete_backup.backup_description).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% DynamoDB API:
+%% [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContinuousBackups.html]
+%%
+%% ===Example===
+%%
+%% Checks the status of continuous backups and point in time recovery on the specified table.
+%%
+%% `
+%% {ok, ContinuousBackupDescription} =
+%%     erlcloud_ddb2:describe_continuous_backups(<<"Forum">>),
+%% '
+%% @end
+%%-------------------------------------------------------------------------------
+
+-spec  describe_continuous_backup_opts() -> opt_table().
+describe_continuous_backup_opts() ->
+    [{table_name, <<"TableName">>, fun id/1}].
+
+-spec  point_in_time_recovery_description() -> record_desc().
+point_in_time_recovery_description() ->
+    {#point_in_time_recovery_description{},
+     [{<<"EarliestRestorableDateTime">>, #point_in_time_recovery_description.earliest_restorable_date_time, fun id/2},
+      {<<"LatestRestorableDateTime">>, #point_in_time_recovery_description.latest_restorable_date_time, fun id/2},
+      {<<"PointInTimeRecoveryStatus">>, #point_in_time_recovery_description.point_in_time_recovery_status, fun id/2}
+     ]}.
+
+-spec continuous_backups_description() -> record_desc().
+continuous_backups_description() ->
+    {#continuous_backups_description{},
+     [{<<"ContinuousBackupsStatus">>, #continuous_backups_description.continuous_backups_status, fun id/2},
+      {<<"PointInTimeRecoveryDescription">>, #continuous_backups_description.point_in_time_recovery_description,
+       fun(V, Opts) -> undynamize_record(point_in_time_recovery_description(), V, Opts) end}
+     ]}.
+
+-spec continuous_backups_record() -> record_desc().
+continuous_backups_record() ->
+    {#ddb2_continuous_backups_record{},
+     [{<<"ContinuousBackupsDescription">>, #ddb2_continuous_backups_record.continuous_backups_description,
+      fun(V, Opts) -> undynamize_record(continuous_backups_description(), V, Opts) end}
+     ]}.
+
+-type  describe_continuous_backup_return() :: ddb_return(#ddb2_create_backup{}, [table_name()]).
+
+-spec  describe_continuous_backups(table_name()) -> list_backups_return().
+describe_continuous_backups(TableName)
+    when is_bitstring(TableName) ->
+    describe_continuous_backups(TableName,[], default_config()).
+
+-spec  describe_continuous_backups(table_name(), ddb_opts()) -> describe_continuous_backup_return().
+describe_continuous_backups(TableName, Opts)
+    when is_bitstring(TableName) ->
+    describe_continuous_backups(TableName, Opts, default_config()).
+
+-spec  describe_continuous_backups(table_name(), ddb_opts(), aws_config()) -> describe_continuous_backup_return().
+describe_continuous_backups(TableName, Opts, Config)
+    when is_bitstring(TableName) ->
+    {AwsOpts, DdbOpts} = opts(describe_continuous_backup_opts(), Opts),
+    Return = erlcloud_ddb_impl:request(
+        Config,
+        "DynamoDB_20120810.DescribeContinuousBackups",
+        [{<<"TableName">>, TableName}] ++ AwsOpts),
+    out(Return, fun(Json, UOpts) -> undynamize_record(continuous_backups_record(), Json, UOpts) end,
+        DdbOpts, #ddb2_continuous_backups_record.continuous_backups_description).
+
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% DynamoDB API:
+%% [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableFromBackup.html]
+%%
+%% ===Example===
+%%
+%% Creates a new table from an existing backup.
+%%
+%% `
+%% {ok, Table} =
+%%     erlcloud_ddb2:restore_table_from_backup(<<"BackupArn">>,<<"Forum">>),
+%% '
+%% @end
+%%-------------------------------------------------------------------------------
+
+-spec restore_table_from_backup_opts() -> opt_table().
+restore_table_from_backup_opts() ->
+    [{backup_arn, <<"BackupArn">>, fun id/1},
+     {target_table_name, <<"TargetTableName">>, fun id/1}
+    ].
+
+-type restore_table_from_backup_return() :: ddb_return(#ddb2_create_table{}, #ddb2_table_description{}).
+
+-spec restore_table_from_backup(binary(), table_name()) -> restore_table_from_backup_return().
+restore_table_from_backup(BackupArn, TargetTableName)
+    when is_bitstring(BackupArn), is_bitstring(TargetTableName) ->
+    restore_table_from_backup(BackupArn, TargetTableName,[], default_config()).
+
+-spec restore_table_from_backup(binary(), table_name(), ddb_opts()) -> restore_table_from_backup_return().
+restore_table_from_backup(BackupArn, TargetTableName, Opts)
+    when is_bitstring(BackupArn), is_bitstring(TargetTableName) ->
+    restore_table_from_backup(BackupArn, TargetTableName, Opts, default_config()).
+
+-spec restore_table_from_backup(binary(), table_name(), ddb_opts(), aws_config()) -> restore_table_from_backup_return().
+restore_table_from_backup(BackupArn, TargetTableName, Opts, Config)
+    when is_bitstring(BackupArn), is_bitstring(TargetTableName) ->
+    {AwsOpts, DdbOpts} = opts(restore_table_from_backup_opts(), Opts),
+    Return = erlcloud_ddb_impl:request(
+        Config,
+        "DynamoDB_20120810.RestoreTableFromBackup",
+        [{<<"BackupArn">>, BackupArn},
+        {<<"TargetTableName">>, TargetTableName}] ++ AwsOpts),
+    out(Return, fun(Json, UOpts) -> undynamize_record(create_table_record(), Json, UOpts) end,
+        DdbOpts, #ddb2_create_table.table_description).

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -4617,31 +4617,31 @@ tag_resource_output_tests(_) ->
 %% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UntagResource.html
 untag_resource_input_tests(_) ->
     Tests =
-     [?_ddb_test(
-      {"ListTagsOfResource example request",
-       ?_f(erlcloud_ddb2:untag_resource(<<"arn:aws:dynamodb:us-east-1:111122223333:table/Forum">>,
-        [<<"example_key1">>, <<"example_key2">>])), "
-   {
-       \"ResourceArn\": \"arn:aws:dynamodb:us-east-1:111122223333:table/Forum\",
-       \"TagKeys\": [
-           \"example_key1\",
-           \"example_key2\"
-       ]
-   }"
-      })
-     ],
+        [?_ddb_test(
+            {"ListTagsOfResource example request",
+             ?_f(erlcloud_ddb2:untag_resource(<<"arn:aws:dynamodb:us-east-1:111122223333:table/Forum">>,
+                                              [<<"example_key1">>, <<"example_key2">>])), "
+{
+    \"ResourceArn\": \"arn:aws:dynamodb:us-east-1:111122223333:table/Forum\",
+    \"TagKeys\": [
+        \"example_key1\",
+        \"example_key2\"
+    ]
+}"
+            })
+        ],
     Response = "",
     input_tests(Response, Tests).
 
 untag_resource_output_tests(_) ->
-    Tests =
-     [?_ddb_test(
-      {"ListTagsOfResource example response", "",
-       ok})
-     ],
+    Tests = 
+        [?_ddb_test(
+            {"ListTagsOfResource example response", "",
+             ok})
+        ],
     output_tests(?_f(erlcloud_ddb2:untag_resource(<<"arn:aws:dynamodb:us-east-1:111122223333:table/Forum">>,
-     [<<"example_key1">>, <<"example_key2">>])),
-     Tests).
+                                                  [<<"example_key1">>, <<"example_key2">>])),
+                Tests).
 
 %% UpdateContinuousBackups test based on the API examples:
 %% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateContinuousBackups.html

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -69,7 +69,19 @@ operation_test_() ->
       fun update_table_input_tests/1,
       fun update_table_output_tests/1,
       fun update_time_to_live_input_tests/1,
-      fun update_time_to_live_output_tests/1
+      fun update_time_to_live_output_tests/1,
+      fun list_backups_input_tests/1,
+      fun list_backups_output_tests/1,
+      fun create_backup_input_tests/1,
+      fun create_backup_output_tests/1,
+      fun delete_backup_input_tests/1,
+      fun delete_backup_output_tests/1,
+      fun describe_backup_input_tests/1,
+      fun describe_backup_output_tests/1,
+      fun describe_continuous_backups_input_tests/1,
+      fun describe_continuous_backups_output_tests/1,
+      fun restore_table_from_backup_input_tests/1,
+      fun restore_table_from_backup_output_tests/1
      ]}.
 
 start() ->
@@ -4091,3 +4103,852 @@ update_time_to_live_output_tests(_) ->
                 enabled = true}}})],
     output_tests(?_f(erlcloud_ddb2:update_time_to_live(<<"SessionData">>, 
       [{attribute_name, <<"ExpirationTime">>}, {enabled, true}])), Tests).
+
+%% ListBackups test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListBackups.html
+list_backups_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"ListBackups example request",
+    ?_f(erlcloud_ddb2:list_backups([{limit, 4},{exclusive_start_backup_arn, <<"arn:aws:dynamodb:">>},{table_name, <<"Forum">>},{time_range_lower_bound,1522926603.688},{time_range_upper_bound, 1523022454.098}])), "
+    {
+        \"Limit\": 4,
+        \"TableName\": \"Forum\",
+        \"ExclusiveStartBackupArn\": \"arn:aws:dynamodb:\",
+        \"TimeRangeLowerBound\": 1522926603.688,
+        \"TimeRangeUpperBound\": 1523022454.098
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"BackupSummaries\": [
+      {
+         \"BackupArn\": \"arn:aws:dynamodb:\",
+         \"BackupCreationDateTime\": 1522926603.688,
+         \"BackupName\": \"Forum_backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"AVAILABLE\",
+         \"TableArn\": \"arn:aws:dynamodb:\",
+         \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
+         \"TableName\": \"Forum\"
+      }
+   ],
+   \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:\"
+}",
+ input_tests(Response, Tests).
+
+list_backups_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"ListBackups example response", "
+    {
+   \"BackupSummaries\": [
+      {
+         \"BackupArn\": \"arn:aws:dynamodb:\",
+         \"BackupCreationDateTime\": 1522926603.688,
+         \"BackupName\": \"Forum_backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"AVAILABLE\",
+         \"TableArn\": \"arn:aws:dynamodb:\",
+         \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
+         \"TableName\": \"Forum\"
+      }
+   ],
+   \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:\"
+}",
+    {ok,[#ddb2_backup_summaries{
+     backup_arn = <<"arn:aws:dynamodb:">>,
+     backup_creation_date_time = 1522926603.688,
+     backup_name = <<"Forum_backup">>,
+     backup_size_bytes = 1,
+     backup_status = <<"AVAILABLE">>,
+     table_arn = <<"arn:aws:dynamodb:">>,
+     table_id = <<"64d52641-ca33-4d44-8620-c8eccf22ef3d">>,
+     table_name = <<"Forum">>}]}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:list_backups()), Tests).
+
+
+%% CreateBackup test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateBackup.html
+create_backup_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"CreateBackup example request",
+    ?_f(erlcloud_ddb2:create_backup(<<"Forum_Backup">>,<<"Forum">>)), "
+    {
+        \"BackupName\": \"Forum_Backup\",
+        \"TableName\": \"Forum\"
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"BackupDetails\": {
+      \"BackupArn\": \"arn:aws:dynamodb:\",
+      \"BackupCreationDateTime\": 1523269031.475,
+      \"BackupName\": \"Forum_Backup\",
+      \"BackupSizeBytes\": 6,
+      \"BackupStatus\": \"CREATING\"
+      }
+   }",
+ input_tests(Response, Tests).
+
+create_backup_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"CreateBackup example response", "
+    {
+   \"BackupDetails\": {
+      \"BackupArn\": \"arn:aws:dynamodb:\",
+      \"BackupCreationDateTime\": 1523269031.475,
+      \"BackupName\": \"Forum_Backup\",
+      \"BackupSizeBytes\": 6,
+      \"BackupStatus\": \"CREATING\"
+      }
+}",
+    {ok,#ddb2_backup_details{
+     backup_arn = <<"arn:aws:dynamodb:">>,
+     backup_creation_date_time = 1523269031.475,
+     backup_name = <<"Forum_Backup">>,
+     backup_size_Bytes = 6,
+     backup_status = <<"CREATING">>}}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:create_backup(<<"Forum_Backup">>,<<"Forum">>)), Tests).
+
+
+%% DeleteBackup test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteBackup.html
+delete_backup_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DeleteBackup example request",
+    ?_f(erlcloud_ddb2:delete_backup(<<"arn:aws:dynamodb:">>)), "
+    {
+        \"BackupArn\": \"arn:aws:dynamodb:\"
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"BackupDescription\": {
+      \"BackupDetails\": {
+         \"BackupArn\": \"arn:aws:dynamodb:\",
+         \"BackupCreationDateTime\": 1523269031.475,
+         \"BackupName\": \"Forum_Backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"DELETED\"
+      },
+      \"SourceTableDetails\": {
+         \"ItemCount\": 0,
+         \"KeySchema\": [
+            {
+               \"AttributeName\": \"id\",
+               \"KeyType\": \"HASH\"
+            }
+         ],
+         \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+         },
+         \"TableArn\": \"arn:aws:dynamodb:\",
+         \"TableCreationDateTime\": 1523269031.475,
+         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+         \"TableName\": \"Forum\",
+         \"TableSizeBytes\": 1
+      },
+      \"SourceTableFeatureDetails\": {
+         \"GlobalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr\",
+                     \"KeyType\": \"HASH\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr2\" ],
+                  \"ProjectionType\": \"ALL\"
+               },
+               \"ProvisionedThroughput\": {
+                  \"ReadCapacityUnits\": 5,
+                  \"WriteCapacityUnits\": 5
+               }
+            }
+         ],
+         \"LocalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx2\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr3\",
+                     \"KeyType\": \"RANGE\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr4\" ],
+                  \"ProjectionType\": \"KEYS_ONLY\"
+               }
+            }
+         ],
+         \"SSEDescription\": {
+            \"Status\": \"DISABLED\"
+         },
+         \"StreamDescription\": {
+            \"StreamEnabled\": true,
+            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+         },
+         \"TimeToLiveDescription\": {
+            \"AttributeName\": \"none\",
+           \"TimeToLiveStatus\": \"DISABLED\"
+         }
+      }
+   }
+}",
+ input_tests(Response, Tests).
+
+delete_backup_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DeleteBackup example response", "
+    {
+    \"BackupDescription\": {
+      \"BackupDetails\": {
+         \"BackupArn\": \"arn:aws:dynamodb:\",
+         \"BackupCreationDateTime\": 1523269031.475,
+         \"BackupName\": \"Forum_Backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"DELETED\"
+      },
+      \"SourceTableDetails\": {
+         \"ItemCount\": 0,
+         \"KeySchema\": [
+            {
+               \"AttributeName\": \"id\",
+               \"KeyType\": \"HASH\"
+            }
+         ],
+         \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+         },
+         \"TableArn\": \"arn:aws:dynamodb:\",
+         \"TableCreationDateTime\": 1523269031.475,
+         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+         \"TableName\": \"Forum\",
+         \"TableSizeBytes\": 1
+      },
+      \"SourceTableFeatureDetails\": {
+         \"GlobalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr\",
+                     \"KeyType\": \"HASH\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr2\" ],
+                  \"ProjectionType\": \"ALL\"
+               },
+               \"ProvisionedThroughput\": {
+                  \"ReadCapacityUnits\": 5,
+                  \"WriteCapacityUnits\": 5
+               }
+            }
+         ],
+         \"LocalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx2\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr3\",
+                     \"KeyType\": \"RANGE\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr4\" ],
+                  \"ProjectionType\": \"KEYS_ONLY\"
+               }
+            }
+         ],
+         \"SSEDescription\": {
+            \"Status\": \"DISABLED\"
+         },
+         \"StreamDescription\": {
+            \"StreamEnabled\": true,
+            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+         },
+         \"TimeToLiveDescription\": {
+            \"AttributeName\": \"none\",
+           \"TimeToLiveStatus\": \"DISABLED\"
+         }
+      }
+   }
+}",
+    {ok,#ddb2_delete_backup_record{
+     dackup_details =
+         #ddb2_backup_details{
+          backup_arn = <<"arn:aws:dynamodb:">>,
+          backup_creation_date_time = 1523269031.475,
+          backup_name = <<"Forum_Backup">>,
+          backup_size_Bytes = 1,
+          backup_status = <<"DELETED">>},
+     source_table_details =
+          #ddb2_source_table_details{
+           item_count = 0,
+           key_schema = <<"id">>,
+           provisioned_throughput =
+            #ddb2_provisioned_throughput{
+             read_capacity_units = 5,
+             write_capacity_units = 5},
+           table_arn = <<"arn:aws:dynamodb:">>,
+           table_creation_date_time = 1523269031.475,
+           table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
+           table_name = <<"Forum">>,
+           table_size_bytes = 1},
+     source_table_feature_details =
+           #ddb2_source_table_feature_details{
+                global_secondary_indexes =
+                  [
+                    #ddb2_global_secondary_index_info{
+                     index_name = <<"Idx">>,
+                     key_schema = <<"Atr">>,
+                     projection = all,
+                     provisioned_throughput =
+                     #ddb2_provisioned_throughput{
+                      read_capacity_units = 5,
+                      write_capacity_units = 5
+                   }}
+                  ],
+               local_secondary_indexes =
+                  [
+                    #ddb2_local_secondary_index_info{
+                     index_name = <<"Idx2">>,
+                     key_schema = <<"Atr3">>,
+                     projection = keys_only
+                 }],
+              sse_description = {status,disabled},
+              stream_description = {true,new_and_old_images},
+              time_to_live_description = {ddb2_time_to_live_description,<<"none">>,
+                 disabled}}
+    }}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:delete_backup(<<"arn:aws:dynamodb:">>)), Tests).
+
+%% DescribeBackup test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContinuousBackups.html
+describe_backup_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DescribeBackup example request",
+    ?_f(erlcloud_ddb2:describe_backup(<<"BackupArn">>)), "
+    {
+        \"BackupArn\": \"BackupArn\"
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"BackupDescription\": {
+      \"BackupDetails\": {
+         \"BackupArn\": \"arn:aws:dynamodb:\",
+         \"BackupCreationDateTime\": 1523269031.475,
+         \"BackupName\": \"Forum_Backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"DELETED\"
+      },
+      \"SourceTableDetails\": {
+         \"ItemCount\": 0,
+         \"KeySchema\": [
+            {
+               \"AttributeName\": \"id\",
+               \"KeyType\": \"HASH\"
+            }
+         ],
+         \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+         },
+         \"TableArn\": \"arn:aws:dynamodb:\",
+         \"TableCreationDateTime\": 1523269031.475,
+         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+         \"TableName\": \"Forum\",
+         \"TableSizeBytes\": 1
+      },
+      \"SourceTableFeatureDetails\": {
+         \"GlobalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr\",
+                     \"KeyType\": \"HASH\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr2\" ],
+                  \"ProjectionType\": \"ALL\"
+               },
+               \"ProvisionedThroughput\": {
+                  \"ReadCapacityUnits\": 5,
+                  \"WriteCapacityUnits\": 5
+               }
+            }
+         ],
+         \"LocalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx2\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr3\",
+                     \"KeyType\": \"RANGE\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr4\" ],
+                  \"ProjectionType\": \"KEYS_ONLY\"
+               }
+            }
+         ],
+         \"SSEDescription\": {
+            \"Status\": \"DISABLED\"
+         },
+         \"StreamDescription\": {
+            \"StreamEnabled\": true,
+            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+         },
+         \"TimeToLiveDescription\": {
+            \"AttributeName\": \"none\",
+           \"TimeToLiveStatus\": \"DISABLED\"
+         }
+      }
+   }
+}",
+ input_tests(Response, Tests).
+
+describe_backup_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DescribeBackup example response", "
+   {
+   \"BackupDescription\": {
+      \"BackupDetails\": {
+         \"BackupArn\": \"arn:aws:dynamodb:\",
+         \"BackupCreationDateTime\": 1523269031.475,
+         \"BackupName\": \"Forum_Backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"DELETED\"
+      },
+      \"SourceTableDetails\": {
+         \"ItemCount\": 0,
+         \"KeySchema\": [
+            {
+               \"AttributeName\": \"id\",
+               \"KeyType\": \"HASH\"
+            }
+         ],
+         \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+         },
+         \"TableArn\": \"arn:aws:dynamodb:\",
+         \"TableCreationDateTime\": 1523269031.475,
+         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+         \"TableName\": \"Forum\",
+         \"TableSizeBytes\": 1
+      },
+      \"SourceTableFeatureDetails\": {
+         \"GlobalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr\",
+                     \"KeyType\": \"HASH\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr2\" ],
+                  \"ProjectionType\": \"ALL\"
+               },
+               \"ProvisionedThroughput\": {
+                  \"ReadCapacityUnits\": 5,
+                  \"WriteCapacityUnits\": 5
+               }
+            }
+         ],
+         \"LocalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx2\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr3\",
+                     \"KeyType\": \"RANGE\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr4\" ],
+                  \"ProjectionType\": \"KEYS_ONLY\"
+               }
+            }
+         ],
+         \"SSEDescription\": {
+            \"Status\": \"DISABLED\"
+         },
+         \"StreamDescription\": {
+            \"StreamEnabled\": true,
+            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+         },
+         \"TimeToLiveDescription\": {
+            \"AttributeName\": \"none\",
+           \"TimeToLiveStatus\": \"DISABLED\"
+         }
+      }
+   }
+}",
+    {ok,#ddb2_delete_backup_record{
+     dackup_details =
+     #ddb2_backup_details{
+      backup_arn = <<"arn:aws:dynamodb:">>,
+      backup_creation_date_time = 1523269031.475,
+      backup_name = <<"Forum_Backup">>,
+      backup_size_Bytes = 1,
+      backup_status = <<"DELETED">>},
+     source_table_details =
+     #ddb2_source_table_details{
+      item_count = 0,
+      key_schema = <<"id">>,
+      provisioned_throughput =
+      #ddb2_provisioned_throughput{
+       read_capacity_units = 5,
+       write_capacity_units = 5},
+      table_arn = <<"arn:aws:dynamodb:">>,
+      table_creation_date_time = 1523269031.475,
+      table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
+      table_name = <<"Forum">>,
+      table_size_bytes = 1},
+     source_table_feature_details =
+     #ddb2_source_table_feature_details{
+      global_secondary_indexes =
+      [
+       #ddb2_global_secondary_index_info{
+        index_name = <<"Idx">>,
+        key_schema = <<"Atr">>,
+        projection = all,
+        provisioned_throughput =
+        #ddb2_provisioned_throughput{
+         read_capacity_units = 5,
+         write_capacity_units = 5
+        }}
+      ],
+      local_secondary_indexes =
+      [
+       #ddb2_local_secondary_index_info{
+        index_name = <<"Idx2">>,
+        key_schema = <<"Atr3">>,
+        projection = keys_only
+       }],
+      sse_description = {status,disabled},
+      stream_description = {true,new_and_old_images},
+      time_to_live_description = {ddb2_time_to_live_description,<<"none">>,
+       disabled}}
+    }}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:describe_backup(<<"BackupArn">>)), Tests).
+
+%% DescribeContinuousBackups test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContinuousBackups.html
+describe_continuous_backups_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DescribeContinuousBackups example request",
+    ?_f(erlcloud_ddb2:describe_continuous_backups(<<"Forum">>)), "
+    {
+        \"TableName\": \"Forum\"
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"ContinuousBackupsDescription\": {
+      \"ContinuousBackupsStatus\": \"ENABLED\",
+      \"PointInTimeRecoveryDescription\": {
+         \"EarliestRestorableDateTime\": 1,
+         \"LatestRestorableDateTime\": 1,
+         \"PointInTimeRecoveryStatus\": \"DISABLED\"
+        }
+     }
+   }",
+ input_tests(Response, Tests).
+
+describe_continuous_backups_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DescribeContinuousBackups example response", "
+   {
+   \"ContinuousBackupsDescription\": {
+      \"ContinuousBackupsStatus\": \"ENABLED\",
+      \"PointInTimeRecoveryDescription\": {
+         \"EarliestRestorableDateTime\": 1,
+         \"LatestRestorableDateTime\": 1,
+         \"PointInTimeRecoveryStatus\": \"DISABLED\"
+        }
+     }
+}",
+    {ok,#continuous_backups_description{
+     continuous_backups_status = <<"ENABLED">>,
+     point_in_time_recovery_description =
+          #point_in_time_recovery_description{
+            earliest_restorable_date_time = 1,
+            latest_restorable_date_time = 1,
+            point_in_time_recovery_status = <<"DISABLED">>}}}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:describe_continuous_backups(<<"Forum">>)), Tests).
+
+%% RestoreTableFromBackup test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableFromBackup.html
+restore_table_from_backup_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"RestoreTableFromBackup example request",
+    ?_f(erlcloud_ddb2:restore_table_from_backup(<<"BackupArn">>,<<"Thread">>)), "
+    {
+        \"BackupArn\": \"BackupArn\",
+        \"TargetTableName\": \"Thread\"
+    }"
+   })
+  ],
+ Response = "
+{
+    \"TableDescription\": {
+        \"AttributeDefinitions\": [
+            {
+                \"AttributeName\": \"ForumName\",
+                \"AttributeType\": \"S\"
+            },
+            {
+                \"AttributeName\": \"LastPostDateTime\",
+                \"AttributeType\": \"S\"
+            },
+            {
+                \"AttributeName\": \"Subject\",
+                \"AttributeType\": \"S\"
+            }
+        ],
+        \"CreationDateTime\": 1.36372808007E9,
+        \"GlobalSecondaryIndexes\": [
+            {
+                \"IndexName\": \"SubjectIndex\",
+                \"IndexSizeBytes\": 2048,
+                \"IndexStatus\": \"CREATING\",
+                \"ItemCount\": 47,
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"Subject\",
+                        \"KeyType\": \"HASH\"
+                    },
+                    {
+                        \"AttributeName\": \"LastPostDateTime\",
+                        \"KeyType\": \"RANGE\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"KEYS_ONLY\"
+                },
+                \"ProvisionedThroughput\": {
+                    \"LastDecreaseDateTime\": 0,
+                    \"LastIncreaseDateTime\": 1,
+                    \"NumberOfDecreasesToday\": 2,
+                    \"ReadCapacityUnits\": 3,
+                    \"WriteCapacityUnits\": 4
+                }
+            }
+        ],
+        \"ItemCount\": 0,
+        \"KeySchema\": [
+            {
+                \"AttributeName\": \"ForumName\",
+                \"KeyType\": \"HASH\"
+            },
+            {
+                \"AttributeName\": \"Subject\",
+                \"KeyType\": \"RANGE\"
+            }
+        ],
+        \"LocalSecondaryIndexes\": [
+            {
+                \"IndexName\": \"LastPostIndex\",
+                \"IndexSizeBytes\": 0,
+                \"ItemCount\": 0,
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"ForumName\",
+                        \"KeyType\": \"HASH\"
+                    },
+                    {
+                        \"AttributeName\": \"LastPostDateTime\",
+                        \"KeyType\": \"RANGE\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"KEYS_ONLY\"
+                }
+            }
+        ],
+        \"ProvisionedThroughput\": {
+            \"NumberOfDecreasesToday\": 0,
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+        },
+        \"TableName\": \"Thread\",
+        \"TableSizeBytes\": 0,
+        \"TableStatus\": \"CREATING\"
+    }
+}",
+ input_tests(Response, Tests).
+
+restore_table_from_backup_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"RestoreTableFromBackup example response", "{
+    \"TableDescription\": {
+        \"AttributeDefinitions\": [
+            {
+                \"AttributeName\": \"ForumName\",
+                \"AttributeType\": \"S\"
+            },
+            {
+                \"AttributeName\": \"LastPostDateTime\",
+                \"AttributeType\": \"S\"
+            },
+            {
+                \"AttributeName\": \"Subject\",
+                \"AttributeType\": \"S\"
+            }
+        ],
+        \"CreationDateTime\": 1.36372808007E9,
+        \"GlobalSecondaryIndexes\": [
+            {
+                \"IndexName\": \"SubjectIndex\",
+                \"IndexSizeBytes\": 2048,
+                \"IndexStatus\": \"CREATING\",
+                \"ItemCount\": 47,
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"Subject\",
+                        \"KeyType\": \"HASH\"
+                    },
+                    {
+                        \"AttributeName\": \"LastPostDateTime\",
+                        \"KeyType\": \"RANGE\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"KEYS_ONLY\"
+                },
+                \"ProvisionedThroughput\": {
+                    \"LastDecreaseDateTime\": 0,
+                    \"LastIncreaseDateTime\": 1,
+                    \"NumberOfDecreasesToday\": 2,
+                    \"ReadCapacityUnits\": 3,
+                    \"WriteCapacityUnits\": 4
+                }
+            }
+        ],
+        \"ItemCount\": 0,
+        \"KeySchema\": [
+            {
+                \"AttributeName\": \"ForumName\",
+                \"KeyType\": \"HASH\"
+            },
+            {
+                \"AttributeName\": \"Subject\",
+                \"KeyType\": \"RANGE\"
+            }
+        ],
+        \"LocalSecondaryIndexes\": [
+            {
+                \"IndexName\": \"LastPostIndex\",
+                \"IndexSizeBytes\": 0,
+                \"ItemCount\": 0,
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"ForumName\",
+                        \"KeyType\": \"HASH\"
+                    },
+                    {
+                        \"AttributeName\": \"LastPostDateTime\",
+                        \"KeyType\": \"RANGE\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"KEYS_ONLY\"
+                }
+            }
+        ],
+        \"ProvisionedThroughput\": {
+            \"NumberOfDecreasesToday\": 0,
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+        },
+        \"TableName\": \"Thread\",
+        \"TableSizeBytes\": 0,
+        \"TableStatus\": \"CREATING\"
+    }
+}",
+    {ok, #ddb2_table_description
+    {attribute_definitions = [{<<"ForumName">>, s},
+     {<<"LastPostDateTime">>, s},
+     {<<"Subject">>, s}],
+     creation_date_time = 1363728080.07,
+     item_count = 0,
+     key_schema = {<<"ForumName">>, <<"Subject">>},
+     local_secondary_indexes =
+     [#ddb2_local_secondary_index_description{
+      index_name = <<"LastPostIndex">>,
+      index_size_bytes = 0,
+      item_count = 0,
+      key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
+      projection = keys_only}],
+     global_secondary_indexes =
+     [#ddb2_global_secondary_index_description{
+      index_name = <<"SubjectIndex">>,
+      index_size_bytes = 2048,
+      index_status = creating,
+      item_count = 47,
+      key_schema = {<<"Subject">>, <<"LastPostDateTime">>},
+      projection = keys_only,
+      provisioned_throughput = #ddb2_provisioned_throughput_description{
+       last_decrease_date_time = 0,
+       last_increase_date_time = 1,
+       number_of_decreases_today = 2,
+       read_capacity_units = 3,
+       write_capacity_units = 4}
+     }],
+     provisioned_throughput =
+     #ddb2_provisioned_throughput_description{
+      last_decrease_date_time = undefined,
+      last_increase_date_time = undefined,
+      number_of_decreases_today = 0,
+      read_capacity_units = 5,
+      write_capacity_units = 5},
+     table_name = <<"Thread">>,
+     table_size_bytes = 0,
+     table_status = creating}}})
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:restore_table_from_backup(<<"BackupArn">>,<<"Thread">>)), Tests).

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -80,10 +80,10 @@ operation_test_() ->
       fun scan_output_tests/1,
       fun tag_resource_input_tests/1,
       fun tag_resource_output_tests/1,
-      fun update_continuous_backups_input_tests/1,
-      fun update_continuous_backups_output_tests/1,
       fun untag_resource_input_tests/1,
       fun untag_resource_output_tests/1,
+      fun update_continuous_backups_input_tests/1,
+      fun update_continuous_backups_output_tests/1,
       fun update_item_input_tests/1,
       fun update_item_output_tests/1,
       fun update_global_table_input_tests/1,
@@ -882,36 +882,36 @@ create_backup_input_tests(_) ->
    })
   ],
  Response = "
-    {
-   \"BackupDetails\": {
-      \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
-      \"BackupCreationDateTime\": 1523269031.475,
-      \"BackupName\": \"Forum_Backup\",
-      \"BackupSizeBytes\": 6,
-      \"BackupStatus\": \"CREATING\"
+{
+    \"BackupDetails\": {
+          \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+          \"BackupCreationDateTime\": 1523269031.475,
+          \"BackupName\": \"Forum_Backup\",
+          \"BackupSizeBytes\": 6,
+          \"BackupStatus\": \"CREATING\"
       }
-   }",
+}",
  input_tests(Response, Tests).
 
 create_backup_output_tests(_) ->
  Tests =
   [?_ddb_test(
    {"CreateBackup example response", "
-    {
-   \"BackupDetails\": {
-      \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
-      \"BackupCreationDateTime\": 1523269031.475,
-      \"BackupName\": \"Forum_Backup\",
-      \"BackupSizeBytes\": 6,
-      \"BackupStatus\": \"CREATING\"
-      }
+{
+    \"BackupDetails\": {
+        \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+        \"BackupCreationDateTime\": 1523269031.475,
+        \"BackupName\": \"Forum_Backup\",
+        \"BackupSizeBytes\": 6,
+        \"BackupStatus\": \"CREATING\"
+       }
 }",
     {ok,#ddb2_backup_details{
-     backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
-     backup_creation_date_time = 1523269031.475,
-     backup_name = <<"Forum_Backup">>,
-     backup_size_Bytes = 6,
-     backup_status = creating}}
+        backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+        backup_creation_date_time = 1523269031.475,
+        backup_name = <<"Forum_Backup">>,
+        backup_size_Bytes = 6,
+        backup_status = creating}}
    })
   ],
 
@@ -1303,7 +1303,7 @@ delete_backup_input_tests(_) ->
    })
   ],
  Response = "
-    {
+{
    \"BackupDescription\": {
       \"BackupDetails\": {
          \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
@@ -1385,130 +1385,127 @@ delete_backup_output_tests(_) ->
  Tests =
   [?_ddb_test(
    {"DeleteBackup example response", "
-    {
+{
     \"BackupDescription\": {
-      \"BackupDetails\": {
-         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
-         \"BackupCreationDateTime\": 1523269031.475,
-         \"BackupName\": \"Forum_Backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"DELETED\"
-      },
-      \"SourceTableDetails\": {
-         \"ItemCount\": 0,
-         \"KeySchema\": [
-            {
-               \"AttributeName\": \"id\",
-               \"KeyType\": \"HASH\"
-            }
-         ],
-         \"ProvisionedThroughput\": {
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
+         \"BackupDetails\": {
+             \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+             \"BackupCreationDateTime\": 1523269031.475,
+             \"BackupName\": \"Forum_Backup\",
+             \"BackupSizeBytes\": 1,
+             \"BackupStatus\": \"DELETED\"
          },
-         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
-         \"TableCreationDateTime\": 1523269031.475,
-         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
-         \"TableName\": \"Forum\",
-         \"TableSizeBytes\": 1
-      },
-      \"SourceTableFeatureDetails\": {
-         \"GlobalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr\",
-                     \"KeyType\": \"HASH\"
+         \"SourceTableDetails\": {
+            \"ItemCount\": 0,
+            \"KeySchema\": [
+                {
+                   \"AttributeName\": \"id\",
+                   \"KeyType\": \"HASH\"
+                }
+             ],
+            \"ProvisionedThroughput\": {
+                \"ReadCapacityUnits\": 5,
+                \"WriteCapacityUnits\": 5
+            },
+            \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+            \"TableCreationDateTime\": 1523269031.475,
+            \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+            \"TableName\": \"Forum\",
+            \"TableSizeBytes\": 1
+         },
+        \"SourceTableFeatureDetails\": {
+            \"GlobalSecondaryIndexes\": [
+               {
+                  \"IndexName\": \"Idx\",
+                  \"KeySchema\": [
+                     {
+                        \"AttributeName\": \"Atr\",
+                        \"KeyType\": \"HASH\"
+                     }
+                  ],
+                  \"Projection\": {
+                     \"NonKeyAttributes\": [ \"Atr2\" ],
+                     \"ProjectionType\": \"ALL\"
+                  },
+                  \"ProvisionedThroughput\": {
+                     \"ReadCapacityUnits\": 5,
+                     \"WriteCapacityUnits\": 5
                   }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr2\" ],
-                  \"ProjectionType\": \"ALL\"
-               },
-               \"ProvisionedThroughput\": {
-                  \"ReadCapacityUnits\": 5,
-                  \"WriteCapacityUnits\": 5
                }
-            }
-         ],
-         \"LocalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx2\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr3\",
-                     \"KeyType\": \"RANGE\"
+            ],
+            \"LocalSecondaryIndexes\": [
+               {
+                  \"IndexName\": \"Idx2\",
+                  \"KeySchema\": [
+                     {
+                        \"AttributeName\": \"Atr3\",
+                        \"KeyType\": \"RANGE\"
+                     }
+                  ],
+                  \"Projection\": {
+                     \"NonKeyAttributes\": [ \"Atr4\" ],
+                     \"ProjectionType\": \"KEYS_ONLY\"
                   }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr4\" ],
-                  \"ProjectionType\": \"KEYS_ONLY\"
                }
+            ],
+            \"SSEDescription\": {
+               \"Status\": \"DISABLED\"
+            },
+            \"StreamDescription\": {
+               \"StreamEnabled\": true,
+               \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+            },
+            \"TimeToLiveDescription\": {
+               \"AttributeName\": \"none\",
+              \"TimeToLiveStatus\": \"DISABLED\"
             }
-         ],
-         \"SSEDescription\": {
-            \"Status\": \"DISABLED\"
-         },
-         \"StreamDescription\": {
-            \"StreamEnabled\": true,
-            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
-         },
-         \"TimeToLiveDescription\": {
-            \"AttributeName\": \"none\",
-           \"TimeToLiveStatus\": \"DISABLED\"
-         }
-      }
+        }
    }
 }",
     {ok,#ddb2_backup_description{
      backup_details =
      #ddb2_backup_details{
-      backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
-      backup_creation_date_time = 1523269031.475,
-      backup_name = <<"Forum_Backup">>,
-      backup_size_Bytes = 1,
-      backup_status = deleted},
+         backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+         backup_creation_date_time = 1523269031.475,
+         backup_name = <<"Forum_Backup">>,
+         backup_size_Bytes = 1,
+         backup_status = deleted},
      source_table_details =
      #ddb2_source_table_details{
-      item_count = 0,
-      key_schema = <<"id">>,
-      provisioned_throughput =
-      #ddb2_provisioned_throughput{
-       read_capacity_units = 5,
-       write_capacity_units = 5},
-      table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
-      table_creation_date_time = 1523269031.475,
-      table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
-      table_name = <<"Forum">>,
-      table_size_bytes = 1},
+         item_count = 0,
+         key_schema = <<"id">>,
+         provisioned_throughput =
+         #ddb2_provisioned_throughput{
+             read_capacity_units = 5,
+             write_capacity_units = 5},
+         table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
+         table_creation_date_time = 1523269031.475,
+         table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
+         table_name = <<"Forum">>,
+         table_size_bytes = 1},
      source_table_feature_details =
      #ddb2_source_table_feature_details{
-      global_secondary_indexes =
-      [
-       #ddb2_global_secondary_index_info{
-        index_name = <<"Idx">>,
-        key_schema = <<"Atr">>,
-        projection = all,
-        provisioned_throughput =
-        #ddb2_provisioned_throughput{
-         read_capacity_units = 5,
-         write_capacity_units = 5
-        }}
-      ],
-      local_secondary_indexes =
-      [
-       #ddb2_local_secondary_index_info{
-        index_name = <<"Idx2">>,
-        key_schema = <<"Atr3">>,
-        projection = keys_only
-       }],
-      sse_description = {status,disabled},
-      stream_description = {true,new_and_old_images},
-      time_to_live_description =
-      #ddb2_time_to_live_description{
-       attribute_name = <<"none">>,
-       time_to_live_status = disabled}}
+         global_secondary_indexes =
+         [#ddb2_global_secondary_index_info{
+              index_name = <<"Idx">>,
+              key_schema = <<"Atr">>,
+              projection = all,
+              provisioned_throughput =
+              #ddb2_provisioned_throughput{
+               read_capacity_units = 5,
+               write_capacity_units = 5
+              }}],
+         local_secondary_indexes =
+         [#ddb2_local_secondary_index_info{
+              index_name = <<"Idx2">>,
+              key_schema = <<"Atr3">>,
+              projection = keys_only
+             }],
+         sse_description = {status,disabled},
+         stream_description = {true,new_and_old_images},
+         time_to_live_description =
+         #ddb2_time_to_live_description{
+             attribute_name = <<"none">>,
+             time_to_live_status = disabled}}
     }}
    })
   ],
@@ -2053,81 +2050,81 @@ describe_backup_input_tests(_) ->
    })
   ],
  Response = "
-    {
-   \"BackupDescription\": {
-      \"BackupDetails\": {
-         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
-         \"BackupCreationDateTime\": 1523269031.475,
-         \"BackupName\": \"Forum_Backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"DELETED\"
-      },
-      \"SourceTableDetails\": {
-         \"ItemCount\": 0,
-         \"KeySchema\": [
-            {
-               \"AttributeName\": \"id\",
-               \"KeyType\": \"HASH\"
-            }
-         ],
-         \"ProvisionedThroughput\": {
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
-         },
-         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
-         \"TableCreationDateTime\": 1523269031.475,
-         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
-         \"TableName\": \"Forum\",
-         \"TableSizeBytes\": 1
-      },
-      \"SourceTableFeatureDetails\": {
-         \"GlobalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr\",
-                     \"KeyType\": \"HASH\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr2\" ],
-                  \"ProjectionType\": \"ALL\"
-               },
-               \"ProvisionedThroughput\": {
-                  \"ReadCapacityUnits\": 5,
-                  \"WriteCapacityUnits\": 5
+{
+    \"BackupDescription\": {
+        \"BackupDetails\": {
+            \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+            \"BackupCreationDateTime\": 1523269031.475,
+            \"BackupName\": \"Forum_Backup\",
+            \"BackupSizeBytes\": 1,
+            \"BackupStatus\": \"DELETED\"
+        },
+        \"SourceTableDetails\": {
+            \"ItemCount\": 0,
+            \"KeySchema\": [
+               {
+                  \"AttributeName\": \"id\",
+                  \"KeyType\": \"HASH\"
                }
-            }
-         ],
-         \"LocalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx2\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr3\",
-                     \"KeyType\": \"RANGE\"
+            ],
+            \"ProvisionedThroughput\": {
+               \"ReadCapacityUnits\": 5,
+               \"WriteCapacityUnits\": 5
+            },
+            \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+            \"TableCreationDateTime\": 1523269031.475,
+            \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+            \"TableName\": \"Forum\",
+            \"TableSizeBytes\": 1
+        },
+       \"SourceTableFeatureDetails\": {
+           \"GlobalSecondaryIndexes\": [
+               {
+                  \"IndexName\": \"Idx\",
+                  \"KeySchema\": [
+                      {
+                          \"AttributeName\": \"Atr\",
+                          \"KeyType\": \"HASH\"
+                      }
+                  ],
+                  \"Projection\": {
+                      \"NonKeyAttributes\": [ \"Atr2\" ],
+                      \"ProjectionType\": \"ALL\"
+                  },
+                   \"ProvisionedThroughput\": {
+                      \"ReadCapacityUnits\": 5,
+                      \"WriteCapacityUnits\": 5
                   }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr4\" ],
-                  \"ProjectionType\": \"KEYS_ONLY\"
                }
-            }
-         ],
-         \"SSEDescription\": {
-            \"Status\": \"DISABLED\"
-         },
-         \"StreamDescription\": {
-            \"StreamEnabled\": true,
-            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
-         },
-         \"TimeToLiveDescription\": {
-            \"AttributeName\": \"none\",
-           \"TimeToLiveStatus\": \"DISABLED\"
-         }
-      }
-   }
+           ],
+           \"LocalSecondaryIndexes\": [
+               {
+                   \"IndexName\": \"Idx2\",
+                    \"KeySchema\": [
+                        {
+                            \"AttributeName\": \"Atr3\",
+                            \"KeyType\": \"RANGE\"
+                        }
+                   ],
+                   \"Projection\": {
+                       \"NonKeyAttributes\": [ \"Atr4\" ],
+                       \"ProjectionType\": \"KEYS_ONLY\"
+                   }
+               }
+           ],
+           \"SSEDescription\": {
+               \"Status\": \"DISABLED\"
+           },
+           \"StreamDescription\": {
+               \"StreamEnabled\": true,
+               \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+           },
+           \"TimeToLiveDescription\": {
+               \"AttributeName\": \"none\",
+               \"TimeToLiveStatus\": \"DISABLED\"
+           }
+       }
+    }
 }",
  input_tests(Response, Tests).
 
@@ -2135,131 +2132,128 @@ describe_backup_output_tests(_) ->
  Tests =
   [?_ddb_test(
    {"DescribeBackup example response", "
-   {
-   \"BackupDescription\": {
-      \"BackupDetails\": {
-         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
-         \"BackupCreationDateTime\": 1523269031.475,
-         \"BackupName\": \"Forum_Backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"DELETED\"
-      },
-      \"SourceTableDetails\": {
-         \"ItemCount\": 0,
-         \"KeySchema\": [
-            {
-               \"AttributeName\": \"id\",
-               \"KeyType\": \"HASH\"
-            }
-         ],
-         \"ProvisionedThroughput\": {
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
+{
+     \"BackupDescription\": {
+         \"BackupDetails\": {
+             \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+             \"BackupCreationDateTime\": 1523269031.475,
+             \"BackupName\": \"Forum_Backup\",
+             \"BackupSizeBytes\": 1,
+             \"BackupStatus\": \"DELETED\"
          },
-         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
-         \"TableCreationDateTime\": 1523269031.475,
-         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
-         \"TableName\": \"Forum\",
-         \"TableSizeBytes\": 1
-      },
-      \"SourceTableFeatureDetails\": {
-         \"GlobalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr\",
+         \"SourceTableDetails\": {
+             \"ItemCount\": 0,
+             \"KeySchema\": [
+                 {
+                     \"AttributeName\": \"id\",
                      \"KeyType\": \"HASH\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr2\" ],
-                  \"ProjectionType\": \"ALL\"
-               },
-               \"ProvisionedThroughput\": {
-                  \"ReadCapacityUnits\": 5,
-                  \"WriteCapacityUnits\": 5
-               }
-            }
-         ],
-         \"LocalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx2\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr3\",
-                     \"KeyType\": \"RANGE\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr4\" ],
-                  \"ProjectionType\": \"KEYS_ONLY\"
-               }
-            }
-         ],
-         \"SSEDescription\": {
-            \"Status\": \"DISABLED\"
+                 }
+             ],
+             \"ProvisionedThroughput\": {
+                 \"ReadCapacityUnits\": 5,
+                 \"WriteCapacityUnits\": 5
+             },
+             \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+             \"TableCreationDateTime\": 1523269031.475,
+             \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+             \"TableName\": \"Forum\",
+             \"TableSizeBytes\": 1
          },
-         \"StreamDescription\": {
-            \"StreamEnabled\": true,
-            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
-         },
-         \"TimeToLiveDescription\": {
-            \"AttributeName\": \"none\",
-           \"TimeToLiveStatus\": \"DISABLED\"
+         \"SourceTableFeatureDetails\": {
+             \"GlobalSecondaryIndexes\": [
+                {
+                    \"IndexName\": \"Idx\",
+                    \"KeySchema\": [
+                       {
+                           \"AttributeName\": \"Atr\",
+                           \"KeyType\": \"HASH\"
+                       }
+                    ],
+                    \"Projection\": {
+                        \"NonKeyAttributes\": [ \"Atr2\" ],
+                        \"ProjectionType\": \"ALL\"
+                    },
+                    \"ProvisionedThroughput\": {
+                        \"ReadCapacityUnits\": 5,
+                        \"WriteCapacityUnits\": 5
+                    }
+                }
+            ],
+            \"LocalSecondaryIndexes\": [
+                {
+                    \"IndexName\": \"Idx2\",
+                    \"KeySchema\": [
+                        {
+                            \"AttributeName\": \"Atr3\",
+                            \"KeyType\": \"RANGE\"
+                        }
+                    ],
+                    \"Projection\": {
+                        \"NonKeyAttributes\": [ \"Atr4\" ],
+                        \"ProjectionType\": \"KEYS_ONLY\"
+                    }
+                }
+            ],
+             \"SSEDescription\": {
+                 \"Status\": \"DISABLED\"
+             },
+             \"StreamDescription\": {
+                 \"StreamEnabled\": true,
+                 \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+             },
+             \"TimeToLiveDescription\": {
+                 \"AttributeName\": \"none\",
+                 \"TimeToLiveStatus\": \"DISABLED\"
+             }
          }
-      }
-   }
+    }
 }",
     {ok,#ddb2_backup_description{
-     backup_details =
-     #ddb2_backup_details{
-      backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
-      backup_creation_date_time = 1523269031.475,
-      backup_name = <<"Forum_Backup">>,
-      backup_size_Bytes = 1,
-      backup_status = deleted},
-     source_table_details =
-     #ddb2_source_table_details{
-      item_count = 0,
-      key_schema = <<"id">>,
-      provisioned_throughput =
-      #ddb2_provisioned_throughput{
-       read_capacity_units = 5,
-       write_capacity_units = 5},
-      table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
-      table_creation_date_time = 1523269031.475,
-      table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
-      table_name = <<"Forum">>,
-      table_size_bytes = 1},
-     source_table_feature_details =
-     #ddb2_source_table_feature_details{
-      global_secondary_indexes =
-      [
-       #ddb2_global_secondary_index_info{
-        index_name = <<"Idx">>,
-        key_schema = <<"Atr">>,
-        projection = all,
-        provisioned_throughput =
-        #ddb2_provisioned_throughput{
-         read_capacity_units = 5,
-         write_capacity_units = 5
-        }}
-      ],
-      local_secondary_indexes =
-      [
-       #ddb2_local_secondary_index_info{
-        index_name = <<"Idx2">>,
-        key_schema = <<"Atr3">>,
-        projection = keys_only
-       }],
-      sse_description = {status,disabled},
-      stream_description = {true,new_and_old_images},
-      time_to_live_description =
-      #ddb2_time_to_live_description{
-       attribute_name = <<"none">>,
-       time_to_live_status = disabled}}
-    }}
+        backup_details =
+            #ddb2_backup_details{
+                backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+                backup_creation_date_time = 1523269031.475,
+                backup_name = <<"Forum_Backup">>,
+                backup_size_Bytes = 1,
+                backup_status = deleted},
+        source_table_details =
+            #ddb2_source_table_details{
+                item_count = 0,
+                key_schema = <<"id">>,
+                provisioned_throughput =
+                    #ddb2_provisioned_throughput{
+                     read_capacity_units = 5,
+                     write_capacity_units = 5},
+                table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
+                table_creation_date_time = 1523269031.475,
+                table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
+                table_name = <<"Forum">>,
+                table_size_bytes = 1},
+        source_table_feature_details =
+            #ddb2_source_table_feature_details{
+             global_secondary_indexes =
+                 [#ddb2_global_secondary_index_info{
+                     index_name = <<"Idx">>,
+                     key_schema = <<"Atr">>,
+                     projection = all,
+                     provisioned_throughput =
+                        #ddb2_provisioned_throughput{
+                         read_capacity_units = 5,
+                         write_capacity_units = 5
+                      }}],
+             local_secondary_indexes =
+                 [#ddb2_local_secondary_index_info{
+                   index_name = <<"Idx2">>,
+                   key_schema = <<"Atr3">>,
+                   projection = keys_only
+                  }],
+             sse_description = {status,disabled},
+             stream_description = {true,new_and_old_images},
+             time_to_live_description =
+                 #ddb2_time_to_live_description{
+                  attribute_name = <<"none">>,
+                  time_to_live_status = disabled}}
+       }}
    })
   ],
 
@@ -2278,39 +2272,40 @@ describe_continuous_backups_input_tests(_) ->
    })
   ],
  Response = "
-    {
+{
    \"ContinuousBackupsDescription\": {
-      \"ContinuousBackupsStatus\": \"ENABLED\",
-      \"PointInTimeRecoveryDescription\": {
-         \"EarliestRestorableDateTime\": 1,
-         \"LatestRestorableDateTime\": 1,
-         \"PointInTimeRecoveryStatus\": \"DISABLED\"
+       \"ContinuousBackupsStatus\": \"ENABLED\",
+        \"PointInTimeRecoveryDescription\": {
+            \"EarliestRestorableDateTime\": 1,
+            \"LatestRestorableDateTime\": 1,
+            \"PointInTimeRecoveryStatus\": \"DISABLED\"
         }
-     }
-   }",
+   }
+}",
  input_tests(Response, Tests).
 
 describe_continuous_backups_output_tests(_) ->
  Tests =
   [?_ddb_test(
    {"DescribeContinuousBackups example response", "
-   {
+{
    \"ContinuousBackupsDescription\": {
-      \"ContinuousBackupsStatus\": \"ENABLED\",
-      \"PointInTimeRecoveryDescription\": {
-         \"EarliestRestorableDateTime\": 1,
-         \"LatestRestorableDateTime\": 1,
-         \"PointInTimeRecoveryStatus\": \"DISABLED\"
+       \"ContinuousBackupsStatus\": \"ENABLED\",
+        \"PointInTimeRecoveryDescription\": {
+            \"EarliestRestorableDateTime\": 1,
+            \"LatestRestorableDateTime\": 1,
+            \"PointInTimeRecoveryStatus\": \"DISABLED\"
         }
-     }
+   }
 }",
     {ok,#ddb2_continuous_backups_description{
-     continuous_backups_status = enabled,
-     point_in_time_recovery_description =
-     #ddb2_point_in_time_recovery_description{
-      earliest_restorable_date_time = 1,
-      latest_restorable_date_time = 1,
-      point_in_time_recovery_status = disabled}}}
+        continuous_backups_status = enabled,
+        point_in_time_recovery_description =
+            #ddb2_point_in_time_recovery_description{
+                earliest_restorable_date_time = 1,
+                latest_restorable_date_time = 1,
+                point_in_time_recovery_status = disabled}
+    }}
    })
   ],
 
@@ -2940,20 +2935,20 @@ list_backups_input_tests(_) ->
    })
   ],
  Response = "
-    {
-   \"BackupSummaries\": [
-      {
-         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
-         \"BackupCreationDateTime\": 1522926603.688,
-         \"BackupName\": \"Forum_backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"AVAILABLE\",
-         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
-         \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
-         \"TableName\": \"Forum\"
-      }
-   ],
-   \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b66bcb\"
+{
+    \"BackupSummaries\": [
+        {
+            \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+            \"BackupCreationDateTime\": 1522926603.688,
+            \"BackupName\": \"Forum_backup\",
+            \"BackupSizeBytes\": 1,
+            \"BackupStatus\": \"AVAILABLE\",
+            \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+            \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
+            \"TableName\": \"Forum\"
+        }
+    ],
+    \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b66bcb\"
 }",
  input_tests(Response, Tests).
 
@@ -2961,30 +2956,32 @@ list_backups_output_tests(_) ->
  Tests =
   [?_ddb_test(
    {"ListBackups example response", "
-    {
-   \"BackupSummaries\": [
-      {
-         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
-         \"BackupCreationDateTime\": 1522926603.688,
-         \"BackupName\": \"Forum_backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"AVAILABLE\",
-         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
-         \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
-         \"TableName\": \"Forum\"
-      }
-   ],
-   \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b66bcb\"
+{
+    \"BackupSummaries\": [
+        {
+            \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+            \"BackupCreationDateTime\": 1522926603.688,
+            \"BackupName\": \"Forum_backup\",
+            \"BackupSizeBytes\": 1,
+            \"BackupStatus\": \"AVAILABLE\",
+            \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+            \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
+            \"TableName\": \"Forum\"
+        }
+    ],
+    \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b66bcb\"
 }",
-    {ok,[#ddb2_backup_summary{
-     backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
-     backup_creation_date_time = 1522926603.688,
-     backup_name = <<"Forum_backup">>,
-     backup_size_bytes = 1,
-     backup_status = <<"AVAILABLE">>,
-     table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
-     table_id = <<"64d52641-ca33-4d44-8620-c8eccf22ef3d">>,
-     table_name = <<"Forum">>}]}
+    {ok,
+         [#ddb2_backup_summary{
+             backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+             backup_creation_date_time = 1522926603.688,
+             backup_name = <<"Forum_backup">>,
+             backup_size_bytes = 1,
+             backup_status = available,
+             table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
+             table_id = <<"64d52641-ca33-4d44-8620-c8eccf22ef3d">>,
+             table_name = <<"Forum">>
+         }]}
    })
   ],
 
@@ -3876,53 +3873,55 @@ restore_table_from_backup_output_tests(_) ->
     }
 }",
     {ok, #ddb2_table_description
-    {attribute_definitions = [
-     {<<"ForumName">>, s},
-     {<<"LastPostDateTime">>, s},
-     {<<"Subject">>, s}
-    ],
-     creation_date_time = 1363728080.07,
-     item_count = 0,
-     key_schema = {<<"ForumName">>, <<"Subject">>},
-     local_secondary_indexes =
-     [#ddb2_local_secondary_index_description{
-      index_name = <<"LastPostIndex">>,
-      index_size_bytes = 0,
-      item_count = 0,
-      key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
-      projection = keys_only}],
-     global_secondary_indexes =
-     [#ddb2_global_secondary_index_description{
-      index_name = <<"SubjectIndex">>,
-      index_size_bytes = 2048,
-      index_status = creating,
-      item_count = 47,
-      key_schema = {<<"Subject">>, <<"LastPostDateTime">>},
-      projection = keys_only,
-      provisioned_throughput = #ddb2_provisioned_throughput_description{
-       last_decrease_date_time = 0,
-       last_increase_date_time = 1,
-       number_of_decreases_today = 2,
-       read_capacity_units = 3,
-       write_capacity_units = 4}
-     }],
-     provisioned_throughput =
-     #ddb2_provisioned_throughput_description{
-      last_decrease_date_time = undefined,
-      last_increase_date_time = undefined,
-      number_of_decreases_today = 0,
-      read_capacity_units = 5,
-      write_capacity_units = 5},
-     restore_summary =
-     #ddb2_restore_summary{
-      restore_date_time = 1363728080.07,
-      restore_in_progress = false,
-      source_backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
-      source_table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>
-     },
-     table_name = <<"Thread">>,
-     table_size_bytes = 0,
-     table_status = creating}}})
+        {attribute_definitions = [
+            {<<"ForumName">>, s},
+            {<<"LastPostDateTime">>, s},
+            {<<"Subject">>, s}
+        ],
+         creation_date_time = 1363728080.07,
+         item_count = 0,
+         key_schema = {<<"ForumName">>, <<"Subject">>},
+         local_secondary_indexes =
+             [#ddb2_local_secondary_index_description{
+                 index_name = <<"LastPostIndex">>,
+                 index_size_bytes = 0,
+                 item_count = 0,
+                 key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
+                 projection = keys_only}],
+         global_secondary_indexes =
+             [#ddb2_global_secondary_index_description{
+                 index_name = <<"SubjectIndex">>,
+                 index_size_bytes = 2048,
+                 index_status = creating,
+                 item_count = 47,
+                 key_schema = {<<"Subject">>, <<"LastPostDateTime">>},
+                 projection = keys_only,
+                 provisioned_throughput =
+                     #ddb2_provisioned_throughput_description{
+                      last_decrease_date_time = 0,
+                      last_increase_date_time = 1,
+                      number_of_decreases_today = 2,
+                      read_capacity_units = 3,
+                      write_capacity_units = 4}
+             }],
+         provisioned_throughput =
+             #ddb2_provisioned_throughput_description{
+              last_decrease_date_time = undefined,
+              last_increase_date_time = undefined,
+              number_of_decreases_today = 0,
+              read_capacity_units = 5,
+              write_capacity_units = 5},
+         restore_summary =
+             #ddb2_restore_summary{
+              restore_date_time = 1363728080.07,
+              restore_in_progress = false,
+              source_backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+              source_table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>
+             },
+         table_name = <<"Thread">>,
+         table_size_bytes = 0,
+         table_status = creating}
+    }})
   ],
 
  output_tests(?_f(erlcloud_ddb2:restore_table_from_backup(<<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,<<"Thread">>)), Tests).
@@ -4132,53 +4131,53 @@ restore_table_to_point_in_time_output_tests(_) ->
     }
 }",
     {ok, #ddb2_table_description
-    {attribute_definitions = [
-     {<<"ForumName">>, s},
-     {<<"LastPostDateTime">>, s},
-     {<<"Subject">>, s}
-     ],
-     creation_date_time = 1363728080.07,
-     item_count = 0,
-     key_schema = {<<"ForumName">>, <<"Subject">>},
-     local_secondary_indexes =
-     [#ddb2_local_secondary_index_description{
-      index_name = <<"LastPostIndex">>,
-      index_size_bytes = 0,
-      item_count = 0,
-      key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
-      projection = keys_only}],
-     global_secondary_indexes =
-     [#ddb2_global_secondary_index_description{
-      index_name = <<"SubjectIndex">>,
-      index_size_bytes = 2048,
-      index_status = creating,
-      item_count = 47,
-      key_schema = {<<"Subject">>, <<"LastPostDateTime">>},
-      projection = keys_only,
-      provisioned_throughput = #ddb2_provisioned_throughput_description{
-       last_decrease_date_time = 0,
-       last_increase_date_time = 1,
-       number_of_decreases_today = 2,
-       read_capacity_units = 3,
-       write_capacity_units = 4}
-     }],
-     provisioned_throughput =
-     #ddb2_provisioned_throughput_description{
-      last_decrease_date_time = undefined,
-      last_increase_date_time = undefined,
-      number_of_decreases_today = 0,
-      read_capacity_units = 5,
-      write_capacity_units = 5},
-     restore_summary =
-     #ddb2_restore_summary{
-      restore_date_time = 1363728080.07,
-      restore_in_progress = false,
-      source_backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
-      source_table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>
-     },
-     table_name = <<"Thread">>,
-     table_size_bytes = 0,
-     table_status = creating}}})
+        {attribute_definitions = [
+             {<<"ForumName">>, s},
+             {<<"LastPostDateTime">>, s},
+             {<<"Subject">>, s}
+         ],
+        creation_date_time = 1363728080.07,
+        item_count = 0,
+        key_schema = {<<"ForumName">>, <<"Subject">>},
+        local_secondary_indexes =
+            [#ddb2_local_secondary_index_description{
+                index_name = <<"LastPostIndex">>,
+                index_size_bytes = 0,
+                item_count = 0,
+                key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
+                projection = keys_only}],
+        global_secondary_indexes =
+            [#ddb2_global_secondary_index_description{
+                index_name = <<"SubjectIndex">>,
+                index_size_bytes = 2048,
+                index_status = creating,
+                item_count = 47,
+                key_schema = {<<"Subject">>, <<"LastPostDateTime">>},
+                projection = keys_only,
+                provisioned_throughput = #ddb2_provisioned_throughput_description{
+                 last_decrease_date_time = 0,
+                 last_increase_date_time = 1,
+                 number_of_decreases_today = 2,
+                 read_capacity_units = 3,
+                 write_capacity_units = 4}
+            }],
+        provisioned_throughput =
+            #ddb2_provisioned_throughput_description{
+             last_decrease_date_time = undefined,
+             last_increase_date_time = undefined,
+             number_of_decreases_today = 0,
+             read_capacity_units = 5,
+             write_capacity_units = 5},
+        restore_summary =
+            #ddb2_restore_summary{
+             restore_date_time = 1363728080.07,
+             restore_in_progress = false,
+             source_backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+             source_table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>
+            },
+        table_name = <<"Thread">>,
+        table_size_bytes = 0,
+        table_status = creating}}})
   ],
 
  output_tests(?_f(erlcloud_ddb2:restore_table_to_point_in_time(<<"Thread">>, <<"ThreadTo">>, [{restore_date_time, 1522926603.688}, {use_latest_restorable_time, false}])), Tests).
@@ -4614,6 +4613,35 @@ tag_resource_output_tests(_) ->
                                                 [{<<"example_key1">>, <<"example_value1">>},
                                                  {<<"example_key2">>, <<"example_value2">>}])),
                      Tests).
+%% UntagResource test based on the API:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UntagResource.html
+untag_resource_input_tests(_) ->
+    Tests =
+     [?_ddb_test(
+      {"ListTagsOfResource example request",
+       ?_f(erlcloud_ddb2:untag_resource(<<"arn:aws:dynamodb:us-east-1:111122223333:table/Forum">>,
+        [<<"example_key1">>, <<"example_key2">>])), "
+   {
+       \"ResourceArn\": \"arn:aws:dynamodb:us-east-1:111122223333:table/Forum\",
+       \"TagKeys\": [
+           \"example_key1\",
+           \"example_key2\"
+       ]
+   }"
+      })
+     ],
+    Response = "",
+    input_tests(Response, Tests).
+
+untag_resource_output_tests(_) ->
+    Tests =
+     [?_ddb_test(
+      {"ListTagsOfResource example response", "",
+       ok})
+     ],
+    output_tests(?_f(erlcloud_ddb2:untag_resource(<<"arn:aws:dynamodb:us-east-1:111122223333:table/Forum">>,
+     [<<"example_key1">>, <<"example_key2">>])),
+     Tests).
 
 %% UpdateContinuousBackups test based on the API examples:
 %% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateContinuousBackups.html
@@ -4631,71 +4659,41 @@ update_continuous_backups_input_tests(_) ->
    })
   ],
  Response = "{
-   \"ContinuousBackupsDescription\": {
-      \"ContinuousBackupsStatus\": \"ENABLED\",
-      \"PointInTimeRecoveryDescription\": {
-         \"EarliestRestorableDateTime\": 1,
-         \"LatestRestorableDateTime\": 1,
-         \"PointInTimeRecoveryStatus\": \"DISABLED\"
-        }
-     }
-   }",
+    \"ContinuousBackupsDescription\": {
+        \"ContinuousBackupsStatus\": \"ENABLED\",
+        \"PointInTimeRecoveryDescription\": {
+           \"EarliestRestorableDateTime\": 1,
+           \"LatestRestorableDateTime\": 1,
+           \"PointInTimeRecoveryStatus\": \"DISABLED\"
+          }
+      }
+}",
  input_tests(Response, Tests).
 
 update_continuous_backups_output_tests(_) ->
  Tests =
   [?_ddb_test(
    {"UpdateContinuousBackups example response", "{
-   \"ContinuousBackupsDescription\": {
-      \"ContinuousBackupsStatus\": \"ENABLED\",
-      \"PointInTimeRecoveryDescription\": {
-         \"EarliestRestorableDateTime\": 1,
-         \"LatestRestorableDateTime\": 1,
-         \"PointInTimeRecoveryStatus\": \"DISABLED\"
-        }
-     }
-   }",
+    \"ContinuousBackupsDescription\": {
+        \"ContinuousBackupsStatus\": \"ENABLED\",
+        \"PointInTimeRecoveryDescription\": {
+           \"EarliestRestorableDateTime\": 1,
+           \"LatestRestorableDateTime\": 1,
+           \"PointInTimeRecoveryStatus\": \"DISABLED\"
+          }
+      }
+}",
     {ok,#ddb2_continuous_backups_description{
-     continuous_backups_status = enabled,
-     point_in_time_recovery_description =
-     #ddb2_point_in_time_recovery_description{
-      earliest_restorable_date_time = 1,
-      latest_restorable_date_time = 1,
-      point_in_time_recovery_status = disabled}}}
-   })
+        continuous_backups_status = enabled,
+        point_in_time_recovery_description =
+            #ddb2_point_in_time_recovery_description{
+                earliest_restorable_date_time = 1,
+                latest_restorable_date_time = 1,
+                point_in_time_recovery_status = disabled}}}
+      })
   ],
 
  output_tests(?_f(erlcloud_ddb2:update_continuous_backups(<<"Thread">>,true)), Tests).
-
-%% UntagResource test based on the API:
-%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UntagResource.html
-untag_resource_input_tests(_) ->
-    Tests =
-        [?_ddb_test(
-            {"ListTagsOfResource example request",
-             ?_f(erlcloud_ddb2:untag_resource(<<"arn:aws:dynamodb:us-east-1:111122223333:table/Forum">>,
-                                              [<<"example_key1">>, <<"example_key2">>])), "
-{
-    \"ResourceArn\": \"arn:aws:dynamodb:us-east-1:111122223333:table/Forum\",
-    \"TagKeys\": [
-        \"example_key1\",
-        \"example_key2\"
-    ]
-}"
-            })
-        ],
-    Response = "",
-    input_tests(Response, Tests).
-
-untag_resource_output_tests(_) ->
-    Tests = 
-        [?_ddb_test(
-            {"ListTagsOfResource example response", "",
-             ok})
-        ],
-    output_tests(?_f(erlcloud_ddb2:untag_resource(<<"arn:aws:dynamodb:us-east-1:111122223333:table/Forum">>,
-                                                  [<<"example_key1">>, <<"example_key2">>])),
-                     Tests).
 
 %% UpdateItem test based on the API examples:
 %% http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -33,14 +33,22 @@ operation_test_() ->
       fun batch_get_item_output_tests/1,
       fun batch_write_item_input_tests/1,
       fun batch_write_item_output_tests/1,
+      fun create_backup_input_tests/1,
+      fun create_backup_output_tests/1,
       fun create_global_table_input_tests/1,
       fun create_global_table_output_tests/1,
       fun create_table_input_tests/1,
       fun create_table_output_tests/1,
+      fun delete_backup_input_tests/1,
+      fun delete_backup_output_tests/1,
       fun delete_item_input_tests/1,
       fun delete_item_output_tests/1,
       fun delete_table_input_tests/1,
       fun delete_table_output_tests/1,
+      fun describe_backup_input_tests/1,
+      fun describe_backup_output_tests/1,
+      fun describe_continuous_backups_input_tests/1,
+      fun describe_continuous_backups_output_tests/1,
       fun describe_limits_input_tests/1,
       fun describe_limits_output_tests/1,
       fun describe_global_table_input_tests/1,
@@ -52,6 +60,8 @@ operation_test_() ->
       fun get_item_input_tests/1,
       fun get_item_output_tests/1,
       fun get_item_output_typed_tests/1,
+      fun list_backups_input_tests/1,
+      fun list_backups_output_tests/1,
       fun list_global_tables_input_tests/1,
       fun list_global_tables_output_tests/1,
       fun list_tables_input_tests/1,
@@ -60,6 +70,8 @@ operation_test_() ->
       fun put_item_output_tests/1,
       fun q_input_tests/1,
       fun q_output_tests/1,
+      fun restore_table_from_backup_input_tests/1,
+      fun restore_table_from_backup_output_tests/1,
       fun scan_input_tests/1,
       fun scan_output_tests/1,
       fun update_item_input_tests/1,
@@ -69,19 +81,7 @@ operation_test_() ->
       fun update_table_input_tests/1,
       fun update_table_output_tests/1,
       fun update_time_to_live_input_tests/1,
-      fun update_time_to_live_output_tests/1,
-      fun list_backups_input_tests/1,
-      fun list_backups_output_tests/1,
-      fun create_backup_input_tests/1,
-      fun create_backup_output_tests/1,
-      fun delete_backup_input_tests/1,
-      fun delete_backup_output_tests/1,
-      fun describe_backup_input_tests/1,
-      fun describe_backup_output_tests/1,
-      fun describe_continuous_backups_input_tests/1,
-      fun describe_continuous_backups_output_tests/1,
-      fun restore_table_from_backup_input_tests/1,
-      fun restore_table_from_backup_output_tests/1
+      fun update_time_to_live_output_tests/1
      ]}.
 
 start() ->
@@ -854,6 +854,55 @@ batch_write_item_output_tests(_) ->
     
     output_tests(?_f(erlcloud_ddb2:batch_write_item([], [{out, record}])), Tests).
 
+%% CreateBackup test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateBackup.html
+create_backup_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"CreateBackup example request",
+    ?_f(erlcloud_ddb2:create_backup(<<"Forum_Backup">>,<<"Forum">>)), "
+    {
+        \"BackupName\": \"Forum_Backup\",
+        \"TableName\": \"Forum\"
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"BackupDetails\": {
+      \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+      \"BackupCreationDateTime\": 1523269031.475,
+      \"BackupName\": \"Forum_Backup\",
+      \"BackupSizeBytes\": 6,
+      \"BackupStatus\": \"CREATING\"
+      }
+   }",
+ input_tests(Response, Tests).
+
+create_backup_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"CreateBackup example response", "
+    {
+   \"BackupDetails\": {
+      \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+      \"BackupCreationDateTime\": 1523269031.475,
+      \"BackupName\": \"Forum_Backup\",
+      \"BackupSizeBytes\": 6,
+      \"BackupStatus\": \"CREATING\"
+      }
+}",
+    {ok,#ddb2_backup_details{
+     backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+     backup_creation_date_time = 1523269031.475,
+     backup_name = <<"Forum_Backup">>,
+     backup_size_Bytes = 6,
+     backup_status = <<"CREATING">>}}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:create_backup(<<"Forum_Backup">>,<<"Forum">>)), Tests).
+
 %% CreateGlobalTable input test:
 create_global_table_input_tests(_) ->
     Tests =
@@ -1226,6 +1275,231 @@ create_table_input_tests(_) ->
     }
 }",
     input_tests(Response, Tests).
+
+%% DeleteBackup test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteBackup.html
+delete_backup_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DeleteBackup example request",
+    ?_f(erlcloud_ddb2:delete_backup(<<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>)), "
+    {
+        \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\"
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"BackupDescription\": {
+      \"BackupDetails\": {
+         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+         \"BackupCreationDateTime\": 1523269031.475,
+         \"BackupName\": \"Forum_Backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"DELETED\"
+      },
+      \"SourceTableDetails\": {
+         \"ItemCount\": 0,
+         \"KeySchema\": [
+            {
+               \"AttributeName\": \"id\",
+               \"KeyType\": \"HASH\"
+            }
+         ],
+         \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+         },
+         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+         \"TableCreationDateTime\": 1523269031.475,
+         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+         \"TableName\": \"Forum\",
+         \"TableSizeBytes\": 1
+      },
+      \"SourceTableFeatureDetails\": {
+         \"GlobalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr\",
+                     \"KeyType\": \"HASH\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr2\" ],
+                  \"ProjectionType\": \"ALL\"
+               },
+               \"ProvisionedThroughput\": {
+                  \"ReadCapacityUnits\": 5,
+                  \"WriteCapacityUnits\": 5
+               }
+            }
+         ],
+         \"LocalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx2\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr3\",
+                     \"KeyType\": \"RANGE\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr4\" ],
+                  \"ProjectionType\": \"KEYS_ONLY\"
+               }
+            }
+         ],
+         \"SSEDescription\": {
+            \"Status\": \"DISABLED\"
+         },
+         \"StreamDescription\": {
+            \"StreamEnabled\": true,
+            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+         },
+         \"TimeToLiveDescription\": {
+            \"AttributeName\": \"none\",
+           \"TimeToLiveStatus\": \"DISABLED\"
+         }
+      }
+   }
+}",
+ input_tests(Response, Tests).
+
+delete_backup_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DeleteBackup example response", "
+    {
+    \"BackupDescription\": {
+      \"BackupDetails\": {
+         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+         \"BackupCreationDateTime\": 1523269031.475,
+         \"BackupName\": \"Forum_Backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"DELETED\"
+      },
+      \"SourceTableDetails\": {
+         \"ItemCount\": 0,
+         \"KeySchema\": [
+            {
+               \"AttributeName\": \"id\",
+               \"KeyType\": \"HASH\"
+            }
+         ],
+         \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+         },
+         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+         \"TableCreationDateTime\": 1523269031.475,
+         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+         \"TableName\": \"Forum\",
+         \"TableSizeBytes\": 1
+      },
+      \"SourceTableFeatureDetails\": {
+         \"GlobalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr\",
+                     \"KeyType\": \"HASH\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr2\" ],
+                  \"ProjectionType\": \"ALL\"
+               },
+               \"ProvisionedThroughput\": {
+                  \"ReadCapacityUnits\": 5,
+                  \"WriteCapacityUnits\": 5
+               }
+            }
+         ],
+         \"LocalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx2\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr3\",
+                     \"KeyType\": \"RANGE\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr4\" ],
+                  \"ProjectionType\": \"KEYS_ONLY\"
+               }
+            }
+         ],
+         \"SSEDescription\": {
+            \"Status\": \"DISABLED\"
+         },
+         \"StreamDescription\": {
+            \"StreamEnabled\": true,
+            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+         },
+         \"TimeToLiveDescription\": {
+            \"AttributeName\": \"none\",
+           \"TimeToLiveStatus\": \"DISABLED\"
+         }
+      }
+   }
+}",
+    {ok,#ddb2_delete_backup_record{
+     dackup_details =
+     #ddb2_backup_details{
+      backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+      backup_creation_date_time = 1523269031.475,
+      backup_name = <<"Forum_Backup">>,
+      backup_size_Bytes = 1,
+      backup_status = <<"DELETED">>},
+     source_table_details =
+     #ddb2_source_table_details{
+      item_count = 0,
+      key_schema = <<"id">>,
+      provisioned_throughput =
+      #ddb2_provisioned_throughput{
+       read_capacity_units = 5,
+       write_capacity_units = 5},
+      table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
+      table_creation_date_time = 1523269031.475,
+      table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
+      table_name = <<"Forum">>,
+      table_size_bytes = 1},
+     source_table_feature_details =
+     #ddb2_source_table_feature_details{
+      global_secondary_indexes =
+      [
+       #ddb2_global_secondary_index_info{
+        index_name = <<"Idx">>,
+        key_schema = <<"Atr">>,
+        projection = all,
+        provisioned_throughput =
+        #ddb2_provisioned_throughput{
+         read_capacity_units = 5,
+         write_capacity_units = 5
+        }}
+      ],
+      local_secondary_indexes =
+      [
+       #ddb2_local_secondary_index_info{
+        index_name = <<"Idx2">>,
+        key_schema = <<"Atr3">>,
+        projection = keys_only
+       }],
+      sse_description = {status,disabled},
+      stream_description = {true,new_and_old_images},
+      time_to_live_description =
+      #ddb2_time_to_live_description{
+       attribute_name = <<"none">>,
+       time_to_live_status = disabled}}
+    }}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:delete_backup(<<"arn:aws:dynamodb:">>)), Tests).
 
 create_table_output_tests(_) ->
     Tests = 
@@ -1751,6 +2025,282 @@ delete_table_output_tests(_) ->
         ],
     
     output_tests(?_f(erlcloud_ddb2:delete_table(<<"name">>)), Tests).
+
+%% DescribeBackup test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContinuousBackups.html
+describe_backup_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DescribeBackup example request",
+    ?_f(erlcloud_ddb2:describe_backup(<<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>)), "
+    {
+        \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\"
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"BackupDescription\": {
+      \"BackupDetails\": {
+         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+         \"BackupCreationDateTime\": 1523269031.475,
+         \"BackupName\": \"Forum_Backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"DELETED\"
+      },
+      \"SourceTableDetails\": {
+         \"ItemCount\": 0,
+         \"KeySchema\": [
+            {
+               \"AttributeName\": \"id\",
+               \"KeyType\": \"HASH\"
+            }
+         ],
+         \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+         },
+         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+         \"TableCreationDateTime\": 1523269031.475,
+         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+         \"TableName\": \"Forum\",
+         \"TableSizeBytes\": 1
+      },
+      \"SourceTableFeatureDetails\": {
+         \"GlobalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr\",
+                     \"KeyType\": \"HASH\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr2\" ],
+                  \"ProjectionType\": \"ALL\"
+               },
+               \"ProvisionedThroughput\": {
+                  \"ReadCapacityUnits\": 5,
+                  \"WriteCapacityUnits\": 5
+               }
+            }
+         ],
+         \"LocalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx2\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr3\",
+                     \"KeyType\": \"RANGE\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr4\" ],
+                  \"ProjectionType\": \"KEYS_ONLY\"
+               }
+            }
+         ],
+         \"SSEDescription\": {
+            \"Status\": \"DISABLED\"
+         },
+         \"StreamDescription\": {
+            \"StreamEnabled\": true,
+            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+         },
+         \"TimeToLiveDescription\": {
+            \"AttributeName\": \"none\",
+           \"TimeToLiveStatus\": \"DISABLED\"
+         }
+      }
+   }
+}",
+ input_tests(Response, Tests).
+
+describe_backup_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DescribeBackup example response", "
+   {
+   \"BackupDescription\": {
+      \"BackupDetails\": {
+         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+         \"BackupCreationDateTime\": 1523269031.475,
+         \"BackupName\": \"Forum_Backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"DELETED\"
+      },
+      \"SourceTableDetails\": {
+         \"ItemCount\": 0,
+         \"KeySchema\": [
+            {
+               \"AttributeName\": \"id\",
+               \"KeyType\": \"HASH\"
+            }
+         ],
+         \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+         },
+         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+         \"TableCreationDateTime\": 1523269031.475,
+         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
+         \"TableName\": \"Forum\",
+         \"TableSizeBytes\": 1
+      },
+      \"SourceTableFeatureDetails\": {
+         \"GlobalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr\",
+                     \"KeyType\": \"HASH\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr2\" ],
+                  \"ProjectionType\": \"ALL\"
+               },
+               \"ProvisionedThroughput\": {
+                  \"ReadCapacityUnits\": 5,
+                  \"WriteCapacityUnits\": 5
+               }
+            }
+         ],
+         \"LocalSecondaryIndexes\": [
+            {
+               \"IndexName\": \"Idx2\",
+               \"KeySchema\": [
+                  {
+                     \"AttributeName\": \"Atr3\",
+                     \"KeyType\": \"RANGE\"
+                  }
+               ],
+               \"Projection\": {
+                  \"NonKeyAttributes\": [ \"Atr4\" ],
+                  \"ProjectionType\": \"KEYS_ONLY\"
+               }
+            }
+         ],
+         \"SSEDescription\": {
+            \"Status\": \"DISABLED\"
+         },
+         \"StreamDescription\": {
+            \"StreamEnabled\": true,
+            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
+         },
+         \"TimeToLiveDescription\": {
+            \"AttributeName\": \"none\",
+           \"TimeToLiveStatus\": \"DISABLED\"
+         }
+      }
+   }
+}",
+    {ok,#ddb2_delete_backup_record{
+     dackup_details =
+     #ddb2_backup_details{
+      backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+      backup_creation_date_time = 1523269031.475,
+      backup_name = <<"Forum_Backup">>,
+      backup_size_Bytes = 1,
+      backup_status = <<"DELETED">>},
+     source_table_details =
+     #ddb2_source_table_details{
+      item_count = 0,
+      key_schema = <<"id">>,
+      provisioned_throughput =
+      #ddb2_provisioned_throughput{
+       read_capacity_units = 5,
+       write_capacity_units = 5},
+      table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
+      table_creation_date_time = 1523269031.475,
+      table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
+      table_name = <<"Forum">>,
+      table_size_bytes = 1},
+     source_table_feature_details =
+     #ddb2_source_table_feature_details{
+      global_secondary_indexes =
+      [
+       #ddb2_global_secondary_index_info{
+        index_name = <<"Idx">>,
+        key_schema = <<"Atr">>,
+        projection = all,
+        provisioned_throughput =
+        #ddb2_provisioned_throughput{
+         read_capacity_units = 5,
+         write_capacity_units = 5
+        }}
+      ],
+      local_secondary_indexes =
+      [
+       #ddb2_local_secondary_index_info{
+        index_name = <<"Idx2">>,
+        key_schema = <<"Atr3">>,
+        projection = keys_only
+       }],
+      sse_description = {status,disabled},
+      stream_description = {true,new_and_old_images},
+      time_to_live_description =
+      #ddb2_time_to_live_description{
+       attribute_name = <<"none">>,
+       time_to_live_status = disabled}}
+    }}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:describe_backup(<<"BackupArn">>)), Tests).
+
+%% DescribeContinuousBackups test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContinuousBackups.html
+describe_continuous_backups_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DescribeContinuousBackups example request",
+    ?_f(erlcloud_ddb2:describe_continuous_backups(<<"Forum">>)), "
+    {
+        \"TableName\": \"Forum\"
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"ContinuousBackupsDescription\": {
+      \"ContinuousBackupsStatus\": \"ENABLED\",
+      \"PointInTimeRecoveryDescription\": {
+         \"EarliestRestorableDateTime\": 1,
+         \"LatestRestorableDateTime\": 1,
+         \"PointInTimeRecoveryStatus\": \"DISABLED\"
+        }
+     }
+   }",
+ input_tests(Response, Tests).
+
+describe_continuous_backups_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"DescribeContinuousBackups example response", "
+   {
+   \"ContinuousBackupsDescription\": {
+      \"ContinuousBackupsStatus\": \"ENABLED\",
+      \"PointInTimeRecoveryDescription\": {
+         \"EarliestRestorableDateTime\": 1,
+         \"LatestRestorableDateTime\": 1,
+         \"PointInTimeRecoveryStatus\": \"DISABLED\"
+        }
+     }
+}",
+    {ok,#continuous_backups_description{
+     continuous_backups_status = <<"ENABLED">>,
+     point_in_time_recovery_description =
+     #point_in_time_recovery_description{
+      earliest_restorable_date_time = 1,
+      latest_restorable_date_time = 1,
+      point_in_time_recovery_status = <<"DISABLED">>}}}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:describe_continuous_backups(<<"Forum">>)), Tests).
 
 %% DescribeLimits test based on the API examples:
 %% http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeLimits.html
@@ -2358,6 +2908,73 @@ get_item_output_typed_tests(_) ->
     
     output_tests(?_f(erlcloud_ddb2:get_item(
                        <<"table">>, {<<"k">>, <<"v">>}, [{out, typed_record}])), Tests).
+
+%% ListBackups test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListBackups.html
+list_backups_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"ListBackups example request",
+    ?_f(erlcloud_ddb2:list_backups([{limit, 4},{exclusive_start_backup_arn, <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523516528459-dfd5667f">>},{table_name, <<"Forum">>},{time_range_lower_bound,1522926603.688},{time_range_upper_bound, 1523022454.098}])), "
+    {
+        \"Limit\": 4,
+        \"TableName\": \"Forum\",
+        \"ExclusiveStartBackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523516528459-dfd5667f\",
+        \"TimeRangeLowerBound\": 1522926603.688,
+        \"TimeRangeUpperBound\": 1523022454.098
+    }"
+   })
+  ],
+ Response = "
+    {
+   \"BackupSummaries\": [
+      {
+         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+         \"BackupCreationDateTime\": 1522926603.688,
+         \"BackupName\": \"Forum_backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"AVAILABLE\",
+         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+         \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
+         \"TableName\": \"Forum\"
+      }
+   ],
+   \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b66bcb\"
+}",
+ input_tests(Response, Tests).
+
+list_backups_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"ListBackups example response", "
+    {
+   \"BackupSummaries\": [
+      {
+         \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+         \"BackupCreationDateTime\": 1522926603.688,
+         \"BackupName\": \"Forum_backup\",
+         \"BackupSizeBytes\": 1,
+         \"BackupStatus\": \"AVAILABLE\",
+         \"TableArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum\",
+         \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
+         \"TableName\": \"Forum\"
+      }
+   ],
+   \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b66bcb\"
+}",
+    {ok,[#ddb2_backup_summaries{
+     backup_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,
+     backup_creation_date_time = 1522926603.688,
+     backup_name = <<"Forum_backup">>,
+     backup_size_bytes = 1,
+     backup_status = <<"AVAILABLE">>,
+     table_arn = <<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum">>,
+     table_id = <<"64d52641-ca33-4d44-8620-c8eccf22ef3d">>,
+     table_name = <<"Forum">>}]}
+   })
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:list_backups()), Tests).
 
 %% ListGlobalTables input test:
 list_global_tables_input_tests(_) ->
@@ -2990,6 +3607,240 @@ q_output_tests(_) ->
         ],
     
     output_tests(?_f(erlcloud_ddb2:q(<<"table">>, [{<<"k">>, <<"v">>, eq}], [{out, record}])), Tests).
+
+%% RestoreTableFromBackup test based on the API examples:
+%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableFromBackup.html
+restore_table_from_backup_input_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"RestoreTableFromBackup example request",
+    ?_f(erlcloud_ddb2:restore_table_from_backup(<<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,<<"Thread">>)), "
+    {
+        \"BackupArn\": \"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb\",
+        \"TargetTableName\": \"Thread\"
+    }"
+   })
+  ],
+ Response = "
+{
+    \"TableDescription\": {
+        \"AttributeDefinitions\": [
+            {
+                \"AttributeName\": \"ForumName\",
+                \"AttributeType\": \"S\"
+            },
+            {
+                \"AttributeName\": \"LastPostDateTime\",
+                \"AttributeType\": \"S\"
+            },
+            {
+                \"AttributeName\": \"Subject\",
+                \"AttributeType\": \"S\"
+            }
+        ],
+        \"CreationDateTime\": 1.36372808007E9,
+        \"GlobalSecondaryIndexes\": [
+            {
+                \"IndexName\": \"SubjectIndex\",
+                \"IndexSizeBytes\": 2048,
+                \"IndexStatus\": \"CREATING\",
+                \"ItemCount\": 47,
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"Subject\",
+                        \"KeyType\": \"HASH\"
+                    },
+                    {
+                        \"AttributeName\": \"LastPostDateTime\",
+                        \"KeyType\": \"RANGE\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"KEYS_ONLY\"
+                },
+                \"ProvisionedThroughput\": {
+                    \"LastDecreaseDateTime\": 0,
+                    \"LastIncreaseDateTime\": 1,
+                    \"NumberOfDecreasesToday\": 2,
+                    \"ReadCapacityUnits\": 3,
+                    \"WriteCapacityUnits\": 4
+                }
+            }
+        ],
+        \"ItemCount\": 0,
+        \"KeySchema\": [
+            {
+                \"AttributeName\": \"ForumName\",
+                \"KeyType\": \"HASH\"
+            },
+            {
+                \"AttributeName\": \"Subject\",
+                \"KeyType\": \"RANGE\"
+            }
+        ],
+        \"LocalSecondaryIndexes\": [
+            {
+                \"IndexName\": \"LastPostIndex\",
+                \"IndexSizeBytes\": 0,
+                \"ItemCount\": 0,
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"ForumName\",
+                        \"KeyType\": \"HASH\"
+                    },
+                    {
+                        \"AttributeName\": \"LastPostDateTime\",
+                        \"KeyType\": \"RANGE\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"KEYS_ONLY\"
+                }
+            }
+        ],
+        \"ProvisionedThroughput\": {
+            \"NumberOfDecreasesToday\": 0,
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+        },
+        \"TableName\": \"Thread\",
+        \"TableSizeBytes\": 0,
+        \"TableStatus\": \"CREATING\"
+    }
+}",
+ input_tests(Response, Tests).
+
+restore_table_from_backup_output_tests(_) ->
+ Tests =
+  [?_ddb_test(
+   {"RestoreTableFromBackup example response", "{
+    \"TableDescription\": {
+        \"AttributeDefinitions\": [
+            {
+                \"AttributeName\": \"ForumName\",
+                \"AttributeType\": \"S\"
+            },
+            {
+                \"AttributeName\": \"LastPostDateTime\",
+                \"AttributeType\": \"S\"
+            },
+            {
+                \"AttributeName\": \"Subject\",
+                \"AttributeType\": \"S\"
+            }
+        ],
+        \"CreationDateTime\": 1.36372808007E9,
+        \"GlobalSecondaryIndexes\": [
+            {
+                \"IndexName\": \"SubjectIndex\",
+                \"IndexSizeBytes\": 2048,
+                \"IndexStatus\": \"CREATING\",
+                \"ItemCount\": 47,
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"Subject\",
+                        \"KeyType\": \"HASH\"
+                    },
+                    {
+                        \"AttributeName\": \"LastPostDateTime\",
+                        \"KeyType\": \"RANGE\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"KEYS_ONLY\"
+                },
+                \"ProvisionedThroughput\": {
+                    \"LastDecreaseDateTime\": 0,
+                    \"LastIncreaseDateTime\": 1,
+                    \"NumberOfDecreasesToday\": 2,
+                    \"ReadCapacityUnits\": 3,
+                    \"WriteCapacityUnits\": 4
+                }
+            }
+        ],
+        \"ItemCount\": 0,
+        \"KeySchema\": [
+            {
+                \"AttributeName\": \"ForumName\",
+                \"KeyType\": \"HASH\"
+            },
+            {
+                \"AttributeName\": \"Subject\",
+                \"KeyType\": \"RANGE\"
+            }
+        ],
+        \"LocalSecondaryIndexes\": [
+            {
+                \"IndexName\": \"LastPostIndex\",
+                \"IndexSizeBytes\": 0,
+                \"ItemCount\": 0,
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"ForumName\",
+                        \"KeyType\": \"HASH\"
+                    },
+                    {
+                        \"AttributeName\": \"LastPostDateTime\",
+                        \"KeyType\": \"RANGE\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"KEYS_ONLY\"
+                }
+            }
+        ],
+        \"ProvisionedThroughput\": {
+            \"NumberOfDecreasesToday\": 0,
+            \"ReadCapacityUnits\": 5,
+            \"WriteCapacityUnits\": 5
+        },
+        \"TableName\": \"Thread\",
+        \"TableSizeBytes\": 0,
+        \"TableStatus\": \"CREATING\"
+    }
+}",
+    {ok, #ddb2_table_description
+    {attribute_definitions = [{<<"ForumName">>, s},
+     {<<"LastPostDateTime">>, s},
+     {<<"Subject">>, s}],
+     creation_date_time = 1363728080.07,
+     item_count = 0,
+     key_schema = {<<"ForumName">>, <<"Subject">>},
+     local_secondary_indexes =
+     [#ddb2_local_secondary_index_description{
+      index_name = <<"LastPostIndex">>,
+      index_size_bytes = 0,
+      item_count = 0,
+      key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
+      projection = keys_only}],
+     global_secondary_indexes =
+     [#ddb2_global_secondary_index_description{
+      index_name = <<"SubjectIndex">>,
+      index_size_bytes = 2048,
+      index_status = creating,
+      item_count = 47,
+      key_schema = {<<"Subject">>, <<"LastPostDateTime">>},
+      projection = keys_only,
+      provisioned_throughput = #ddb2_provisioned_throughput_description{
+       last_decrease_date_time = 0,
+       last_increase_date_time = 1,
+       number_of_decreases_today = 2,
+       read_capacity_units = 3,
+       write_capacity_units = 4}
+     }],
+     provisioned_throughput =
+     #ddb2_provisioned_throughput_description{
+      last_decrease_date_time = undefined,
+      last_increase_date_time = undefined,
+      number_of_decreases_today = 0,
+      read_capacity_units = 5,
+      write_capacity_units = 5},
+     table_name = <<"Thread">>,
+     table_size_bytes = 0,
+     table_status = creating}}})
+  ],
+
+ output_tests(?_f(erlcloud_ddb2:restore_table_from_backup(<<"arn:aws:dynamodb:us-east-1:387047610112:table/Forum/backup/01523517555423-69b67bcb">>,<<"Thread">>)), Tests).
 
 %% Scan test based on the API examples:
 %% http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html
@@ -4103,852 +4954,3 @@ update_time_to_live_output_tests(_) ->
                 enabled = true}}})],
     output_tests(?_f(erlcloud_ddb2:update_time_to_live(<<"SessionData">>, 
       [{attribute_name, <<"ExpirationTime">>}, {enabled, true}])), Tests).
-
-%% ListBackups test based on the API examples:
-%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListBackups.html
-list_backups_input_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"ListBackups example request",
-    ?_f(erlcloud_ddb2:list_backups([{limit, 4},{exclusive_start_backup_arn, <<"arn:aws:dynamodb:">>},{table_name, <<"Forum">>},{time_range_lower_bound,1522926603.688},{time_range_upper_bound, 1523022454.098}])), "
-    {
-        \"Limit\": 4,
-        \"TableName\": \"Forum\",
-        \"ExclusiveStartBackupArn\": \"arn:aws:dynamodb:\",
-        \"TimeRangeLowerBound\": 1522926603.688,
-        \"TimeRangeUpperBound\": 1523022454.098
-    }"
-   })
-  ],
- Response = "
-    {
-   \"BackupSummaries\": [
-      {
-         \"BackupArn\": \"arn:aws:dynamodb:\",
-         \"BackupCreationDateTime\": 1522926603.688,
-         \"BackupName\": \"Forum_backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"AVAILABLE\",
-         \"TableArn\": \"arn:aws:dynamodb:\",
-         \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
-         \"TableName\": \"Forum\"
-      }
-   ],
-   \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:\"
-}",
- input_tests(Response, Tests).
-
-list_backups_output_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"ListBackups example response", "
-    {
-   \"BackupSummaries\": [
-      {
-         \"BackupArn\": \"arn:aws:dynamodb:\",
-         \"BackupCreationDateTime\": 1522926603.688,
-         \"BackupName\": \"Forum_backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"AVAILABLE\",
-         \"TableArn\": \"arn:aws:dynamodb:\",
-         \"TableId\": \"64d52641-ca33-4d44-8620-c8eccf22ef3d\",
-         \"TableName\": \"Forum\"
-      }
-   ],
-   \"LastEvaluatedBackupArn\": \"arn:aws:dynamodb:\"
-}",
-    {ok,[#ddb2_backup_summaries{
-     backup_arn = <<"arn:aws:dynamodb:">>,
-     backup_creation_date_time = 1522926603.688,
-     backup_name = <<"Forum_backup">>,
-     backup_size_bytes = 1,
-     backup_status = <<"AVAILABLE">>,
-     table_arn = <<"arn:aws:dynamodb:">>,
-     table_id = <<"64d52641-ca33-4d44-8620-c8eccf22ef3d">>,
-     table_name = <<"Forum">>}]}
-   })
-  ],
-
- output_tests(?_f(erlcloud_ddb2:list_backups()), Tests).
-
-
-%% CreateBackup test based on the API examples:
-%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateBackup.html
-create_backup_input_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"CreateBackup example request",
-    ?_f(erlcloud_ddb2:create_backup(<<"Forum_Backup">>,<<"Forum">>)), "
-    {
-        \"BackupName\": \"Forum_Backup\",
-        \"TableName\": \"Forum\"
-    }"
-   })
-  ],
- Response = "
-    {
-   \"BackupDetails\": {
-      \"BackupArn\": \"arn:aws:dynamodb:\",
-      \"BackupCreationDateTime\": 1523269031.475,
-      \"BackupName\": \"Forum_Backup\",
-      \"BackupSizeBytes\": 6,
-      \"BackupStatus\": \"CREATING\"
-      }
-   }",
- input_tests(Response, Tests).
-
-create_backup_output_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"CreateBackup example response", "
-    {
-   \"BackupDetails\": {
-      \"BackupArn\": \"arn:aws:dynamodb:\",
-      \"BackupCreationDateTime\": 1523269031.475,
-      \"BackupName\": \"Forum_Backup\",
-      \"BackupSizeBytes\": 6,
-      \"BackupStatus\": \"CREATING\"
-      }
-}",
-    {ok,#ddb2_backup_details{
-     backup_arn = <<"arn:aws:dynamodb:">>,
-     backup_creation_date_time = 1523269031.475,
-     backup_name = <<"Forum_Backup">>,
-     backup_size_Bytes = 6,
-     backup_status = <<"CREATING">>}}
-   })
-  ],
-
- output_tests(?_f(erlcloud_ddb2:create_backup(<<"Forum_Backup">>,<<"Forum">>)), Tests).
-
-
-%% DeleteBackup test based on the API examples:
-%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteBackup.html
-delete_backup_input_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"DeleteBackup example request",
-    ?_f(erlcloud_ddb2:delete_backup(<<"arn:aws:dynamodb:">>)), "
-    {
-        \"BackupArn\": \"arn:aws:dynamodb:\"
-    }"
-   })
-  ],
- Response = "
-    {
-   \"BackupDescription\": {
-      \"BackupDetails\": {
-         \"BackupArn\": \"arn:aws:dynamodb:\",
-         \"BackupCreationDateTime\": 1523269031.475,
-         \"BackupName\": \"Forum_Backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"DELETED\"
-      },
-      \"SourceTableDetails\": {
-         \"ItemCount\": 0,
-         \"KeySchema\": [
-            {
-               \"AttributeName\": \"id\",
-               \"KeyType\": \"HASH\"
-            }
-         ],
-         \"ProvisionedThroughput\": {
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
-         },
-         \"TableArn\": \"arn:aws:dynamodb:\",
-         \"TableCreationDateTime\": 1523269031.475,
-         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
-         \"TableName\": \"Forum\",
-         \"TableSizeBytes\": 1
-      },
-      \"SourceTableFeatureDetails\": {
-         \"GlobalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr\",
-                     \"KeyType\": \"HASH\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr2\" ],
-                  \"ProjectionType\": \"ALL\"
-               },
-               \"ProvisionedThroughput\": {
-                  \"ReadCapacityUnits\": 5,
-                  \"WriteCapacityUnits\": 5
-               }
-            }
-         ],
-         \"LocalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx2\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr3\",
-                     \"KeyType\": \"RANGE\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr4\" ],
-                  \"ProjectionType\": \"KEYS_ONLY\"
-               }
-            }
-         ],
-         \"SSEDescription\": {
-            \"Status\": \"DISABLED\"
-         },
-         \"StreamDescription\": {
-            \"StreamEnabled\": true,
-            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
-         },
-         \"TimeToLiveDescription\": {
-            \"AttributeName\": \"none\",
-           \"TimeToLiveStatus\": \"DISABLED\"
-         }
-      }
-   }
-}",
- input_tests(Response, Tests).
-
-delete_backup_output_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"DeleteBackup example response", "
-    {
-    \"BackupDescription\": {
-      \"BackupDetails\": {
-         \"BackupArn\": \"arn:aws:dynamodb:\",
-         \"BackupCreationDateTime\": 1523269031.475,
-         \"BackupName\": \"Forum_Backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"DELETED\"
-      },
-      \"SourceTableDetails\": {
-         \"ItemCount\": 0,
-         \"KeySchema\": [
-            {
-               \"AttributeName\": \"id\",
-               \"KeyType\": \"HASH\"
-            }
-         ],
-         \"ProvisionedThroughput\": {
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
-         },
-         \"TableArn\": \"arn:aws:dynamodb:\",
-         \"TableCreationDateTime\": 1523269031.475,
-         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
-         \"TableName\": \"Forum\",
-         \"TableSizeBytes\": 1
-      },
-      \"SourceTableFeatureDetails\": {
-         \"GlobalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr\",
-                     \"KeyType\": \"HASH\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr2\" ],
-                  \"ProjectionType\": \"ALL\"
-               },
-               \"ProvisionedThroughput\": {
-                  \"ReadCapacityUnits\": 5,
-                  \"WriteCapacityUnits\": 5
-               }
-            }
-         ],
-         \"LocalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx2\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr3\",
-                     \"KeyType\": \"RANGE\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr4\" ],
-                  \"ProjectionType\": \"KEYS_ONLY\"
-               }
-            }
-         ],
-         \"SSEDescription\": {
-            \"Status\": \"DISABLED\"
-         },
-         \"StreamDescription\": {
-            \"StreamEnabled\": true,
-            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
-         },
-         \"TimeToLiveDescription\": {
-            \"AttributeName\": \"none\",
-           \"TimeToLiveStatus\": \"DISABLED\"
-         }
-      }
-   }
-}",
-    {ok,#ddb2_delete_backup_record{
-     dackup_details =
-         #ddb2_backup_details{
-          backup_arn = <<"arn:aws:dynamodb:">>,
-          backup_creation_date_time = 1523269031.475,
-          backup_name = <<"Forum_Backup">>,
-          backup_size_Bytes = 1,
-          backup_status = <<"DELETED">>},
-     source_table_details =
-          #ddb2_source_table_details{
-           item_count = 0,
-           key_schema = <<"id">>,
-           provisioned_throughput =
-            #ddb2_provisioned_throughput{
-             read_capacity_units = 5,
-             write_capacity_units = 5},
-           table_arn = <<"arn:aws:dynamodb:">>,
-           table_creation_date_time = 1523269031.475,
-           table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
-           table_name = <<"Forum">>,
-           table_size_bytes = 1},
-     source_table_feature_details =
-           #ddb2_source_table_feature_details{
-                global_secondary_indexes =
-                  [
-                    #ddb2_global_secondary_index_info{
-                     index_name = <<"Idx">>,
-                     key_schema = <<"Atr">>,
-                     projection = all,
-                     provisioned_throughput =
-                     #ddb2_provisioned_throughput{
-                      read_capacity_units = 5,
-                      write_capacity_units = 5
-                   }}
-                  ],
-               local_secondary_indexes =
-                  [
-                    #ddb2_local_secondary_index_info{
-                     index_name = <<"Idx2">>,
-                     key_schema = <<"Atr3">>,
-                     projection = keys_only
-                 }],
-              sse_description = {status,disabled},
-              stream_description = {true,new_and_old_images},
-              time_to_live_description = {ddb2_time_to_live_description,<<"none">>,
-                 disabled}}
-    }}
-   })
-  ],
-
- output_tests(?_f(erlcloud_ddb2:delete_backup(<<"arn:aws:dynamodb:">>)), Tests).
-
-%% DescribeBackup test based on the API examples:
-%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContinuousBackups.html
-describe_backup_input_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"DescribeBackup example request",
-    ?_f(erlcloud_ddb2:describe_backup(<<"BackupArn">>)), "
-    {
-        \"BackupArn\": \"BackupArn\"
-    }"
-   })
-  ],
- Response = "
-    {
-   \"BackupDescription\": {
-      \"BackupDetails\": {
-         \"BackupArn\": \"arn:aws:dynamodb:\",
-         \"BackupCreationDateTime\": 1523269031.475,
-         \"BackupName\": \"Forum_Backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"DELETED\"
-      },
-      \"SourceTableDetails\": {
-         \"ItemCount\": 0,
-         \"KeySchema\": [
-            {
-               \"AttributeName\": \"id\",
-               \"KeyType\": \"HASH\"
-            }
-         ],
-         \"ProvisionedThroughput\": {
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
-         },
-         \"TableArn\": \"arn:aws:dynamodb:\",
-         \"TableCreationDateTime\": 1523269031.475,
-         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
-         \"TableName\": \"Forum\",
-         \"TableSizeBytes\": 1
-      },
-      \"SourceTableFeatureDetails\": {
-         \"GlobalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr\",
-                     \"KeyType\": \"HASH\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr2\" ],
-                  \"ProjectionType\": \"ALL\"
-               },
-               \"ProvisionedThroughput\": {
-                  \"ReadCapacityUnits\": 5,
-                  \"WriteCapacityUnits\": 5
-               }
-            }
-         ],
-         \"LocalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx2\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr3\",
-                     \"KeyType\": \"RANGE\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr4\" ],
-                  \"ProjectionType\": \"KEYS_ONLY\"
-               }
-            }
-         ],
-         \"SSEDescription\": {
-            \"Status\": \"DISABLED\"
-         },
-         \"StreamDescription\": {
-            \"StreamEnabled\": true,
-            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
-         },
-         \"TimeToLiveDescription\": {
-            \"AttributeName\": \"none\",
-           \"TimeToLiveStatus\": \"DISABLED\"
-         }
-      }
-   }
-}",
- input_tests(Response, Tests).
-
-describe_backup_output_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"DescribeBackup example response", "
-   {
-   \"BackupDescription\": {
-      \"BackupDetails\": {
-         \"BackupArn\": \"arn:aws:dynamodb:\",
-         \"BackupCreationDateTime\": 1523269031.475,
-         \"BackupName\": \"Forum_Backup\",
-         \"BackupSizeBytes\": 1,
-         \"BackupStatus\": \"DELETED\"
-      },
-      \"SourceTableDetails\": {
-         \"ItemCount\": 0,
-         \"KeySchema\": [
-            {
-               \"AttributeName\": \"id\",
-               \"KeyType\": \"HASH\"
-            }
-         ],
-         \"ProvisionedThroughput\": {
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
-         },
-         \"TableArn\": \"arn:aws:dynamodb:\",
-         \"TableCreationDateTime\": 1523269031.475,
-         \"TableId\": \"284a7e42-42ed-4854-b9fd-9a5a4b972dc4\",
-         \"TableName\": \"Forum\",
-         \"TableSizeBytes\": 1
-      },
-      \"SourceTableFeatureDetails\": {
-         \"GlobalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr\",
-                     \"KeyType\": \"HASH\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr2\" ],
-                  \"ProjectionType\": \"ALL\"
-               },
-               \"ProvisionedThroughput\": {
-                  \"ReadCapacityUnits\": 5,
-                  \"WriteCapacityUnits\": 5
-               }
-            }
-         ],
-         \"LocalSecondaryIndexes\": [
-            {
-               \"IndexName\": \"Idx2\",
-               \"KeySchema\": [
-                  {
-                     \"AttributeName\": \"Atr3\",
-                     \"KeyType\": \"RANGE\"
-                  }
-               ],
-               \"Projection\": {
-                  \"NonKeyAttributes\": [ \"Atr4\" ],
-                  \"ProjectionType\": \"KEYS_ONLY\"
-               }
-            }
-         ],
-         \"SSEDescription\": {
-            \"Status\": \"DISABLED\"
-         },
-         \"StreamDescription\": {
-            \"StreamEnabled\": true,
-            \"StreamViewType\": \"NEW_AND_OLD_IMAGES\"
-         },
-         \"TimeToLiveDescription\": {
-            \"AttributeName\": \"none\",
-           \"TimeToLiveStatus\": \"DISABLED\"
-         }
-      }
-   }
-}",
-    {ok,#ddb2_delete_backup_record{
-     dackup_details =
-     #ddb2_backup_details{
-      backup_arn = <<"arn:aws:dynamodb:">>,
-      backup_creation_date_time = 1523269031.475,
-      backup_name = <<"Forum_Backup">>,
-      backup_size_Bytes = 1,
-      backup_status = <<"DELETED">>},
-     source_table_details =
-     #ddb2_source_table_details{
-      item_count = 0,
-      key_schema = <<"id">>,
-      provisioned_throughput =
-      #ddb2_provisioned_throughput{
-       read_capacity_units = 5,
-       write_capacity_units = 5},
-      table_arn = <<"arn:aws:dynamodb:">>,
-      table_creation_date_time = 1523269031.475,
-      table_id = <<"284a7e42-42ed-4854-b9fd-9a5a4b972dc4">>,
-      table_name = <<"Forum">>,
-      table_size_bytes = 1},
-     source_table_feature_details =
-     #ddb2_source_table_feature_details{
-      global_secondary_indexes =
-      [
-       #ddb2_global_secondary_index_info{
-        index_name = <<"Idx">>,
-        key_schema = <<"Atr">>,
-        projection = all,
-        provisioned_throughput =
-        #ddb2_provisioned_throughput{
-         read_capacity_units = 5,
-         write_capacity_units = 5
-        }}
-      ],
-      local_secondary_indexes =
-      [
-       #ddb2_local_secondary_index_info{
-        index_name = <<"Idx2">>,
-        key_schema = <<"Atr3">>,
-        projection = keys_only
-       }],
-      sse_description = {status,disabled},
-      stream_description = {true,new_and_old_images},
-      time_to_live_description = {ddb2_time_to_live_description,<<"none">>,
-       disabled}}
-    }}
-   })
-  ],
-
- output_tests(?_f(erlcloud_ddb2:describe_backup(<<"BackupArn">>)), Tests).
-
-%% DescribeContinuousBackups test based on the API examples:
-%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContinuousBackups.html
-describe_continuous_backups_input_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"DescribeContinuousBackups example request",
-    ?_f(erlcloud_ddb2:describe_continuous_backups(<<"Forum">>)), "
-    {
-        \"TableName\": \"Forum\"
-    }"
-   })
-  ],
- Response = "
-    {
-   \"ContinuousBackupsDescription\": {
-      \"ContinuousBackupsStatus\": \"ENABLED\",
-      \"PointInTimeRecoveryDescription\": {
-         \"EarliestRestorableDateTime\": 1,
-         \"LatestRestorableDateTime\": 1,
-         \"PointInTimeRecoveryStatus\": \"DISABLED\"
-        }
-     }
-   }",
- input_tests(Response, Tests).
-
-describe_continuous_backups_output_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"DescribeContinuousBackups example response", "
-   {
-   \"ContinuousBackupsDescription\": {
-      \"ContinuousBackupsStatus\": \"ENABLED\",
-      \"PointInTimeRecoveryDescription\": {
-         \"EarliestRestorableDateTime\": 1,
-         \"LatestRestorableDateTime\": 1,
-         \"PointInTimeRecoveryStatus\": \"DISABLED\"
-        }
-     }
-}",
-    {ok,#continuous_backups_description{
-     continuous_backups_status = <<"ENABLED">>,
-     point_in_time_recovery_description =
-          #point_in_time_recovery_description{
-            earliest_restorable_date_time = 1,
-            latest_restorable_date_time = 1,
-            point_in_time_recovery_status = <<"DISABLED">>}}}
-   })
-  ],
-
- output_tests(?_f(erlcloud_ddb2:describe_continuous_backups(<<"Forum">>)), Tests).
-
-%% RestoreTableFromBackup test based on the API examples:
-%% https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableFromBackup.html
-restore_table_from_backup_input_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"RestoreTableFromBackup example request",
-    ?_f(erlcloud_ddb2:restore_table_from_backup(<<"BackupArn">>,<<"Thread">>)), "
-    {
-        \"BackupArn\": \"BackupArn\",
-        \"TargetTableName\": \"Thread\"
-    }"
-   })
-  ],
- Response = "
-{
-    \"TableDescription\": {
-        \"AttributeDefinitions\": [
-            {
-                \"AttributeName\": \"ForumName\",
-                \"AttributeType\": \"S\"
-            },
-            {
-                \"AttributeName\": \"LastPostDateTime\",
-                \"AttributeType\": \"S\"
-            },
-            {
-                \"AttributeName\": \"Subject\",
-                \"AttributeType\": \"S\"
-            }
-        ],
-        \"CreationDateTime\": 1.36372808007E9,
-        \"GlobalSecondaryIndexes\": [
-            {
-                \"IndexName\": \"SubjectIndex\",
-                \"IndexSizeBytes\": 2048,
-                \"IndexStatus\": \"CREATING\",
-                \"ItemCount\": 47,
-                \"KeySchema\": [
-                    {
-                        \"AttributeName\": \"Subject\",
-                        \"KeyType\": \"HASH\"
-                    },
-                    {
-                        \"AttributeName\": \"LastPostDateTime\",
-                        \"KeyType\": \"RANGE\"
-                    }
-                ],
-                \"Projection\": {
-                    \"ProjectionType\": \"KEYS_ONLY\"
-                },
-                \"ProvisionedThroughput\": {
-                    \"LastDecreaseDateTime\": 0,
-                    \"LastIncreaseDateTime\": 1,
-                    \"NumberOfDecreasesToday\": 2,
-                    \"ReadCapacityUnits\": 3,
-                    \"WriteCapacityUnits\": 4
-                }
-            }
-        ],
-        \"ItemCount\": 0,
-        \"KeySchema\": [
-            {
-                \"AttributeName\": \"ForumName\",
-                \"KeyType\": \"HASH\"
-            },
-            {
-                \"AttributeName\": \"Subject\",
-                \"KeyType\": \"RANGE\"
-            }
-        ],
-        \"LocalSecondaryIndexes\": [
-            {
-                \"IndexName\": \"LastPostIndex\",
-                \"IndexSizeBytes\": 0,
-                \"ItemCount\": 0,
-                \"KeySchema\": [
-                    {
-                        \"AttributeName\": \"ForumName\",
-                        \"KeyType\": \"HASH\"
-                    },
-                    {
-                        \"AttributeName\": \"LastPostDateTime\",
-                        \"KeyType\": \"RANGE\"
-                    }
-                ],
-                \"Projection\": {
-                    \"ProjectionType\": \"KEYS_ONLY\"
-                }
-            }
-        ],
-        \"ProvisionedThroughput\": {
-            \"NumberOfDecreasesToday\": 0,
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
-        },
-        \"TableName\": \"Thread\",
-        \"TableSizeBytes\": 0,
-        \"TableStatus\": \"CREATING\"
-    }
-}",
- input_tests(Response, Tests).
-
-restore_table_from_backup_output_tests(_) ->
- Tests =
-  [?_ddb_test(
-   {"RestoreTableFromBackup example response", "{
-    \"TableDescription\": {
-        \"AttributeDefinitions\": [
-            {
-                \"AttributeName\": \"ForumName\",
-                \"AttributeType\": \"S\"
-            },
-            {
-                \"AttributeName\": \"LastPostDateTime\",
-                \"AttributeType\": \"S\"
-            },
-            {
-                \"AttributeName\": \"Subject\",
-                \"AttributeType\": \"S\"
-            }
-        ],
-        \"CreationDateTime\": 1.36372808007E9,
-        \"GlobalSecondaryIndexes\": [
-            {
-                \"IndexName\": \"SubjectIndex\",
-                \"IndexSizeBytes\": 2048,
-                \"IndexStatus\": \"CREATING\",
-                \"ItemCount\": 47,
-                \"KeySchema\": [
-                    {
-                        \"AttributeName\": \"Subject\",
-                        \"KeyType\": \"HASH\"
-                    },
-                    {
-                        \"AttributeName\": \"LastPostDateTime\",
-                        \"KeyType\": \"RANGE\"
-                    }
-                ],
-                \"Projection\": {
-                    \"ProjectionType\": \"KEYS_ONLY\"
-                },
-                \"ProvisionedThroughput\": {
-                    \"LastDecreaseDateTime\": 0,
-                    \"LastIncreaseDateTime\": 1,
-                    \"NumberOfDecreasesToday\": 2,
-                    \"ReadCapacityUnits\": 3,
-                    \"WriteCapacityUnits\": 4
-                }
-            }
-        ],
-        \"ItemCount\": 0,
-        \"KeySchema\": [
-            {
-                \"AttributeName\": \"ForumName\",
-                \"KeyType\": \"HASH\"
-            },
-            {
-                \"AttributeName\": \"Subject\",
-                \"KeyType\": \"RANGE\"
-            }
-        ],
-        \"LocalSecondaryIndexes\": [
-            {
-                \"IndexName\": \"LastPostIndex\",
-                \"IndexSizeBytes\": 0,
-                \"ItemCount\": 0,
-                \"KeySchema\": [
-                    {
-                        \"AttributeName\": \"ForumName\",
-                        \"KeyType\": \"HASH\"
-                    },
-                    {
-                        \"AttributeName\": \"LastPostDateTime\",
-                        \"KeyType\": \"RANGE\"
-                    }
-                ],
-                \"Projection\": {
-                    \"ProjectionType\": \"KEYS_ONLY\"
-                }
-            }
-        ],
-        \"ProvisionedThroughput\": {
-            \"NumberOfDecreasesToday\": 0,
-            \"ReadCapacityUnits\": 5,
-            \"WriteCapacityUnits\": 5
-        },
-        \"TableName\": \"Thread\",
-        \"TableSizeBytes\": 0,
-        \"TableStatus\": \"CREATING\"
-    }
-}",
-    {ok, #ddb2_table_description
-    {attribute_definitions = [{<<"ForumName">>, s},
-     {<<"LastPostDateTime">>, s},
-     {<<"Subject">>, s}],
-     creation_date_time = 1363728080.07,
-     item_count = 0,
-     key_schema = {<<"ForumName">>, <<"Subject">>},
-     local_secondary_indexes =
-     [#ddb2_local_secondary_index_description{
-      index_name = <<"LastPostIndex">>,
-      index_size_bytes = 0,
-      item_count = 0,
-      key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
-      projection = keys_only}],
-     global_secondary_indexes =
-     [#ddb2_global_secondary_index_description{
-      index_name = <<"SubjectIndex">>,
-      index_size_bytes = 2048,
-      index_status = creating,
-      item_count = 47,
-      key_schema = {<<"Subject">>, <<"LastPostDateTime">>},
-      projection = keys_only,
-      provisioned_throughput = #ddb2_provisioned_throughput_description{
-       last_decrease_date_time = 0,
-       last_increase_date_time = 1,
-       number_of_decreases_today = 2,
-       read_capacity_units = 3,
-       write_capacity_units = 4}
-     }],
-     provisioned_throughput =
-     #ddb2_provisioned_throughput_description{
-      last_decrease_date_time = undefined,
-      last_increase_date_time = undefined,
-      number_of_decreases_today = 0,
-      read_capacity_units = 5,
-      write_capacity_units = 5},
-     table_name = <<"Thread">>,
-     table_size_bytes = 0,
-     table_status = creating}}})
-  ],
-
- output_tests(?_f(erlcloud_ddb2:restore_table_from_backup(<<"BackupArn">>,<<"Thread">>)), Tests).


### PR DESCRIPTION
Implemented API:
1. ListBackups
2. CreateBackup
3. DeleteBackup
4. DescribeBackup
5. DescribeContinuousBackups
6. RestoreTableFromBackup
And tests.