### PR TITLE
make lambda invokes headers visible

### DIFF
--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -333,10 +333,22 @@ get_function_configuration(Function, Qualifier, Config) ->
 %% Lambda API:
 %% [http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html]
 %%
-%% ===Example===
+%% option {show_headers, true|false} may be used for invoking Lambdas
+%% this option changes returned spec of successfull Lambda invocation
+%%      false(default): output spec is {ok, Data}
+%%      true: output spec is {ok, Headers, Data} where additional headers of
+%%            Lambda invocation is returned
+%%
+%%
+%% ===Examples===
 %% Async invoke with no logs and empty event
 %% erlcloud_lambda:invoke(<<"my_lambda">>, [],
 %%    [{"X-Amz-Invocation-Type", "Event"}, {"X-Amz-Log-Type", "None"}], AwsCfg).
+%% Sync invoke returned invocation headers (contains logs)
+%% erlcloud_lambda:invoke(<<"my_lambda">>, [],
+%%    [{show_headers, true}, {"X-Amz-Log-Type", "Tail"},
+%%    {"X-Amz-Invocation-Type", "RequestResponse"}], AwsCfg).
+%%
 %%
 %%-----------------------------------------------------------------------------
 -spec invoke(FunctionName :: binary()) -> return_val().

--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -734,17 +734,18 @@ lambda_request_no_update(Config, Method, Path, Options, Body, QParam) ->
     case erlcloud_aws:do_aws_request_form_raw(
            Method, Config#aws_config.lambda_scheme, Config#aws_config.lambda_host,
            Config#aws_config.lambda_port, Path, Form, Headers, Config, ShowRespHeaders) of
-        {ok, <<"">>} ->
-            {ok, []};
-        {ok, Data} ->
-            {ok, jsx:decode(Data)};
-        {ok, Headers, <<"">>} ->
-            {ok, Headers, []};
-        {ok, Headers, Data} ->
-            {ok, Headers, jsx:decode(Data)};
+        {ok, RespHeaders, RespBody} ->
+            {ok, RespHeaders, decode_body(RespBody)};
+        {ok, RespBody} ->
+            {ok, decode_body(RespBody)};
         E ->
             E
     end.
+
+decode_body(<<>>) ->
+    [];
+decode_body(BinData) ->
+    jsx:decode(BinData).
 
 encode_body(undefined) ->
     <<>>;

--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -729,13 +729,13 @@ lambda_request_no_update(Config, Method, Path, Hdrs, Body, QParam) ->
                Value  -> Value
            end,
     Headers = headers(Method, Path, Hdrs, Config, encode_body(Body), QParam),
-    case erlcloud_aws:aws_request_form_raw(
+    case erlcloud_aws:do_aws_request_form_raw(
            Method, Config#aws_config.lambda_scheme, Config#aws_config.lambda_host,
-           Config#aws_config.lambda_port, Path, Form, Headers, Config) of
+           Config#aws_config.lambda_port, Path, Form, Headers, Config, true) of
         {ok, <<"">>} ->
             {ok, []};
-        {ok, Data} ->
-            {ok, jsx:decode(Data)};
+        {ok, {Headers, Data}} ->
+            {ok, {Headers, jsx:decode(Data)}};
         E ->
             E
     end.

--- a/test/erlcloud_lambda_tests.erl
+++ b/test/erlcloud_lambda_tests.erl
@@ -634,7 +634,7 @@ api_tests(_) ->
      end,
      fun() ->
              Result = erlcloud_lambda:invoke(<<"name">>, [], [{show_headers, true}], #aws_config{}),
-             Expected = {ok, [], {<<"message">>, <<"Hello World!">>}},
+             Expected = {ok, [], [{<<"message">>, <<"Hello World!">>}]},
              ?assertEqual(Expected, Result)
      end,
      fun() ->

--- a/test/erlcloud_lambda_tests.erl
+++ b/test/erlcloud_lambda_tests.erl
@@ -633,6 +633,11 @@ api_tests(_) ->
              ?assertEqual(Expected, Result)
      end,
      fun() ->
+             Result = erlcloud_lambda:invoke(<<"name">>, [], [{show_headers, true}], #aws_config{}),
+             Expected = {ok, [], {<<"message">>, <<"Hello World!">>}},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
              Result = erlcloud_lambda:list_aliases(<<"name">>),
              Expected = {ok, [{<<"Aliases">>,
                                [[{<<"AliasArn">>, <<"arn:aws:lambda:us-east-1:352283894008:function:name:aliasName">>},


### PR DESCRIPTION
`lambda:invoke` returns `{ok, {Headers, Data}}` for success Lambda calls instead of `{ok, Data}` as currently