### PR TITLE
Fix raw_response_body option

### DIFF
--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -744,7 +744,8 @@ lambda_request_no_update(Config, Method, Path, Options, Body, QParam) ->
            end,
     ShowRespHeaders = proplists:get_value(show_headers, Options, false),
     RawBody = proplists:get_value(raw_response_body, Options, false),
-    Hdrs = proplists:delete(show_headers, Options),
+    Hdrs0 = proplists:delete(show_headers, Options),
+    Hdrs = proplists:delete(raw_response_body, Hdrs0),
     Headers = headers(Method, Path, Hdrs, Config, encode_body(Body), QParam),
     case erlcloud_aws:do_aws_request_form_raw(
            Method, Config#aws_config.lambda_scheme, Config#aws_config.lambda_host,

--- a/test/erlcloud_lambda_tests.erl
+++ b/test/erlcloud_lambda_tests.erl
@@ -638,6 +638,11 @@ api_tests(_) ->
              ?assertEqual(Expected, Result)
      end,
      fun() ->
+             Result = erlcloud_lambda:invoke(<<"name">>, [], [raw_response_body], #aws_config{}),
+             Expected = {ok, <<"{\"message\":\"Hello World!\"}">>},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
              Result = erlcloud_lambda:list_aliases(<<"name">>),
              Expected = {ok, [{<<"Aliases">>,
                                [[{<<"AliasArn">>, <<"arn:aws:lambda:us-east-1:352283894008:function:name:aliasName">>},


### PR DESCRIPTION
Sorry for bug in previous pr.
Here is fix for:

```
 {error,{socket_error,{function_clause,[{lhttpc_lib,canonical_header,[raw_response_body],[{file,"
```

and unit test for it.