### PR TITLE
list mfa devices, simulate policies with context entries

### DIFF
--- a/include/erlcloud_iam.hrl
+++ b/include/erlcloud_iam.hrl
@@ -1,0 +1,3 @@
+-type context_key() :: context_key_name | context_key_type | context_key_values.
+-type context_entry() :: [{context_key(), string() | list()}].
+-type context_entries() :: list(context_entry()).


### PR DESCRIPTION
 - support for `list_virtual_mfa_devices` function
 - support for `ContextEntry` parameters in `simulate_custom_policy` function (https://docs.aws.amazon.com/IAM/latest/APIReference/API_ContextEntry.html)