### PR TITLE
Retry lambda call in case of x-amz-function-error exists

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -137,6 +137,11 @@
           %% If you provide a custom function be aware of this anticipated change.
           %% See erlcloud_retry for full documentation.
           retry=fun erlcloud_retry:no_retry/1::erlcloud_retry:retry_fun(),
+
+          %% By default treat all non 2xx http error codes as errors.
+          %% But in some cases, like lambda call it useful to override such
+          %% behaviour by custom one.
+          response_type=fun erlcloud_retry:only_http_errors/1::erlcloud_retry:response_type_fun(),
           %% Currently matches DynamoDB retry
           %% It's likely this is too many retries for other services
           retry_num=10::non_neg_integer(),

--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -141,7 +141,7 @@
           %% By default treat all non 2xx http error codes as errors.
           %% But in some cases, like lambda call it useful to override such
           %% behaviour by custom one.
-          response_type=fun erlcloud_retry:only_http_errors/1::erlcloud_retry:response_type_fun(),
+          retry_response_type=fun erlcloud_retry:only_http_errors/1::erlcloud_retry:response_type_fun(),
           %% Currently matches DynamoDB retry
           %% It's likely this is too many retries for other services
           retry_num=10::non_neg_integer(),

--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -18,7 +18,12 @@
                   %% hackney,
                   lhttpc]},
   {modules, []},
-  {env, []},
+  {env, [
+      %% AWS Lambda may response 200 with additional headers in case of errors.
+      %% Set flag to true to use retry logic for such cases
+      %% @see https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html
+      {retry_x_amz_function_error, false}
+  ]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/erlcloud/erlcloud"}]},
   {maintainers, []}

--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -18,12 +18,7 @@
                   %% hackney,
                   lhttpc]},
   {modules, []},
-  {env, [
-      %% AWS Lambda may response 200 with additional headers in case of errors.
-      %% Set flag to true to use retry logic for such cases
-      %% @see https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html
-      {retry_x_amz_function_error, false}
-  ]},
+  {env, []},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/erlcloud/erlcloud"}]},
   {maintainers, []}

--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -72,7 +72,7 @@ request_and_retry(Config, ResultFun, {retry, Request}, MaxAttempts) ->
         {ok, {{Status, StatusLine}, ResponseHeaders, ResponseBody}} ->
             ResponseType = case Status >= 200 andalso Status < 300 of
                 true ->
-                    {ok, RetryFunctionErrors} = application:get_env(erlcloud, retry_x_amz_function_error),
+                    RetryFunctionErrors = application:get_env(erlcloud, retry_x_amz_function_error, false),
                     case RetryFunctionErrors andalso lists:keymember("x-amz-function-error", 1, ResponseHeaders) of
                         true -> error;
                         false -> ok

--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -23,7 +23,7 @@
          default_retry/1,
 
          only_http_errors/1,
-         aws_api_errors/1
+         lambda_fun_errors/1
         ]).
 -export_type([should_retry/0, retry_fun/0, response_type_fun/0]).
 
@@ -64,8 +64,8 @@ only_http_errors(#aws_request{response_status=Status})
 only_http_errors(_) ->
     error.
 
--spec aws_api_errors(#aws_request{}) -> ok | error.
-aws_api_errors(#aws_request{response_status=Status, response_headers=ResponseHeaders})
+-spec lambda_fun_errors(#aws_request{}) -> ok | error.
+lambda_fun_errors(#aws_request{response_status=Status, response_headers=ResponseHeaders})
   when Status >= 200, Status < 300
        ->
     case lists:keymember("x-amz-function-error", 1, ResponseHeaders) of
@@ -74,7 +74,7 @@ aws_api_errors(#aws_request{response_status=Status, response_headers=ResponseHea
         false ->
             ok
     end;
-aws_api_errors(_) ->
+lambda_fun_errors(_) ->
     error.
 
 request_and_retry(_, _, {_, Request}, 0) ->

--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -91,7 +91,7 @@ request_and_retry(Config, ResultFun, {retry, Request}, MaxAttempts) ->
       } = Request,
     Request2 = Request#aws_request{attempt = Attempt + 1},
     RetryFun = Config#aws_config.retry,
-    ResponseTypeFun = Config#aws_config.response_type,
+    ResponseTypeFun = Config#aws_config.retry_response_type,
     Rsp = erlcloud_httpc:request(URI, Method, Headers, Body,
         erlcloud_aws:get_timeout(Config), Config),
     case Rsp of


### PR DESCRIPTION
AWS lambda may return 200 and error headers instead of 5xx (for example in case of OOM or internal crash). Some times it's necessary to retry such requests.

see https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html
