### PR TITLE
Uniform guard clauses for sqs:send_message

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -414,10 +414,10 @@ send_message(QueueName, MessageBody) ->
     send_message(QueueName, MessageBody, default_config()).
 
 -spec send_message(string(), string(), 0..900 | none | aws_config()) -> proplist() | no_return().
-send_message(QueueName, MessageBody, Config)
-  when is_record(Config, aws_config) ->
+send_message(QueueName, MessageBody, #aws_config{} = Config) ->
     send_message(QueueName, MessageBody, none, Config);
-send_message(QueueName, MessageBody, DelaySeconds) ->
+send_message(QueueName, MessageBody, DelaySeconds) 
+  when ((DelaySeconds >= 0 andalso DelaySeconds =< 900) orelse DelaySeconds =:= none) ->
     send_message(QueueName, MessageBody, DelaySeconds, default_config()).
 
 -spec send_message(string(), string(), 0..900 | none, aws_config()) -> proplist() | no_return().


### PR DESCRIPTION
Aviod getting a default record if calling sqs:send_message/3 with
`undefined` as the `AwsConfig`.

The old code led to a very weird error as the `undefined` was then used
for `DelaySeconds` and then the guard on sqs:send_message/5 stops it.

Better to fail-fast as soon as we know the argument is wrong.