### PR TITLE
Erlcloud Mon & CloudWatch - Alarms & Metric Filters

### DIFF
--- a/include/erlcloud_mon.hrl
+++ b/include/erlcloud_mon.hrl
@@ -31,6 +31,13 @@
 -type unit()     :: string().
 
 %%------------------------------------------------------------------------------
+%% @doc The statistic for the metric, other than percentiles.
+%% Valid Values: SampleCount | Average | Sum | Minimum | Maximum
+%% @end
+%%------------------------------------------------------------------------------
+-type statistic() :: string().
+
+%%------------------------------------------------------------------------------
 %% @doc Dimension
 %% The Dimension data type further expands on the identity of a metric using a Name, Value pair.
 %% For examples that use one or more dimensions, see PutMetricData.

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -25,6 +25,9 @@
 -type log_stream_name() :: string() | binary() | undefined.
 -type log_stream_prefix() :: string() | binary() | undefined.
 -type limit() :: pos_integer() | undefined.
+-type filter_name_prefix() :: string() | binary() | undefined.
+-type metric_name() :: string() | binary() | undefined.
+-type metric_namespace() :: string() | binary() | undefined.
 -type log_stream_order() :: log_stream_name | last_event_time | undefined.
 -type events() :: [#{message => binary(), timestamp => pos_integer()}].
 
@@ -36,6 +39,7 @@
 
 -type log_group() :: jsx:json_term().
 -type log_stream() :: jsx:json_term().
+-type metric_filters() :: jsx:json_term().
 
 -type tag():: {binary(), binary()}.
 -type tags_return() :: jsx:json_term().
@@ -64,6 +68,14 @@
     describe_log_streams/5,
     describe_log_streams/6,
     describe_log_streams/7,
+
+    describe_metric_filters/0,
+    describe_metric_filters/1,
+    describe_metric_filters/2,
+    describe_metric_filters/3,
+    describe_metric_filters/4,
+    describe_metric_filters/6,
+    describe_metric_filters/7,
 
     put_logs_events/4,
     put_logs_events/5,
@@ -334,6 +346,97 @@ req_logs_events(LogGroup, LogStream, SeqToken, Events) ->
 log_events(Events) ->
     [maps:with([message, timestamp], X) ||
         #{message := _, timestamp := _} = X <- Events].
+
+%%------------------------------------------------------------------------------
+%% @doc
+%%
+%% DescribeMetricFilters action
+%% https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeMetricFilters.html
+%%
+%% @end
+%%------------------------------------------------------------------------------
+-spec describe_metric_filters() -> result_paged(metric_filters()).
+describe_metric_filters() ->
+    describe_metric_filters(default_config()).
+
+
+-spec describe_metric_filters(
+    aws_config() | log_group_name()
+) -> result_paged(metric_filters()).
+describe_metric_filters(#aws_config{} = Config) ->
+    describe_metric_filters(undefined, Config);
+describe_metric_filters(LogGroupName) ->
+    describe_metric_filters(LogGroupName, default_config()).
+
+
+-spec describe_metric_filters(
+    log_group_name(),
+    aws_config()
+) -> result_paged(metric_filters()).
+describe_metric_filters(LogGroupName, Config) ->
+    describe_metric_filters(LogGroupName, ?DEFAULT_LIMIT, Config).
+
+
+-spec describe_metric_filters(
+    log_group_name(),
+    limit(),
+    aws_config()
+) -> result_paged(metric_filters()).
+describe_metric_filters(LogGroupName, Limit, Config) ->
+    describe_metric_filters(LogGroupName, Limit, undefined, Config).
+
+
+-spec describe_metric_filters(
+    log_group_name(),
+    limit(),
+    filter_name_prefix(),
+    aws_config()
+) -> result_paged(metric_filters()).
+describe_metric_filters(LogGroupName, Limit, FilterNamePrefix, Config) ->
+    describe_metric_filters(LogGroupName, Limit, FilterNamePrefix, undefined,
+                            undefined, Config).
+
+
+-spec describe_metric_filters(
+    log_group_name(),
+    limit(),
+    filter_name_prefix(),
+    metric_name(),
+    metric_namespace(),
+    aws_config()
+) -> result_paged(metric_filters()).
+describe_metric_filters(LogGroupName, Limit, FilterNamePrefix, MetricName,
+                        MetricNamespace, Config) ->
+    describe_metric_filters(LogGroupName, Limit, FilterNamePrefix, MetricName,
+                            MetricNamespace, undefined, Config).
+
+
+-spec describe_metric_filters(
+    log_group_name(),
+    limit(),
+    filter_name_prefix(),
+    metric_name(),
+    metric_namespace(),
+    paging_token(),
+    aws_config()
+) -> result_paged(metric_filters()).
+describe_metric_filters(LogGroupName, Limit, FilterNamePrefix, MetricName,
+                        MetricNamespace, PrevToken, Config) ->
+    case cw_request(Config, "DescribeMetricFilters", [
+        {<<"logGroupName">>, LogGroupName},
+        {<<"limit">>, Limit},
+        {<<"filterNamePrefix">>, FilterNamePrefix},
+        {<<"metricName">>, MetricName},
+        {<<"metricNamespace">>, MetricNamespace},
+        {<<"nextToken">>, PrevToken}
+    ]) of
+        {ok, Data} ->
+            MetricFilters = proplists:get_value(<<"metricFilters">>, Data, []),
+            NextToken = proplists:get_value(<<"nextToken">>, Data, undefined),
+            {ok, MetricFilters, NextToken};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/src/erlcloud_mon.erl
+++ b/src/erlcloud_mon.erl
@@ -16,6 +16,9 @@
 
 -export([
          list_metrics/5, list_metrics/4,
+         describe_alarms_for_metric/2,
+         describe_alarms_for_metric/7,
+         describe_alarms_for_metric/8,
          put_metric_data/3, put_metric_data/2,
          put_metric_data/6, put_metric_data/5,
          get_metric_statistics/4, get_metric_statistics/9, get_metric_statistics/8,
@@ -30,7 +33,8 @@
 -include("erlcloud_mon.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
--import(erlcloud_xml, [get_text/2, get_time/2]).
+-import(erlcloud_xml, [get_text/2, get_time/2, get_bool/2, get_integer/2,
+                       get_float/2, get_text/1]).
 
 -define(XMLNS_MON, "http://monitoring.amazonaws.com/doc/2010-08-01/").
 -define(API_VERSION, "2010-08-01").
@@ -115,6 +119,183 @@ extract_dimension(Node) ->
      {name,  get_text("Name",  Node)},
      {value, get_text("Value", Node)}
     ].
+
+%%------------------------------------------------------------------------------
+%% @doc CloudWatch API - DescribeAlarmsForMetric
+%% [https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarmsForMetric.html]
+%%
+%% USAGE:
+%%
+%% erlcloud_mon:describe_alarms_for_metric("AWS/EC2",
+%%                                         "NetworkIn").
+%% [[{metric_name,"NetworkIn"},
+%%  {namespace,"AWS/EC2"},
+%%  {dimensions,[]},
+%%  {actions_enabled,true},
+%%  {alarm_actions,[{arn,"arn:aws:sns:us-east-1:123456797777:rgallego_cloudtrail_sns_topic"}]},
+%%  {alarm_arn,"arn:aws:cloudwatch:us-east-1:123456797777:alarm:rgallego_unauthorized_alarm"},
+%%  {alarm_configuration_updated_timestamp,{{2018,2,7},
+%%                                          {17,38,24}}},
+%%  {alarm_description,[]},
+%%  {alarm_name,"rgallego_unauthorized_alarm"},
+%%  {comparison_operator,"GreaterThanOrEqualToThreshold"},
+%%  {evaluate_low_sample_count_percentile,[]},
+%%  {evaluation_periods,1},
+%%  {extended_statistic,[]},
+%%  {insufficient_data_actions,[]},
+%%  {ok_actions,[]},
+%%  {period,300},
+%%  {state_reason,"Threshold Crossed: 1 datapoint [2.0 (07/02/18 17:33:00)] was greater than or equal to the threshold (1.0)."},
+%%  {state_reason_data,"{\"version\":\"1.0\",\"queryDate\":\"2018-02-07T17:38:24.953+0000\",\"startDate\":\"2018-02-07T17:33:00.000+0000\",\"statistic\":\"Sum\",\"period\":300,\"recentDatapoints\":[2.0],\"threshold\":1.0}"},
+%%  {state_updated_timestamp,{{2018,2,7},{17,38,24}}},
+%%  {state_value,"ALARM"},
+%%  {statistic,"Sum"},
+%%  {threshold,1.0},
+%%  {treat_missing_data,[]},
+%%  {unit,[]}]]
+%%
+%% @end
+%%------------------------------------------------------------------------------
+-spec describe_alarms_for_metric(
+        Namespace           ::string(),
+        MetricName          ::string()
+                          ) -> term().
+
+describe_alarms_for_metric(
+  Namespace,
+  MetricName
+ ) ->
+    describe_alarms_for_metric(Namespace, MetricName, [],
+                               "", undefined, "",
+                               "", default_config()).
+
+%%------------------------------------------------------------------------------
+%% @doc CloudWatch API - DescribeAlarmsForMetric
+%% [https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarmsForMetric.html]
+%%
+%% USAGE:
+%%
+%% erlcloud_mon:describe_alarms_for_metric("AWS/EC2",
+%%                                         "NetworkIn",
+%%                                         [{"InstanceType","m1.large"}],
+%%                                         "p95",
+%%                                         17,
+%%                                         "",
+%%                                         "Seconds").
+%% See describe_alarms_for_metric/2
+%%
+%% @end
+%%------------------------------------------------------------------------------
+-spec describe_alarms_for_metric(
+        Namespace           ::string(),
+        MetricName          ::string(),
+        DimensionFilter     ::[{string(),string()}],
+        ExtendedStatistic   ::string(),
+        Period              ::pos_integer(),
+        Statistic           ::statistic(),
+        Unit                ::unit()
+                          ) -> term().
+
+describe_alarms_for_metric(
+  Namespace,
+  MetricName,
+  DimensionFilter,
+  ExtendedStatistic,
+  Period,
+  Statistic,
+  Unit
+ ) ->
+    describe_alarms_for_metric(Namespace, MetricName, DimensionFilter,
+                               ExtendedStatistic, Period, Statistic,
+                               Unit, default_config()).
+
+-spec describe_alarms_for_metric(
+        Namespace           ::string(),
+        MetricName          ::string(),
+        DimensionFilter     ::[{string(),string()}],
+        ExtendedStatistic   ::string(),
+        Period              ::pos_integer() | undefined,
+        Statistic           ::statistic(),
+        Unit                ::unit(),
+        Config              ::aws_config()
+                          ) -> term().
+
+describe_alarms_for_metric(
+  Namespace,
+  MetricName,
+  DimensionFilter,
+  ExtendedStatistic,
+  Period,
+  Statistic,
+  Unit,
+  #aws_config{} = Config
+ ) ->
+
+    Params =
+        [{"Namespace",  Namespace},
+         {"MetricName", MetricName}]
+        ++
+        [{"ExtendedStatistic", ExtendedStatistic}   || ExtendedStatistic/=""]
+        ++
+        [{"Period", Period}   || Period/=undefined]
+        ++
+        [{"Statistic", Statistic}   || Statistic/=""]
+        ++
+        [{"Unit", Unit}   || Unit/=""]
+        ++
+        lists:flatten(
+          [begin
+               {Name, Value} = lists:nth(N, DimensionFilter),
+               [{?FMT("Dimensions.member.~b.Name",  [N]), Name},
+                {?FMT("Dimensions.member.~b.Value", [N]), Value}]
+           end
+           || N<-lists:seq(1, length(DimensionFilter))]
+         ),
+    Doc = mon_query(Config, "DescribeAlarmsForMetric", Params),
+    Members = xmerl_xpath:string("/DescribeAlarmsForMetricResponse/DescribeAlarmsForMetricResult/MetricAlarms/member", Doc),
+    [extract_member_dafm(Member) || Member <- Members].
+
+extract_member_dafm(Node) ->
+    [
+     {metric_name,   get_text("MetricName", Node)},
+     {namespace,     get_text("Namespace", Node)},
+     {dimensions,
+      [extract_dimension_dafm(Item) || Item <- xmerl_xpath:string("Dimensions/member", Node)]
+     },
+     {actions_enabled, get_bool("ActionsEnabled", Node)},
+     {alarm_actions,
+      [extract_actions_dafm(Item) || Item <- xmerl_xpath:string("AlarmActions/member", Node)]},
+     {alarm_arn, get_text("AlarmArn", Node)},
+     {alarm_configuration_updated_timestamp, get_time("AlarmConfigurationUpdatedTimestamp", Node)},
+     {alarm_description, get_text("AlarmDescription", Node)},
+     {alarm_name, get_text("AlarmName", Node)},
+     {comparison_operator, get_text("ComparisonOperator", Node)},
+     {evaluate_low_sample_count_percentile, get_text("EvaluateLowSampleCountPercentile", Node)},
+     {evaluation_periods, get_integer("EvaluationPeriods", Node)},
+     {extended_statistic, get_text("ExtendedStatistic", Node)},
+     {insufficient_data_actions,
+      [extract_actions_dafm(Item) || Item <- xmerl_xpath:string("InsufficientDataActions/member", Node)]},
+     {ok_actions,
+      [extract_actions_dafm(Item) || Item <- xmerl_xpath:string("OKActions/member", Node)]},
+     {period, get_integer("Period", Node)},
+     {state_reason, get_text("StateReason", Node)},
+     {state_reason_data, get_text("StateReasonData", Node)},
+     {state_updated_timestamp, get_time("StateUpdatedTimestamp", Node)},
+     {state_value, get_text("StateValue", Node)},
+     {statistic, get_text("Statistic", Node)},
+     {threshold, get_float("Threshold", Node)},
+     {treat_missing_data, get_text("TreatMissingData", Node)},
+     {unit, get_text("Unit", Node)}
+    ].
+
+extract_dimension_dafm(Node) ->
+    [
+     {name,  get_text("Name",  Node)},
+     {value, get_text("Value", Node)}
+    ].
+
+extract_actions_dafm(Node) ->
+    {arn,  get_text(Node)}.
 
 %%------------------------------------------------------------------------------
 %% @doc CloudWatch API - PutMetricData

--- a/test/erlcloud_cloudwatch_logs_tests.erl
+++ b/test/erlcloud_cloudwatch_logs_tests.erl
@@ -40,7 +40,9 @@
 -define(LOG_STREAM_NAME_PREFIX, <<"welcome">>).
 -define(LOG_STREAM_NAME, <<"welcome">>).
 -define(PAGING_TOKEN, <<"arn:aws:logs:us-east-1:352773894028:log-group:/aws/apigateway/welcome:*">>).
-
+-define(FILTER_NAME_PREFIX, <<"aws/apigateway/welcome">>).
+-define(METRIC_NAME, <<"ct_test_metric">>).
+-define(METRIC_NAMESPACE, <<"CISBenchmark">>).
 
 -define(LOG_GROUP, [
     {<<"arn">>, <<"arn:aws:logs:us-east-1:352773894028:log-group:/aws/apigateway/welcome:*">>},
@@ -49,6 +51,20 @@
     {<<"metricFilterCount">>, 0},
     {<<"retentionInDays">>, 10},
     {<<"storedBytes">>, 85}
+]).
+
+-define(METRIC_FILTER, [
+    {<<"creationTime">>, 1518024063379},
+    {<<"filterName">>, <<"ct_test_filter">>},
+    {<<"filterPattern">>, <<"{ ($.errorCode = \"*UnauthorizedOperation\") "
+                            "|| ($.errorCode = \"AccessDenied*\") }">>},
+    {<<"logGroupName">>, ?LOG_GROUP_NAME},
+    {<<"metricTransformations">>, [
+        {<<"defaultValue">>, <<"0">>},
+        {<<"metricValue">>, <<"1">>},
+        {<<"metricNamespace">>, ?METRIC_NAMESPACE},
+        {<<"metricName">>, ?METRIC_NAME}
+    ]}
 ]).
 
 -define(LOG_STREAM, [
@@ -75,6 +91,9 @@ erlcloud_cloudwatch_test_() ->
     {foreach, fun start/0, fun stop/1, [
         fun describe_log_groups_input_tests/1,
         fun describe_log_groups_output_tests/1,
+
+        fun describe_metric_filters_input_tests/1,
+        fun describe_metric_filters_output_tests/1,
 
         fun describe_log_streams_input_tests/1,
         fun describe_log_streams_output_tests/1,
@@ -172,6 +191,118 @@ describe_log_groups_input_tests(_) ->
     ]).
 
 
+describe_metric_filters_input_tests(_) ->
+    input_tests(jsx:encode([{<<"metricFilters">>, []}]), [
+        ?_cloudwatch_test(
+            {"Tests describing metric filters with no parameters",
+             ?_f(erlcloud_cloudwatch_logs:describe_metric_filters()),
+             [{<<"Action">>, <<"DescribeMetricFilters">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"limit">>, ?DEFAULT_LIMIT}]}
+        ),
+        ?_cloudwatch_test(
+            {"Tests describing metric filters with custom AWS config provided",
+             ?_f(erlcloud_cloudwatch_logs:describe_metric_filters(
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"DescribeMetricFilters">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"limit">>, ?DEFAULT_LIMIT}]}
+        ),
+        ?_cloudwatch_test(
+            {"Tests describing metric filters with log group name provided",
+             ?_f(erlcloud_cloudwatch_logs:describe_metric_filters(
+                 ?LOG_GROUP_NAME
+             )),
+             [{<<"Action">>, <<"DescribeMetricFilters">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"limit">>, ?DEFAULT_LIMIT},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME}]}
+        ),
+        ?_cloudwatch_test(
+            {"Tests describing metric filters with custom AWS config and "
+             "log group name provided",
+             ?_f(erlcloud_cloudwatch_logs:describe_metric_filters(
+                 ?LOG_GROUP_NAME,
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"DescribeMetricFilters">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"limit">>, ?DEFAULT_LIMIT},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME}]}
+        ),
+        ?_cloudwatch_test(
+            {"Tests describing metric filters with custom AWS config, "
+             "log group name and limit provided",
+             ?_f(erlcloud_cloudwatch_logs:describe_metric_filters(
+                 ?LOG_GROUP_NAME,
+                 ?NON_DEFAULT_LIMIT,
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"DescribeMetricFilters">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"limit">>, ?NON_DEFAULT_LIMIT},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME}]}
+        ),
+        ?_cloudwatch_test(
+            {"Tests describing metric filters with custom AWS config, "
+             "log group name, limit and filter name prefix provided",
+             ?_f(erlcloud_cloudwatch_logs:describe_metric_filters(
+                 ?LOG_GROUP_NAME,
+                 ?NON_DEFAULT_LIMIT,
+                 ?FILTER_NAME_PREFIX,
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"DescribeMetricFilters">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"filterNamePrefix">>, ?FILTER_NAME_PREFIX},
+              {<<"limit">>, ?NON_DEFAULT_LIMIT},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME}]}
+        ),
+        ?_cloudwatch_test(
+            {"Tests describing metric filters with custom AWS config, "
+             "log group name, limit, filter name prefix, metric name and "
+             "metric namespace provided",
+             ?_f(erlcloud_cloudwatch_logs:describe_metric_filters(
+                 ?LOG_GROUP_NAME,
+                 ?NON_DEFAULT_LIMIT,
+                 ?FILTER_NAME_PREFIX,
+                 ?METRIC_NAME,
+                 ?METRIC_NAMESPACE,
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"DescribeMetricFilters">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"limit">>, ?NON_DEFAULT_LIMIT},
+              {<<"filterNamePrefix">>, ?FILTER_NAME_PREFIX},
+              {<<"metricName">>, ?METRIC_NAME},
+              {<<"metricNamespace">>, ?METRIC_NAMESPACE},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME}]}
+        ),
+        ?_cloudwatch_test(
+            {"Tests describing metric filters with custom AWS config, "
+             "log group name, limit, filter name prefix, metric name, "
+             "metric namespace and pagination token provided",
+             ?_f(erlcloud_cloudwatch_logs:describe_metric_filters(
+                 ?LOG_GROUP_NAME,
+                 ?NON_DEFAULT_LIMIT,
+                 ?FILTER_NAME_PREFIX,
+                 ?METRIC_NAME,
+                 ?METRIC_NAMESPACE,
+                 ?PAGING_TOKEN,
+                 erlcloud_aws:default_config()
+             )),
+             [{<<"Action">>, <<"DescribeMetricFilters">>},
+              {<<"Version">>, ?API_VERSION},
+              {<<"limit">>, ?NON_DEFAULT_LIMIT},
+              {<<"filterNamePrefix">>, ?FILTER_NAME_PREFIX},
+              {<<"metricName">>, ?METRIC_NAME},
+              {<<"metricNamespace">>, ?METRIC_NAMESPACE},
+              {<<"nextToken">>, ?PAGING_TOKEN},
+              {<<"logGroupName">>, ?LOG_GROUP_NAME}]}
+        )
+    ]).
+
 describe_log_groups_output_tests(_) ->
     output_tests(?_f(erlcloud_cloudwatch_logs:describe_log_groups()), [
         ?_cloudwatch_test(
@@ -181,6 +312,15 @@ describe_log_groups_output_tests(_) ->
         )
     ]).
 
+
+describe_metric_filters_output_tests(_) ->
+    output_tests(?_f(erlcloud_cloudwatch_logs:describe_metric_filters()), [
+        ?_cloudwatch_test(
+            {"Tests describing all metric filters",
+             jsx:encode([{<<"metricFilters">>, [?METRIC_FILTER]}]),
+             {ok, [?METRIC_FILTER], undefined}}
+        )
+    ]).
 
 describe_log_streams_input_tests(_) ->
     input_tests(jsx:encode([{<<"logStreams">>, []}]), [

--- a/test/erlcloud_mon_tests.erl
+++ b/test/erlcloud_mon_tests.erl
@@ -1,0 +1,176 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+-module(erlcloud_mon_tests).
+
+
+-include_lib("eunit/include/eunit.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
+
+-define(_mon_test(T), {?LINE, T}).
+
+-define(_f(F), fun() -> F end).
+
+%%==============================================================================
+%% Test entry points
+%%==============================================================================
+
+describe_mon_test_() ->
+    {foreach, fun start/0, fun stop/1, [
+        fun describe_alarms_for_metric_input_tests/1,
+        fun describe_alarms_for_metric_output_tests/1
+    ]}.
+
+start() ->
+    meck:new(erlcloud_aws),
+    ok.
+
+stop(_) ->
+    meck:unload(erlcloud_aws).
+
+%%==============================================================================
+%% Output Test helpers
+%%==============================================================================
+
+output_test(Fun, {Line, {Description, Response, Result}}) ->
+    {Description, {Line, fun() ->
+                        meck:expect(erlcloud_aws, aws_request_xml4, 8,
+                               {ok, element(1, xmerl_scan:string(
+                                    binary_to_list(Response)))}
+                            ),
+                        Actual = Fun(),
+                        ?assertEqual(Result, Actual)
+                    end}}.
+
+
+%%==============================================================================
+%% Input Test helpers
+%%==============================================================================
+
+validate_param(_Param = {Key, _Value}, Params) ->
+    ?assertEqual(true, proplists:is_defined(Key, Params)).
+
+validate_params(Params, Expected) ->
+    [validate_param(X, Params)
+        || X <- [{"Action", ""}, {"Version", ""} | Expected]
+
+    ].
+input_expect(Response, Params) ->
+
+    fun(get, undefined, "monitoring.amazonaws.com", undefined, "/", QParams,
+            "monitoring", _) ->
+        validate_params(QParams, Params),
+        Response
+    end.
+
+input_test(Response, {Line, {Description, Fun, Params}})
+    when is_list(Description) ->
+
+    InputFunction = input_expect(Response, Params),
+
+    meck:expect(erlcloud_aws, aws_request_xml4, InputFunction),
+
+    {Description, {Line, fun() ->
+            Fun()
+        end}}.
+
+
+%%==============================================================================
+%% Input Tests
+%%==============================================================================
+
+describe_alarms_for_metric_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<DescribeAlarmsForMetricResponse>"
+            "</DescribeAlarmsForMetricResponse>">>)
+    ))},
+
+    ExpectedParams = [
+        {"Namespace", ""},
+        {"MetricName", ""},
+        {"Dimensions.member.1.Name", ""},
+        {"Dimensions.member.1.Value", ""},
+        {"ExtendedStatistic", ""},
+        {"Period", ""},
+        {"Statistic", ""},
+        {"Unit", ""}
+    ],
+
+    input_test(Response, ?_mon_test(
+        {"Test describe alarms for metric",
+        ?_f(erlcloud_mon:describe_alarms_for_metric(
+            "AWS/EC2", "NetworkIn", [{"InstanceType","m1.large"}], "p95",
+            17, "Average", "Seconds",
+            #aws_config{})), ExpectedParams})).
+
+
+%%==============================================================================
+%% Output Tests
+%%==============================================================================
+
+describe_alarms_for_metric_output_tests(_) ->
+
+    Test = ?_mon_test({"Test describe alarms for metric",
+            <<"<DescribeAlarmsForMetricResponse xmlns="
+            "\"http://monitoring.amazonaws.com/doc/2010-08-01/\">
+                    <DescribeAlarmsForMetricResult>
+                        <MetricAlarms>
+                        <member>
+                            <MetricName>rgallego_unauthorized_metric</MetricName>
+                            <AlarmConfigurationUpdatedTimestamp>2018-02-07T17:38:24.224Z</AlarmConfigurationUpdatedTimestamp>
+                            <StateValue>ALARM</StateValue>
+                            <Threshold>1.0</Threshold>
+                            <StateReason>Threshold Crossed: 1 datapoint [2.0 (07/02/18 17:33:00)] was greater than or equal to the threshold (1.0).</StateReason>
+                            <InsufficientDataActions/>
+                            <AlarmActions>
+                            <member>arn:aws:sns:us-east-1:123456794008:rgallego_cloudtrail_sns_topic</member>
+                            </AlarmActions>
+                            <StateUpdatedTimestamp>2018-02-07T17:38:24.952Z</StateUpdatedTimestamp>
+                            <Period>300</Period>
+                            <Statistic>Sum</Statistic>
+                            <ComparisonOperator>GreaterThanOrEqualToThreshold</ComparisonOperator>
+                            <AlarmName>rgallego_unauthorized_alarm</AlarmName>
+                            <EvaluationPeriods>1</EvaluationPeriods>
+                            <StateReasonData>{\"version\":\"1.0\",\"queryDate\":\"2018-02-07T17:38:24.953+0000\",\"startDate\":\"2018-02-07T17:33:00.000+0000\",\"statistic\":\"Sum\",\"period\":300,\"recentDatapoints\":[2.0],\"threshold\":1.0}</StateReasonData>
+                            <ActionsEnabled>true</ActionsEnabled>
+                            <Namespace>CISBenchmark</Namespace>
+                            <OKActions/>
+                            <AlarmArn>arn:aws:cloudwatch:us-east-1:123456794008:alarm:rgallego_unauthorized_alarm</AlarmArn>
+                            <Dimensions/>
+                        </member>
+                        </MetricAlarms>
+                    </DescribeAlarmsForMetricResult>
+                    <ResponseMetadata>
+                        <RequestId>0e8470e6-1032-11e8-b27b-7db55194b86f</RequestId>
+                    </ResponseMetadata>
+                </DescribeAlarmsForMetricResponse>">>,
+            [[{metric_name,"rgallego_unauthorized_metric"},
+                {namespace,"CISBenchmark"},
+                {dimensions,[]},
+                {actions_enabled,true},
+                {alarm_actions,[{arn,"arn:aws:sns:us-east-1:123456794008:rgallego_cloudtrail_sns_topic"}]},
+                {alarm_arn,"arn:aws:cloudwatch:us-east-1:123456794008:alarm:rgallego_unauthorized_alarm"},
+                {alarm_configuration_updated_timestamp,{{2018,2,7},
+                                                        {17,38,24}}},
+                {alarm_description,[]},
+                {alarm_name,"rgallego_unauthorized_alarm"},
+                {comparison_operator,"GreaterThanOrEqualToThreshold"},
+                {evaluate_low_sample_count_percentile,[]},
+                {evaluation_periods,1},
+                {extended_statistic,[]},
+                {insufficient_data_actions,[]},
+                {ok_actions,[]},
+                {period,300},
+                {state_reason,"Threshold Crossed: 1 datapoint [2.0 (07/02/18 17:33:00)] was greater than or equal to the threshold (1.0)."},
+                {state_reason_data,"{\"version\":\"1.0\",\"queryDate\":\"2018-02-07T17:38:24.953+0000\",\"startDate\":\"2018-02-07T17:33:00.000+0000\",\"statistic\":\"Sum\",\"period\":300,\"recentDatapoints\":[2.0],\"threshold\":1.0}"},
+                {state_updated_timestamp,{{2018,2,7},{17,38,24}}},
+                {state_value,"ALARM"},
+                {statistic,"Sum"},
+                {threshold,1.0},
+                {treat_missing_data,[]},
+                {unit,[]}]]
+        }),
+
+    output_test(?_f(erlcloud_mon:describe_alarms_for_metric(
+                "AWS/EC2", "NetworkIn", [{"InstanceType","m1.large"}], "p95",
+                17, "Average", "Seconds", #aws_config{}
+            )), Test).


### PR DESCRIPTION
 - Support for `describe_alarms_for_metric`  function. Ref: [DescribeAlarmsForMetric](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarmsForMetric.html)
 - Support for `describe_metric_filters` function. Ref: [DescribeMetricFilters](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeMetricFilters.html)