### PR TITLE
Introduce ecs placementStrategy option

### DIFF
--- a/include/erlcloud_ecs.hrl
+++ b/include/erlcloud_ecs.hrl
@@ -153,6 +153,11 @@
     source_volume :: undefined | binary()
 }).
 
+-record(ecs_placement_strategy, {
+    field :: undefined | binary(),
+    type :: undefined | binary()
+}).
+
 -record(ecs_port_mapping, {
     container_port :: undefined | pos_integer(),
     host_port :: undefined | pos_integer(),
@@ -188,6 +193,7 @@
     memory :: undefined | pos_integer(),
     memory_reservation :: undefined | pos_integer(),
     mount_points :: undefined | [#ecs_mount_point{}],
+    placement_strategy :: undefined | [#ecs_placement_strategy{}],
     name :: undefined | binary(),
     port_mappings :: undefined | [#ecs_port_mapping{}],
     privileged :: undefined | boolean(),

--- a/include/erlcloud_ecs.hrl
+++ b/include/erlcloud_ecs.hrl
@@ -153,11 +153,6 @@
     source_volume :: undefined | binary()
 }).
 
--record(ecs_placement_strategy, {
-    field :: undefined | binary(),
-    type :: undefined | binary()
-}).
-
 -record(ecs_port_mapping, {
     container_port :: undefined | pos_integer(),
     host_port :: undefined | pos_integer(),
@@ -193,7 +188,6 @@
     memory :: undefined | pos_integer(),
     memory_reservation :: undefined | pos_integer(),
     mount_points :: undefined | [#ecs_mount_point{}],
-    placement_strategy :: undefined | [#ecs_placement_strategy{}],
     name :: undefined | binary(),
     port_mappings :: undefined | [#ecs_port_mapping{}],
     privileged :: undefined | boolean(),

--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -163,7 +163,10 @@
     volume_name_opt/0,
     volumes/0,
     volumes_opt/0,
-    volumes_opts/0
+    volumes_opts/0,
+    placement_strategy/0,
+    placement_strategy_opt/0,
+    placement_strategy_opts/0
 ]).
 
 
@@ -364,6 +367,27 @@ volume_host_opt() ->
 volumes_opt() ->
     {volumes, <<"volumes">>, fun encode_volumes/1}.
 
+-type placement_strategy_opt() :: placement_strategy_field_opt() |
+                                  placement_strategy_type_opt().
+-type placement_strategy_opts() :: [placement_strategy_opt()].
+
+-type placement_strategy_field_opt() :: {field, string_param()}.
+-spec placement_strategy_field_opt() -> opt_table_entry().
+placement_strategy_field_opt() ->
+    {field, <<"field">>, fun to_binary/1}.
+
+-type placement_strategy_type_opt() :: {type, string_param()}.
+-spec placement_strategy_type_opt() -> opt_table_entry().
+placement_strategy_type_opt() ->
+    {type, <<"type">>, fun to_binary/1}.
+
+-type placement_strategy() :: {placement_strategy,
+                               maybe_list(placement_strategy_opts())}.
+-spec placement_strategy_opt() -> opt_table_entry().
+placement_strategy_opt() ->
+    {placement_strategy, <<"placementStrategy">>,
+     fun encode_placement_strategy/1}.
+
 -type key_value_pair_opt() :: {name, string_param()} |
                               {value, string_param()}.
 -type key_value_pair_opts() :: maybe_list([key_value_pair_opt()]).
@@ -492,7 +516,7 @@ container_volumes_from_opt() ->
                                     container_log_configuration_opt() |
                                     {memory, pos_integer()} |
                                     {memory_reservation, pos_integer()} |
-                                    container_mount_points_opt() |
+                                    container_mount_points_opt() | 
                                     {name, string_param()} |
                                     container_port_mappings_opt() |
                                     {privileged, boolean()} |
@@ -578,6 +602,18 @@ encode_volumes(Volumes) ->
         end, 
     Volumes).
         
+-spec encode_placement_strategy(placement_strategy_opts()) -> [aws_opts()].
+encode_placement_strategy(Strategy) ->
+    StrategyOpts = [
+        placement_strategy_field_opt(),
+        placement_strategy_type_opt()
+    ],
+    lists:map(
+        fun(Volume) ->
+            {AwsOpts, _EcsOpts} = opts(StrategyOpts, Volume), AwsOpts
+        end, 
+    Strategy).
+
 -spec encode_ecs_volume_from_list(ecs_volume_from_opts()) -> [aws_opts()].
 encode_ecs_volume_from_list(VolumesFrom) ->
     encode_maybe_list(fun ecs_volume_from_opt/0, VolumesFrom).
@@ -2136,6 +2172,7 @@ run_task_opts() ->
         {cluster, <<"cluster">>, fun to_binary/1},
         {count, <<"count">>, fun id/1},
         task_overrides_opt(),
+        placement_strategy_opt(),
         {started_by, <<"startedBy">>, fun to_binary/1}
     ].
 

--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -145,6 +145,9 @@
     maybe_list/1,
     maximum_percent_opt/0,
     minimum_healthy_percent_opt/0, 
+    placement_strategy/0,
+    placement_strategy_opt/0,
+    placement_strategy_opts/0,
     register_task_definition_opt/0,
     register_task_definition_opts/0,
     role_opt/0,
@@ -163,10 +166,7 @@
     volume_name_opt/0,
     volumes/0,
     volumes_opt/0,
-    volumes_opts/0,
-    placement_strategy/0,
-    placement_strategy_opt/0,
-    placement_strategy_opts/0
+    volumes_opts/0
 ]).
 
 
@@ -516,7 +516,7 @@ container_volumes_from_opt() ->
                                     container_log_configuration_opt() |
                                     {memory, pos_integer()} |
                                     {memory_reservation, pos_integer()} |
-                                    container_mount_points_opt() | 
+                                    container_mount_points_opt() |
                                     {name, string_param()} |
                                     container_port_mappings_opt() |
                                     {privileged, boolean()} |
@@ -2163,6 +2163,7 @@ register_task_definition(ContainerDefinitions, Family, Opts, Config) ->
 -type run_task_opt() :: {cluster, string_param()} |
                         {count, pos_integer()} |
                         task_overrides_opt() |
+                        placement_strategy_opt() |
                         {started_by, string_param()}.
 
 -type run_task_opts() :: [run_task_opt()].

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -2323,6 +2323,30 @@ run_task_input_tests(_) ->
   \"taskDefinition\": \"hello_world\"
 }
 "
+            }),
+         ?_ecs_test(
+            {"RunTask example request",
+             ?_f(erlcloud_ecs:run_task(
+                 "hello_world",
+                 [{count, 1},
+                  {placement_strategy, [
+                      [{field, "attribute:ecs.availability-zone"},
+                       {type, "spread"}],
+                      [{field, "instanceId"},
+                       {type, "spread"}]
+                  ]}
+                 ])), "
+{
+  \"count\": 1,
+  \"placementStrategy\": [
+      {\"type\": \"spread\",
+       \"field\": \"attribute:ecs.availability-zone\"},
+      {\"type\": \"spread\",
+       \"field\": \"instanceId\"}
+   ],
+  \"taskDefinition\": \"hello_world\"
+}
+"
             })
         ],
     Response = "


### PR DESCRIPTION
The net effect here is to add support for the placementStrategy option with run_task.  It is backward compatible in that not specifying the option has no effect.