### PR TITLE
kinesis retry on LimitExceededException

### DIFF
--- a/src/erlcloud_kinesis_impl.erl
+++ b/src/erlcloud_kinesis_impl.erl
@@ -151,6 +151,8 @@ client_error(Status, StatusLine, Body) ->
                     {retry, {Type, Message}};
                 <<"ThrottlingException">> = Type ->
                     {retry, {Type, Message}};
+                <<"LimitExceededException">> = Type ->
+                    {retry, {Type, Message}};
                 Other ->
                     {error, {Other, Message}}
             end


### PR DESCRIPTION
LimitExceededException is returned in many cases, which have to do with either exceeding the number of concurrent requests on a resource, or exceeding an allowed attribute of a resource.

Maybe instead of this, we can allow requests to retry on certain methods... to let clients reuse the retry code.