### PR TITLE
erlcloud_ddb_streams: add approximate_creation_date_time to #ddb_streams_stream_record{}

### DIFF
--- a/include/erlcloud_ddb_streams.hrl
+++ b/include/erlcloud_ddb_streams.hrl
@@ -23,7 +23,8 @@
          table_name :: undefined | erlcloud_ddb_streams:table_name()
         }).
 -record(ddb_streams_stream_record,
-        {keys :: undefined | erlcloud_ddb_streams:key(),
+        {approximate_creation_date_time :: undefined | number(),
+         keys :: undefined | erlcloud_ddb_streams:key(),
          new_image :: undefined | erlcloud_ddb_streams:item(),
          old_image :: undefined | erlcloud_ddb_streams:item(),
          sequence_number :: undefined | erlcloud_ddb_streams:sequence_number(),

--- a/src/erlcloud_ddb_streams.erl
+++ b/src/erlcloud_ddb_streams.erl
@@ -467,7 +467,8 @@ stream_description_record() ->
 -spec stream_record_record() -> record_desc().
 stream_record_record() ->
     {#ddb_streams_stream_record{},
-     [{<<"Keys">>, #ddb_streams_stream_record.keys, fun undynamize_key/2},
+     [{<<"ApproximateCreationDateTime">>, #ddb_streams_stream_record.approximate_creation_date_time, fun id/2},
+      {<<"Keys">>, #ddb_streams_stream_record.keys, fun undynamize_key/2},
       {<<"NewImage">>, #ddb_streams_stream_record.new_image, fun undynamize_item/2},
       {<<"OldImage">>, #ddb_streams_stream_record.old_image, fun undynamize_item/2},
       {<<"SequenceNumber">>, #ddb_streams_stream_record.sequence_number, fun id/2},

--- a/test/erlcloud_ddb_streams_tests.erl
+++ b/test/erlcloud_ddb_streams_tests.erl
@@ -369,6 +369,7 @@ get_records_output_tests(_) ->
         {
             \"awsRegion\": \"us-west-2\",
             \"dynamodb\": {
+                \"ApproximateCreationDateTime\": 1551727994,
                 \"Keys\": {
                     \"ForumName\": {\"S\": \"DynamoDB\"},
                     \"Subject\": {\"S\": \"DynamoDB Thread 3\"}
@@ -385,6 +386,7 @@ get_records_output_tests(_) ->
         {
             \"awsRegion\": \"us-west-2\",
             \"dynamodb\": {
+                \"ApproximateCreationDateTime\": 1551727994,
                 \"Keys\": {
                     \"ForumName\": {\"S\": \"DynamoDB\"},
                     \"Subject\": {\"S\": \"DynamoDB Thread 1\"}
@@ -401,6 +403,7 @@ get_records_output_tests(_) ->
         {
             \"awsRegion\": \"us-west-2\",
             \"dynamodb\": {
+                \"ApproximateCreationDateTime\": 1551727994,
                 \"Keys\": {
                     \"ForumName\": {\"S\": \"DynamoDB\"},
                     \"Subject\": {\"S\": \"DynamoDB Thread 2\"}
@@ -419,6 +422,7 @@ get_records_output_tests(_) ->
              {ok, [#ddb_streams_record{
                        aws_region = <<"us-west-2">>,
                        dynamodb = #ddb_streams_stream_record{
+                                      approximate_creation_date_time = 1551727994,
                                       keys = [{<<"ForumName">>, <<"DynamoDB">>},
                                               {<<"Subject">>, <<"DynamoDB Thread 3">>}],
                                       new_image = undefined,
@@ -433,6 +437,7 @@ get_records_output_tests(_) ->
                    #ddb_streams_record{
                        aws_region = <<"us-west-2">>,
                        dynamodb = #ddb_streams_stream_record{
+                                      approximate_creation_date_time = 1551727994,
                                       keys = [{<<"ForumName">>, <<"DynamoDB">>},
                                               {<<"Subject">>, <<"DynamoDB Thread 1">>}],
                                       new_image = undefined,
@@ -447,6 +452,7 @@ get_records_output_tests(_) ->
                    #ddb_streams_record{
                        aws_region = <<"us-west-2">>,
                        dynamodb = #ddb_streams_stream_record{
+                                      approximate_creation_date_time = 1551727994,
                                       keys = [{<<"ForumName">>, <<"DynamoDB">>},
                                               {<<"Subject">>, <<"DynamoDB Thread 2">>}],
                                       new_image = undefined,


### PR DESCRIPTION
Adds [ApproximateCreationDateTime](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_StreamRecord.html#DDB-Type-streams_StreamRecord-ApproximateCreationDateTime) field to `erlcloud_ddb_streams:get_records` function output.