### PR TITLE
Add the replication status in object metadata

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -873,10 +873,17 @@ get_object_metadata(BucketName, Key, Options, Config) ->
      {content_type, proplists:get_value("content-type", Headers)},
      {content_encoding, proplists:get_value("content-encoding", Headers)},
      {delete_marker, list_to_existing_atom(proplists:get_value("x-amz-delete-marker", Headers, "false"))},
+     {replication_status, decode_replication_status(proplists:get_value("x-amz-replication-status", Headers))},
      {version_id, proplists:get_value("x-amz-version-id", Headers, "false")}|extract_metadata(Headers)].
 
 extract_metadata(Headers) ->
     [{Key, Value} || {Key = "x-amz-meta-" ++ _, Value} <- Headers].
+
+decode_replication_status(undefined) -> undefined;
+decode_replication_status("PENDING") -> pending;
+decode_replication_status("COMPLETED") -> completed;
+decode_replication_status("FAILED") -> failed;
+decode_replication_status("REPLICA") -> replica.
 
 -spec get_object_torrent(string(), string()) -> proplist() | no_return().
 


### PR DESCRIPTION
Update `erlcloud_s3:get_object_metadata/4` to return the replication status given by the `x-amz-replication-status` header.

This modification add a new tuple in the response : `{replication_status, Status}` with `Status = undefined | pending | completed | failed | replica`.