### PR TITLE
Update .travis.yml to use newer Erlang/OTP installations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ sudo: false
 language: erlang
 otp_release:
   - 17.5
-  - 18.1
-  - 19.1
-  - 20.0
+  - 18.3
+  - 19.3
+  - 20.3
 env:
   global:
-  - MAIN_OTP=19.1
+  - MAIN_OTP=19.3
   matrix:
   - FORCE_REBAR2=true
   - FORCE_REBAR2=false PATH=$PATH:$PWD


### PR DESCRIPTION
* 18.1 -> 18.3
* 19.1 -> 19.3
* 20.0 -> 20.3