### PR TITLE
Explore more than 1k files

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -315,9 +315,11 @@ extract_delete_objects_batch_err_contents(Nodes) ->
 to_flat_format([{key,Key},{code,Code},{message,Message}]) ->
     {Key,Code,Message}.
 
-% returns paths list from AWS S3 root directory, used as input to delete_objects_batch
+% returns paths list from AWS S3 root directory, used as input to
+% delete_objects_batch
 % example :
-%    25> rp(erlcloud_s3:explore_dirstructure("xmppfiledev", ["sailfish/deleteme"], [])).
+%    25> rp(erlcloud_s3:explore_dirstructure("xmppfiledev",
+%                                            ["sailfish/deleteme"], [])).
 %    ["sailfish/deleteme/deep/deep1/deep4/ZZZ_1.txt",
 %     "sailfish/deleteme/deep/deep1/deep4/ZZZ_0.txt",
 %     "sailfish/deleteme/deep/deep1/ZZZ_0.txt",
@@ -328,27 +330,34 @@ to_flat_format([{key,Key},{code,Code},{message,Message}]) ->
 explore_dirstructure(Bucketname, Branches, Accum) ->
     explore_dirstructure(Bucketname, Branches, Accum, default_config()).
 
--spec explore_dirstructure(string(), list(), list(), aws_config()) -> list() | no_return().
+-spec explore_dirstructure(string(), list(), list(), aws_config()) ->
+                                  list() | no_return().
 explore_dirstructure(_, [], Result, _Config) ->
                                     lists:append(Result);
 explore_dirstructure(Bucketname, [Branch|Tail], Accum, Config)
     when is_record(Config, aws_config) ->
     ProcessContent = fun(Data)->
             Content = proplists:get_value(contents, Data),
-            lists:foldl(fun(I,Acc)-> R = proplists:get_value(key, I), [R|Acc] end, [], Content)
+            lists:foldl(fun(I,Acc)-> R = proplists:get_value(key, I),
+                                     [R|Acc] end, [], Content)
             end,
 
-    Data = list_objects(Bucketname, [{prefix, Branch}, {delimiter, "/"}], Config),
+    Data = list_objects(Bucketname, [{prefix, Branch},
+                                     {delimiter, "/"}], Config),
     case proplists:get_value(common_prefixes, Data) of
         [] -> % it has reached end of the branch
             Files = ProcessContent(Data),
             explore_dirstructure(Bucketname, Tail, [Files|Accum], Config);
         Sub ->
             Files = ProcessContent(Data),
-            List = lists:foldl(fun(I,Acc)-> R = proplists:get_value(prefix, I), [R|Acc] end, [], Sub),
+            List = lists:foldl(fun(I,Acc)-> R = proplists:get_value(prefix, I),
+                                            [R|Acc] end, [], Sub),
             Result = explore_dirstructure(Bucketname, List, [], Config),
-            explore_dirstructure(Bucketname, Tail, [Result, Files|Accum], Config)
+            explore_dirstructure(Bucketname, Tail,
+                                 [Result, Files|Accum], Config)
     end.
+
+
 
 -spec delete_object(string(), string()) -> proplist() | no_return().
 

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -315,17 +315,17 @@ extract_delete_objects_batch_err_contents(Nodes) ->
 to_flat_format([{key,Key},{code,Code},{message,Message}]) ->
     {Key,Code,Message}.
 
-% returns paths list from AWS S3 root directory, used as input to
-% delete_objects_batch
-% example :
-%    25> rp(erlcloud_s3:explore_dirstructure("xmppfiledev",
-%                                            ["sailfish/deleteme"], [])).
-%    ["sailfish/deleteme/deep/deep1/deep4/ZZZ_1.txt",
-%     "sailfish/deleteme/deep/deep1/deep4/ZZZ_0.txt",
-%     "sailfish/deleteme/deep/deep1/ZZZ_0.txt",
-%     "sailfish/deleteme/deep/ZZZ_0.txt"]
-%    ok
-%
+%% returns paths list from AWS S3 root directory, used as input to
+%% delete_objects_batch
+%% example :
+%%    25> rp(erlcloud_s3:explore_dirstructure("xmppfiledev",
+%%                                            ["sailfish/deleteme"], [])).
+%%    ["sailfish/deleteme/deep/deep1/deep4/ZZZ_1.txt",
+%%     "sailfish/deleteme/deep/deep1/deep4/ZZZ_0.txt",
+%%     "sailfish/deleteme/deep/deep1/ZZZ_0.txt",
+%%     "sailfish/deleteme/deep/ZZZ_0.txt"]
+%%    ok
+%%
 -spec explore_dirstructure(string(), list(), list()) -> list() | no_return().
 explore_dirstructure(Bucketname, Branches, Accum) ->
     explore_dirstructure(Bucketname, Branches, Accum, default_config()).


### PR DESCRIPTION
`erlcloud_s3:explore_dirstructure/3` can't handle more than 1000 files in a certain prefix.

The reason is that s3 paginates and only returns 1000 results, and sets `{is_truncated, true}`.

This branch makes `explore_dirstructure` continue at the next_marker when a dir is being truncated. Also some simplification of handling of subdirs since the recursion on the empty list will return the empty list, so one case could be removed.
