### PR TITLE
Allow create volume snapshots with tags

### DIFF
--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -829,7 +829,7 @@ create_snapshot(VolumeID, Description, TagList, Config)
     DefaultParams = [{"VolumeId", VolumeID}, {"Description", Description}],
     TagParams = tags_parameters("snapshot", TagList),
     Params = DefaultParams ++ TagParams,
-    case ec2_query(Config, "CreateSnapshot", Params) of
+    case ec2_query(Config, "CreateSnapshot", Params, ?NEW_API_VERSION) of
         {ok, Doc} ->
             {ok, [
                  {snapshot_id, get_text("/CreateSnapshotResponse/snapshotId", Doc)},

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -839,7 +839,8 @@ create_snapshot(VolumeID, Description, TagList, Config)
                  {start_time, erlcloud_xml:get_time("/CreateSnapshotResponse/attachTime", Doc)},
                  {progress, get_text("/CreateSnapshotResponse/progress", Doc)},
                  {owner_id, get_text("/CreateSnapshotResponse/ownerId", Doc)},
-                 {description, get_text("/CreateSnapshotResponse/description", Doc)}
+                 {description, get_text("/CreateSnapshotResponse/description", Doc)},
+                 {tag_set, [extract_tag_item(Item) || Item <- xmerl_xpath:string("tagSet/item", Doc, [])]}
             ]};
         {error, _} = Error ->
             Error
@@ -920,7 +921,8 @@ create_volume(Size, SnapshotID, AvailabilityZone, VolumeType, Tags, Config)
                 {availability_zone, get_text("availabilityZone", Doc, none)},
                 {status, get_text("status", Doc, none)},
                 {create_time, erlcloud_xml:get_time("createTime", Doc)},
-                {volumeType, get_text("volumeType", Doc, none)}
+                {volumeType, get_text("volumeType", Doc, none)},
+                {tag_set, [extract_tag_item(Item) || Item <- xmerl_xpath:string("tagSet/item", Doc, [])]}
             ]};
         {error, _} = Error ->
             Error

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -25,8 +25,8 @@
 
          %% Elastic Block Store
          attach_volume/3, attach_volume/4,
-         create_snapshot/1, create_snapshot/2, create_snapshot/3,
-         create_volume/3, create_volume/4, create_volume/5,
+         create_snapshot/1, create_snapshot/2, create_snapshot/3, create_snapshot/4,
+         create_volume/3, create_volume/4, create_volume/5, create_volume/6,
          delete_snapshot/1, delete_snapshot/2,
          delete_volume/1, delete_volume/2,
          describe_snapshot_attribute/2, describe_snapshot_attribute/3,


### PR DESCRIPTION
This allows a single atomic request to create-and-tag a snapshot/volume, rather than via consecutive calls to e.g. `CreateSnapshot` then `CreateTags`.

Note that in its current form this will always return the `{tag_set, TagList}` in the proplist result.