### PR TITLE
don't duplicate the Accum on deep structures

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -346,7 +346,7 @@ explore_dirstructure(Bucketname, [Branch|Tail], Accum, Config)
         Sub ->
             Files = ProcessContent(Data),
             List = lists:foldl(fun(I,Acc)-> R = proplists:get_value(prefix, I), [R|Acc] end, [], Sub),
-            Result = explore_dirstructure(Bucketname, List, Accum, Config),
+            Result = explore_dirstructure(Bucketname, List, [], Config),
             explore_dirstructure(Bucketname, Tail, [Result, Files|Accum], Config)
     end.
 


### PR DESCRIPTION
explore_dirstructure/4 har a bug in that it duplicates the Accumulator for all deep structures, if you have more than one entry in Branches.

`25> erlcloud_s3:explore_dirstructure(Bucket, ["inbox/", "sftp/"], []).
["sftp/foo/20180814.csv",
 "sftp/foo/20180813.csv",
 "inbox/f52c9p37bcq64fnf58k5trs1ugakpt5956ljm181","inbox/",
 "inbox/f52c9p37bcq64fnf58k5trs1ugakpt5956ljm181","inbox/"]
`

Note how the last two entries are duplicates. This won't show up if there is only one branch since then the Accum is always []. It will probably double everything again for each extra branch.

Here is a tiny patch to fix this bug.

