### PR TITLE
erlcloud_ddb2: fix issue with serializing GSI creation when billing_mode = PPR

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -3420,7 +3420,8 @@ update_global_table(GlobalTableName, ReplicaUpdates, Opts, Config) ->
 -type global_secondary_index_updates() :: maybe_list(global_secondary_index_update()).
 
 -spec dynamize_global_secondary_index_update(global_secondary_index_update()) -> jsx:json_term().
-dynamize_global_secondary_index_update({IndexName, ReadUnits, WriteUnits}) ->
+dynamize_global_secondary_index_update({IndexName, ReadUnits, WriteUnits})
+    when is_integer(ReadUnits), is_integer(WriteUnits) ->
     [{<<"Update">>, [
         {<<"IndexName">>, IndexName},
         {<<"ProvisionedThroughput">>, dynamize_provisioned_throughput({ReadUnits, WriteUnits})}

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -5317,6 +5317,38 @@ update_table_input_tests(_) ->
 }"
             }),
         ?_ddb_test(
+            {"UpdateTable example request with Create GSI (pay per request)",
+             ?_f(erlcloud_ddb2:update_table(<<"Thread">>,
+                                            [{attribute_definitions, [{<<"HashKey1">>, s}]},
+                                             {global_secondary_index_updates, [
+                                                {<<"Index1">>, <<"HashKey1">>, all}]}])), "
+{
+    \"TableName\": \"Thread\",
+    \"AttributeDefinitions\": [
+        {
+            \"AttributeName\": \"HashKey1\",
+            \"AttributeType\": \"S\"
+        }
+    ],
+    \"GlobalSecondaryIndexUpdates\": [
+        {
+            \"Create\": {
+                \"IndexName\": \"Index1\",
+                \"KeySchema\": [
+                    {
+                        \"AttributeName\": \"HashKey1\",
+                        \"KeyType\": \"HASH\"
+                    }
+                ],
+                \"Projection\": {
+                    \"ProjectionType\": \"ALL\"
+                }
+            }
+        }
+    ]
+}"
+            }),
+        ?_ddb_test(
             {"UpdateTable example request billing_mode = pay_per_request",
              ?_f(erlcloud_ddb2:update_table(<<"Thread">>,
                                             [{billing_mode, pay_per_request}])), "


### PR DESCRIPTION
When billing_mode = pay_per_request, updating the global secondary indexes requires a 3-tuple of `{IndexName, KeySpecification, Projection}`, but this has the same signature as a provisioned throughput update for an index, `{IndexName, RU, WU}`. To address this, we need to adjust the serialization to only internpret GSI updates with RU/WU when they are passed as integers. Otherwise the update should get passed into the new GSI creation serialization path.