### PR TITLE
bump meck to 0.8.12 for rebar2 or older

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,7 +5,7 @@ case erlang:function_exported(rebar3, main, 1) of
     false -> % rebar 2.x or older
         %% Use git-based deps
         %% profiles
-        [{deps, [{meck, ".*",{git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}},
+        [{deps, [{meck, ".*",{git, "https://github.com/eproxus/meck.git", {tag, "0.8.12"}}},
                  {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
                  %% {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.2.0"}}},
                  {eini, ".*", {git, "https://github.com/erlcloud/eini.git", {tag, "1.2.5"}}},


### PR DESCRIPTION
was supposed to be fixed as part of #557 