### PR TITLE
Fix some specs

### DIFF
--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -3092,7 +3092,7 @@ create_flow_logs(LogGroupName, ResourceType, ResourceIDs, TrafficType, DeliverLo
         vpc | subnet | network_interface,
         [string()],
         accept | reject | all,
-        string(),
+        string() | none,
         string() | aws_config()) -> ok_error(string()).
 create_flow_logs(LogGroupName, ResourceType, ResourceIDs, TrafficType, DeliverLogsPermissionArn, Config)
     when is_record(Config, aws_config) ->
@@ -3106,7 +3106,7 @@ create_flow_logs(LogGroupName, ResourceType, ResourceIDs, TrafficType, DeliverLo
         [string()],
         accept | reject | all,
         string(),
-        string(),
+        string() | none,
         aws_config()) -> ok_error(string()).
 create_flow_logs(LogGroupName, ResourceType, ResourceIDs, TrafficType, DeliverLogsPermissionArn, ClientToken, Config)
     when is_record(Config, aws_config) ->

--- a/src/erlcloud_redshift.erl
+++ b/src/erlcloud_redshift.erl
@@ -42,7 +42,7 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
     ok.
 
 -spec redshift_query(aws_config(), string(), list({string(), string()})) ->
-    {ok, term()} | {error, term}.
+    {ok, term()} | {error, term()}.
 redshift_query(Config, Action, Params) ->
     QParams = [{"Action", Action}, {"Version", ?API_VERSION} | Params],
     erlcloud_aws:aws_request_xml4(get, Config#aws_config.redshift_host,

--- a/src/erlcloud_route53.erl
+++ b/src/erlcloud_route53.erl
@@ -487,9 +487,7 @@ describe_all(Fun, Args, Options, Config, Acc) when is_list(Args) ->
                          Config, [Res | Acc]);
         {error, Reason} ->
             {error, Reason}
-    end;
-describe_all(Fun, Args, Options, Config, Acc) ->
-    describe_all(Fun, [Args], Options, Config, Acc).
+    end.
 
 key_replace_or_add(Key, Value, List) ->
     case lists:keymember(Key, 1, List) of

--- a/src/erlcloud_route53.erl
+++ b/src/erlcloud_route53.erl
@@ -501,7 +501,7 @@ key_replace_or_add(Key, Value, List) ->
 
 -spec route53_query(get | post, aws_config(), string(), string(),
                     list({string(), string()}), string()) ->
-    {ok, term()} | {error, term}.
+    {ok, term()} | {error, term()}.
 route53_query(Method, Config, Action, Path, Params, ApiVersion) ->
     QParams = [{"Action", Action}, {"Version", ApiVersion} | Params],
     erlcloud_aws:aws_request_xml4(Method, Config#aws_config.route53_host,

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1118,7 +1118,7 @@ upload_part(BucketName, Key, UploadId, PartNumber, Value, HTTPHeaders, Config)
             Error
     end.
 
--spec complete_multipart(string(), string(), string(), [{integer(), string()}]) -> {ok, proplist()} | {error, any()}.
+-spec complete_multipart(string(), string(), string(), [{integer(), string()}]) -> ok | {error, any()}.
 complete_multipart(BucketName, Key, UploadId, ETags)
   when is_list(BucketName), is_list(Key), is_list(UploadId), is_list(ETags) ->
     complete_multipart(BucketName, Key, UploadId, ETags, [], default_config()).

--- a/test/erlcloud_cloudfront_tests.erl
+++ b/test/erlcloud_cloudfront_tests.erl
@@ -11,9 +11,7 @@
 -define(_f(F), fun() -> F end).
 
 
--type expected_param() :: {string(), string()}.
--type output_test_spec() :: {pos_integer(), {string(), term()} |
-                            {string(), string(), term()}}.
+-type output_test_spec() :: {pos_integer(), {string(), string(), term()}}.
 
 
 %%==============================================================================

--- a/test/erlcloud_route53_tests.erl
+++ b/test/erlcloud_route53_tests.erl
@@ -409,7 +409,7 @@ describe_all_tests(_) ->
                             Fun, [{"End", 6}], #aws_config{}, [])),
              ?assertMatch({ok, [1, 2, 3, 4, 5, 6]},
                           erlcloud_route53:describe_all(
-                            Fun2, 1, [{"End", 6}], #aws_config{}, []))
+                            Fun2, [1], [{"End", 6}], #aws_config{}, []))
      end,
      fun() ->
              Fun = fun(Option, _Config) ->


### PR DESCRIPTION
Not sure what to do with `application:get_env` calls in `erlcloud_aws`. The spec in OTP says only `atom()` is allowed as key, but it would be reasonable to have `term() | tuple()` as keys IMO.