### PR TITLE
Die noisily when unable to parse credentials

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -1254,7 +1254,7 @@ profiles_parse( Content ) ->
     case eini:parse( Content ) of
         {ok, Profiles} -> Profiles;
         Error ->
-            error_msg( "failed to parse credentials, because: ~p", [Error] )
+            erlang:error({error, {unable_to_parse_credential_file, Error}})
     end.
 
 profiles_resolve( Name, Profiles, Options ) ->


### PR DESCRIPTION
When you have a credentials file and it is unparseable for some reason, the function should die noisily because those files are used for local development work and it's a mysterious failure when your profiles are not parsed and the system tries to get information from the AWS metadata server which of course fails and you get back `undefined` as the result of this function call.