### PR TITLE
Increase erlcloud_sts max session duration from 1h to 12h

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -4,7 +4,7 @@
 -record(aws_assume_role,{
     role_arn :: string() | undefined,
     session_name = "erlcloud" :: string(),
-    duration_secs =  900 :: 900..3600,
+    duration_secs =  900 :: 900..43200,
     external_id :: string() | undefined
 }).
 

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -67,7 +67,7 @@
 
 -record(profile_options, {
          session_name :: string(),
-         session_secs :: 900..3600,
+         session_secs :: 900..43200,
          external_id :: string()
 }).
 
@@ -1163,7 +1163,7 @@ profile( Name ) ->
 
 
 -type profile_option() :: {role_session_name, string()}
-                          | {role_session_secs, 900..3600}.
+                          | {role_session_secs, 900..43200}.
 
 %%%---------------------------------------------------------------------------
 -spec profile( Name :: atom(), Options :: [profile_option()] ) ->

--- a/src/erlcloud_sts.erl
+++ b/src/erlcloud_sts.erl
@@ -22,11 +22,11 @@ assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds) ->
 
 
 % See http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
--spec assume_role(#aws_config{}, string(), string(), 900..3600, undefined | string()) -> {#aws_config{}, proplist()} | no_return().
+-spec assume_role(#aws_config{}, string(), string(), 900..43200, undefined | string()) -> {#aws_config{}, proplist()} | no_return().
 assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds, ExternalId)
     when length(RoleArn) >= 20,
          length(RoleSessionName) >= 2, length(RoleSessionName) =< 64,
-         DurationSeconds >= 900, DurationSeconds =< 3600 ->
+         DurationSeconds >= 900, DurationSeconds =< 43200 ->
 
     Params =
         [


### PR DESCRIPTION
From AWS [documentation](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html): 

> By default, the temporary security credentials created by AssumeRole last for one hour. However, you can use the optional DurationSeconds parameter to specify the duration of your session. You can provide a value from 900 seconds (15 minutes) up to the maximum session duration setting for the role. This setting can have a value from 1 hour to 12 hours.