### PR TITLE
empty response is not so empty for states

### DIFF
--- a/src/erlcloud_states.erl
+++ b/src/erlcloud_states.erl
@@ -648,6 +648,8 @@ request(Config, Request) ->
     case erlcloud_aws:request_to_return(Result) of
         {ok, {_, <<>>}} ->
             ok;
+        {ok, {_, <<"{}">>}} ->
+            ok;
         {ok, {_, RespBody}} ->
             {ok, jsx:decode(RespBody, [return_maps])};
         {error, _} = Error ->


### PR DESCRIPTION
https://docs.aws.amazon.com/step-functions/latest/apireference/API_SendTaskSuccess.html says:
``If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.``

In fact it returns body: ``{}``

Test is manual: 
```erlang
application:ensure_all_started(erlcloud).
{ok, C} = erlcloud_aws:auto_config().
D = erlcloud_aws:service_config(states, <<"us-west-2">>, C).	
{ok, Response1} = erlcloud_states:start_execution(<<"arn:aws:states:us-west-2:46XXXXXXXXX4:stateMachine:MyAwesomeFSM">>, #{}, D).
{ok, Response2} = erlcloud_states:get_activity_task(<<"arn:aws:states:us-west-2:46XXXXXXXXX4:activity:my-activity">>, #{}, D).
#{<<"input">> := Input, <<"taskToken">> := Token} = Response2.
ok = erlcloud_states:send_task_success(#{<<"hello">> => <<"world">>}, Token, D).
```

