### PR TITLE
Add support for custom SNS port

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -38,6 +38,7 @@
           emr_port=undefined::non_neg_integer()|undefined,
           sns_scheme="https://"::undefined|string(),
           sns_host="sns.amazonaws.com"::string(),
+          sns_port=undefined::non_neg_integer()|undefined,
           mturk_host="mechanicalturk.amazonaws.com"::string(),
           mon_host="monitoring.amazonaws.com"::string(),
           mon_port=undefined::non_neg_integer()|undefined,

--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -737,7 +737,7 @@ sns_simple_request(Config, Action, Params) ->
 sns_xml_request(Config, Action, Params) ->
     case erlcloud_aws:aws_request_xml4(post,
                                        scheme_to_protocol(Config#aws_config.sns_scheme),
-                                       Config#aws_config.sns_host, undefined, "/",
+                                       Config#aws_config.sns_host, Config#aws_config.sns_port, "/",
                                        [{"Action", Action}, {"Version", ?API_VERSION} | Params],
                                        "sns", Config) of
         {ok, XML} -> XML;
@@ -753,7 +753,7 @@ sns_xml_request(Config, Action, Params) ->
 sns_request(Config, Action, Params) ->
     case erlcloud_aws:aws_request_xml4(post,
                                        scheme_to_protocol(Config#aws_config.sns_scheme),
-                                       Config#aws_config.sns_host, undefined, "/",
+                                       Config#aws_config.sns_host, Config#aws_config.sns_port, "/",
                                        [{"Action", Action}, {"Version", ?API_VERSION} | Params],
                                        "sns", Config) of
         {ok, _Response} -> ok;


### PR DESCRIPTION
Allow to configure SNS service endpoint port, useful for integration with tools like [localstack](https://github.com/localstack/localstack) 