### PR TITLE
Fix function clause in mk_send_batch_entry when message body is binary

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -588,6 +588,12 @@ mk_send_batch_entry(N, {MessageId, MessageBody}, DelaySeconds) ->
 mk_send_batch_entry(N, {MessageId, MessageBody, MessageAttributes}, DelaySeconds) ->
     mk_send_batch_entry(N, {MessageId, MessageBody, MessageAttributes, []}, DelaySeconds);
 mk_send_batch_entry(N, {MessageId, MessageBody, MessageAttributes, Opts}, DelaySeconds)
+  when is_binary(MessageId) ->
+    mk_send_batch_entry(N, {binary_to_list(MessageId), MessageBody, MessageAttributes, Opts}, DelaySeconds);
+mk_send_batch_entry(N, {MessageId, MessageBody, MessageAttributes, Opts}, DelaySeconds)
+    when is_binary(MessageBody) ->
+    mk_send_batch_entry(N, {MessageId, binary_to_list(MessageBody), MessageAttributes, Opts}, DelaySeconds);
+mk_send_batch_entry(N, {MessageId, MessageBody, MessageAttributes, Opts}, DelaySeconds)
   when is_list(MessageId), is_list(MessageBody), is_list(MessageAttributes), is_list(Opts) ->
     N0 = integer_to_list(N),
     EncodedOpts = [


### PR DESCRIPTION
According to the spec `mk_send_batch_entry` accepts `batch_entry()` as 2-nd param.
`batch_entry()` is a tuple where 1-st element is message id and 2-nd element is message body.
Both have type `string()` which can be list or binary.

Function is fixed to accept both lists and binaries.