### PR TITLE
Implement get_queue_url function

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -12,6 +12,7 @@
          delete_message/2, delete_message/3,
          delete_queue/1, delete_queue/2,
          purge_queue/1, purge_queue/2,
+         get_queue_url/1, get_queue_url/2,
          get_queue_attributes/1, get_queue_attributes/2, get_queue_attributes/3,
          list_queues/0, list_queues/1, list_queues/2,
          receive_message/1, receive_message/2, receive_message/3, receive_message/4,
@@ -185,6 +186,20 @@ purge_queue(QueueName) ->
 purge_queue(QueueName, Config)
   when is_list(QueueName), is_record(Config, aws_config) ->
     sqs_simple_request(Config, QueueName, "PurgeQueue", []).
+
+-spec get_queue_url(string()) -> proplist() | no_return().
+get_queue_url(QueueName) ->
+    get_queue_url(QueueName, default_config()).
+
+-spec get_queue_url(string(), aws_config()) -> proplist() | no_return().
+get_queue_url(QueueName, Config) ->
+    Doc = sqs_xml_request(Config, "/", "GetQueueUrl", [{"QueueName", QueueName}]),
+    erlcloud_xml:decode(
+        [
+            {queue_url, "GetQueueUrlResult/QueueUrl", text}
+        ],
+        Doc
+    ).
 
 -spec get_queue_attributes(string()) -> proplist() | no_return().
 get_queue_attributes(QueueName) ->

--- a/test/erlcloud_sqs_tests.erl
+++ b/test/erlcloud_sqs_tests.erl
@@ -18,6 +18,7 @@ erlcloud_api_test_() ->
      fun stop/1,
      [
       fun set_queue_attributes/1,
+      fun get_queue_url/1,
       fun send_message_with_message_opts/1,
       fun send_message_with_message_attributes/1,
       fun receive_messages_with_message_attributes/1,
@@ -160,6 +161,27 @@ set_queue_attributes(_) ->
       <RequestId>40945605-b328-53b5-aed4-1cc24a7240e8</RequestId>
    </ResponseMetadata>
 </SetQueueAttributesResponse>",
+    input_tests(Response, Tests).
+
+get_queue_url(_) ->
+    Expected = [
+        {"Action", "GetQueueUrl"},
+        {"QueueName", "Queue"}
+    ],
+    Tests =
+        [?_sqs_test(
+            {"Test queue URL getting.",
+             ?_f(erlcloud_sqs:get_queue_url("Queue")),
+             Expected})],
+    Response = "
+<GetQueueUrlResponse>
+    <GetQueueUrlResult>
+        <QueueUrl>https://sqs.us-east-2.amazonaws.com/123456789012/Queue</QueueUrl>
+    </GetQueueUrlResult>
+    <ResponseMetadata>
+        <RequestId>470a6f13-2ed9-4181-ad8a-2fdea142988e</RequestId>
+    </ResponseMetadata>
+</GetQueueUrlResponse>",
     input_tests(Response, Tests).
 
 send_message_with_message_opts(_) ->


### PR DESCRIPTION
[SQS docs][] say us to always use URL instead of queue name:

> In your system, always store the entire queue URL exactly as Amazon SQS returns it to you when you create the queue (for example, https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue). Don't build the queue URL from its separate components each time you need to specify the queue URL in a request because Amazon SQS can change the components that make up the queue URL.

[SQS docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-general-identifiers.html#queue-name-url