### PR TITLE
Add erlcloud_kinesis:list_shards/1|2|3

### DIFF
--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -7,6 +7,7 @@
 
 -export([create_stream/2, create_stream/3,
          delete_stream/1, delete_stream/2,
+         list_shards/1, list_shards/2, list_shards/3,
          list_streams/0, list_streams/1, list_streams/2, list_streams/3,
          describe_stream/1, describe_stream/2, describe_stream/3, describe_stream/4,
          describe_stream_summary/1, describe_stream_summary/2,
@@ -29,6 +30,11 @@
 -include("erlcloud_aws.hrl").
 
 -type get_records_limit() :: 1..10000.
+
+-type exclusive_start_shard_id_opt() :: {exclusive_start_shard_id, string()}.
+-type max_results_opt() :: {max_results, non_neg_integer()}.
+-type next_token_opt() :: {next_token, string()}.
+-type stream_creation_timestamp_opt() :: {stream_creation_timestamp, integer()}.
 
 -spec new(string(), string()) -> aws_config().
 
@@ -71,6 +77,20 @@ configure(AccessKeyID, SecretAccessKey, Host, Port) ->
     erlcloud_config:configure(AccessKeyID, SecretAccessKey, Host, Port, fun new/4).
 
 default_config() -> erlcloud_aws:default_config().
+
+dynamize_option({exclusive_start_shard_id, Value}) ->
+    {<<"ExclusiveStartShardId">>, Value};
+dynamize_option({max_results, Value}) when Value >= 1, Value =< 10000 ->
+    {<<"MaxResults">>, Value};
+dynamize_option({next_token, Value}) ->
+    {<<"NextToken">>, Value};
+dynamize_option({stream_creation_timestamp, Value}) ->
+    {<<"StreamCreationTimestamp">>, Value};
+dynamize_option(Option) ->
+    error({erlcloud_kinesis, {invalid_option, Option}}).
+
+dynamize_options(Options) ->
+    [dynamize_option(Option) || Option <- Options].
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -129,6 +149,101 @@ delete_stream(StreamName) ->
 delete_stream(StreamName, Config) when is_record(Config, aws_config) ->
    Json = [{<<"StreamName">>, StreamName}],
    erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DeleteStream", Json).
+
+
+-type list_shards_opts() :: [
+    exclusive_start_shard_id_opt() |
+    max_results_opt() |
+    next_token_opt() |
+    stream_creation_timestamp_opt()
+].
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Kinesis API:
+%% [https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html]
+%%
+%% ===Example===
+%%
+%% This operation returns the following information about the stream: an array of shard objects that comprise the stream.
+%%
+%% `
+%% erlcloud_kinesis:list_shards(<<"staging">>).
+%% {ok, [
+%%     {<<"NextToken">>, <<"AAAAAAAAAAGK9EEG0sJqVhCUS2JsgigQ5dcpB4q9PYswrH2oK44Skbjtm+WR0xA7/hrAFFsohevH1/OyPnbzKBS1byPyCZuVcokYtQe/b1m4c0SCI7jctPT0oUTLRdwSRirKm9dp9YC/EL+kZHOvYAUnztVGsOAPEFC3ECf/bVC927bDZBbRRzy/44OHfWmrCLcbcWqehRh5D14WnL3yLsumhiHDkyuxSlkBepauvMnNLtTOlRtmQ5Q5reoujfq2gzeCSOtLcfXgBMztJqohPdgMzjTQSbwB9Am8rMpHLsDbSdMNXmITvw==">>},
+%%     {<<"Shards">>, [
+%%         [
+%%             {<<"ShardId">>, <<"shardId-000000000001">>},
+%%             {<<"HashKeyRange">>, [
+%%                 {<<"EndingHashKey">>, <<"68056473384187692692674921486353642280">>},
+%%                 {<<"StartingHashKey">>, <<"34028236692093846346337460743176821145">>}
+%%             ]},
+%%             {<<"SequenceNumberRange">>, [
+%%                 {<<"StartingSequenceNumber">>, <<"49579844037727333356165064238440708846556371693205002258">>}
+%%             ]}
+%%         ], [
+%%             {<<"ShardId">>, <<"shardId-000000000002">>},
+%%             {<<"HashKeyRange">>, [
+%%                 {<<"EndingHashKey">>, <<"102084710076281539039012382229530463436">>},
+%%                 {<<"StartingHashKey">>, <<"68056473384187692692674921486353642281">>}
+%%             ]},
+%%             {<<"SequenceNumberRange">>, [
+%%                 {<<"StartingSequenceNumber">>, <<"49579844037749634101363594861582244564829020124710982690">>}
+%%             ]}
+%%         ], [
+%%             {<<"ShardId">>, <<"shardId-000000000003">>},
+%%             {<<"HashKeyRange">>, [
+%%                 {<<"EndingHashKey">>, <<"136112946768375385385349842972707284581">>},
+%%                 {<<"StartingHashKey">>, <<"102084710076281539039012382229530463437">>}
+%%             ]},
+%%             {<<"SequenceNumberRange">>, [
+%%                 {<<"StartingSequenceNumber">>, <<"49579844037771934846562125484723780283101668556216963122">>}
+%%             ]}
+%%         ]
+%%    ]}
+%% ]}
+%% '
+%%
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec list_shards(binary()) -> erlcloud_kinesis_impl:json_return().
+list_shards(StreamName) ->
+   list_shards(StreamName, default_config()).
+
+-spec list_shards(binary(), list_shards_opts() | aws_config()) -> erlcloud_kinesis_impl:json_return().
+list_shards(StreamName, Config) when is_record(Config, aws_config) ->
+    list_shards(StreamName, [], Config);
+list_shards(StreamName, Options) ->
+    list_shards(StreamName, Options, default_config()).
+
+-spec list_shards(binary(), list_shards_opts(), aws_config()) -> erlcloud_kinesis_impl:json_return().
+list_shards(StreamName, Options, Config) when is_record(Config, aws_config) ->
+    case lists:keymember(next_token, 1, Options) of
+        false ->
+            ok;
+        true ->
+            case lists:keymember(stream_creation_timestamp, 1, Options) of
+                false ->
+                    ok;
+                true ->
+                    error({erlcloud_kinesis, {incompatible_options, [
+                        next_token,
+                        stream_creation_timestamp
+                    ]}})
+            end,
+            case lists:keymember(exclusive_start_shard_id, 1, Options) of
+                false ->
+                    ok;
+                true ->
+                    error({erlcloud_kinesis, {incompatible_options, [
+                        next_token,
+                        exclusive_start_shard_id
+                    ]}})
+            end
+    end,
+    Json = [{<<"StreamName">>, StreamName} | dynamize_options(Options)],
+    erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.ListShards", Json).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -234,15 +349,15 @@ describe_stream(StreamName, Limit, Config)
        Limit >= 1, Limit =< 10000 ->
     Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}],
     erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json);
-describe_stream(StreamName, Limit, ExcludeShard) ->
-    describe_stream(StreamName, Limit, ExcludeShard, default_config()).
+describe_stream(StreamName, Limit, ExclusiveStartShardId) ->
+    describe_stream(StreamName, Limit, ExclusiveStartShardId, default_config()).
 
 -spec describe_stream(binary(), get_records_limit(), string(), aws_config()) -> erlcloud_kinesis_impl:json_return().
-describe_stream(StreamName, Limit, ExcludeShard, Config)
+describe_stream(StreamName, Limit, ExclusiveStartShardId, Config)
   when is_record(Config, aws_config),
        is_integer(Limit),
        Limit >= 1, Limit =< 10000 ->
-    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}, {<<"ExclusiveStartShardId">>, ExcludeShard}],
+    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}, {<<"ExclusiveStartShardId">>, ExclusiveStartShardId}],
     erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json).
 
 

--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -78,6 +78,8 @@ configure(AccessKeyID, SecretAccessKey, Host, Port) ->
 
 default_config() -> erlcloud_aws:default_config().
 
+dynamize_option({stream_name, Value}) ->
+    {<<"StreamName">>, Value};
 dynamize_option({exclusive_start_shard_id, Value}) ->
     {<<"ExclusiveStartShardId">>, Value};
 dynamize_option({max_results, Value}) when Value >= 1, Value =< 10000 ->
@@ -235,14 +237,10 @@ list_shards(StreamName, Options) ->
     list_shards(StreamName, Options, default_config()).
 
 -spec list_shards(binary(), list_shards_opts(), aws_config()) -> erlcloud_kinesis_impl:json_return().
-list_shards(StreamName, Options, Config) when is_record(Config, aws_config) ->
-    case dynamize_options(Options) of
-        DynamizedOptions when is_list(DynamizedOptions) ->
-            Json = [{<<"StreamName">>, StreamName} | DynamizedOptions],
-            erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.ListShards", Json);
-        Error ->
-            Error
-    end.
+list_shards(StreamName, Options, Config) ->
+    % Syntaxtic sugar as all other erlcloud_kinesis operating on a stream takes
+    % a stream name as 1st argument.
+    list_shards([{stream_name, StreamName} | Options], Config).
 
 
 %%------------------------------------------------------------------------------

--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -204,7 +204,7 @@ delete_stream(StreamName, Config) when is_record(Config, aws_config) ->
 %%             {<<"ShardId">>, <<"shardId-000000000003">>},
 %%             {<<"HashKeyRange">>, [
 %%                 {<<"EndingHashKey">>, <<"136112946768375385385349842972707284581">>},
-%%                 {<<"StartingHashKey">>, <<"102084710076281539039012382229530463437">>}
+%%                 {<<"StartingHashKey">>, <<"102084710022876281539039012382229530463437">>}
 %%             ]},
 %%             {<<"SequenceNumberRange">>, [
 %%                 {<<"StartingSequenceNumber">>, <<"49579844037771934846562125484723780283101668556216963122">>}
@@ -225,8 +225,12 @@ list_shards(StreamNameOrOptions) ->
 list_shards(StreamName, Config) when is_record(Config, aws_config), is_binary(StreamName) ->
     list_shards(StreamName, [], Config);
 list_shards(Options, Config) when is_record(Config, aws_config), is_list(Options) ->
-    Json = dynamize_options(Options),
-    erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.ListShards", Json);
+    case dynamize_options(Options) of
+        DynamizedOptions when is_list(DynamizedOptions) ->
+            erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.ListShards", DynamizedOptions);
+        Error ->
+            Error
+    end;
 list_shards(StreamName, Options) ->
     list_shards(StreamName, Options, default_config()).
 

--- a/test/erlcloud_kinesis_tests.erl
+++ b/test/erlcloud_kinesis_tests.erl
@@ -33,6 +33,8 @@ operation_test_() ->
       fun create_stream_output_tests/1,
       fun delete_stream_input_tests/1,
       fun delete_stream_output_tests/1,
+      fun list_shards_input_tests/1,
+      fun list_shards_output_tests/1,
       fun list_streams_input_tests/1,
       fun list_streams_output_tests/1,
       fun describe_stream_input_tests/1,
@@ -222,6 +224,132 @@ delete_stream_output_tests(_) ->
         ],
 
     output_tests(?_f(erlcloud_kinesis:delete_stream(<<"streamName">>)), Tests).
+
+%% ListStreams test based on the API examples:
+%% http://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html
+list_shards_input_tests(_) ->
+    Tests =
+        [?_kinesis_test(
+            {"ListShards example request",
+             ?_f(erlcloud_kinesis:list_shards(<<"exampleStreamName">>, [{max_results, 3}])), "{
+                \"StreamName\" : \"exampleStreamName\",
+                \"MaxResults\" : 3
+             }"
+            })
+        ],
+
+    Response = "{
+        \"NextToken\": \"AAAAAAAAAAGK9EEG0sJqVhCUS2JsgigQ5dcpB4q9PYswrH2oK44Skbjtm+WR0xA7/hrAFFsohevH1/OyPnbzKBS1byPyCZuVcokYtQe/b1m4c0SCI7jctPT0oUTLRdwSRirKm9dp9YC/EL+kZHOvYAUnztVGsOAPEFC3ECf/bVC927bDZBbRRzy/44OHfWmrCLcbcWqehRh5D14WnL3yLsumhiHDkyuxSlkBepauvMnNLtTOlRtmQ5Q5reoujfq2gzeCSOtLcfXgBMztJqohPdgMzjTQSbwB9Am8rMpHLsDbSdMNXmITvw==\",
+        \"Shards\": [
+            {
+                \"ShardId\": \"shardId-000000000001\",
+                \"HashKeyRange\": {
+                    \"EndingHashKey\": \"68056473384187692692674921486353642280\",
+                    \"StartingHashKey\": \"34028236692093846346337460743176821145\"
+                },
+                \"SequenceNumberRange\": {
+                    \"StartingSequenceNumber\": \"49579844037727333356165064238440708846556371693205002258\"
+                }
+            },
+            {
+                \"ShardId\": \"shardId-000000000002\",
+                \"HashKeyRange\": {
+                    \"EndingHashKey\": \"102084710076281539039012382229530463436\",
+                    \"StartingHashKey\": \"68056473384187692692674921486353642281\"
+                },
+                \"SequenceNumberRange\": {
+                    \"StartingSequenceNumber\": \"49579844037749634101363594861582244564829020124710982690\"
+                }
+            },
+            {
+                \"ShardId\": \"shardId-000000000003\",
+                \"HashKeyRange\": {
+                    \"EndingHashKey\": \"136112946768375385385349842972707284581\",
+                    \"StartingHashKey\": \"102084710076281539039012382229530463437\"
+                },
+                \"SequenceNumberRange\": {
+                    \"StartingSequenceNumber\": \"49579844037771934846562125484723780283101668556216963122\"
+                }
+            }
+        ]
+    }",
+    input_tests(Response, Tests).
+
+list_shards_output_tests(_) ->
+    Tests =
+        [?_kinesis_test(
+            {"ListShards example response", "{
+                \"NextToken\": \"AAAAAAAAAAGK9EEG0sJqVhCUS2JsgigQ5dcpB4q9PYswrH2oK44Skbjtm+WR0xA7/hrAFFsohevH1/OyPnbzKBS1byPyCZuVcokYtQe/b1m4c0SCI7jctPT0oUTLRdwSRirKm9dp9YC/EL+kZHOvYAUnztVGsOAPEFC3ECf/bVC927bDZBbRRzy/44OHfWmrCLcbcWqehRh5D14WnL3yLsumhiHDkyuxSlkBepauvMnNLtTOlRtmQ5Q5reoujfq2gzeCSOtLcfXgBMztJqohPdgMzjTQSbwB9Am8rMpHLsDbSdMNXmITvw==\",
+                \"Shards\": [
+                    {
+                        \"ShardId\": \"shardId-000000000001\",
+                        \"HashKeyRange\": {
+                            \"EndingHashKey\": \"68056473384187692692674921486353642280\",
+                            \"StartingHashKey\": \"34028236692093846346337460743176821145\"
+                        },
+                        \"SequenceNumberRange\": {
+                            \"StartingSequenceNumber\": \"49579844037727333356165064238440708846556371693205002258\"
+                        }
+                    },
+                    {
+                        \"ShardId\": \"shardId-000000000002\",
+                        \"HashKeyRange\": {
+                            \"EndingHashKey\": \"102084710076281539039012382229530463436\",
+                            \"StartingHashKey\": \"68056473384187692692674921486353642281\"
+                        },
+                        \"SequenceNumberRange\": {
+                            \"StartingSequenceNumber\": \"49579844037749634101363594861582244564829020124710982690\"
+                        }
+                    },
+                    {
+                        \"ShardId\": \"shardId-000000000003\",
+                        \"HashKeyRange\": {
+                            \"EndingHashKey\": \"136112946768375385385349842972707284581\",
+                            \"StartingHashKey\": \"102084710076281539039012382229530463437\"
+                        },
+                        \"SequenceNumberRange\": {
+                            \"StartingSequenceNumber\": \"49579844037771934846562125484723780283101668556216963122\"
+                        }
+                    }
+                ]
+             }",
+             {ok, [
+                 {<<"NextToken">>, <<"AAAAAAAAAAGK9EEG0sJqVhCUS2JsgigQ5dcpB4q9PYswrH2oK44Skbjtm+WR0xA7/hrAFFsohevH1/OyPnbzKBS1byPyCZuVcokYtQe/b1m4c0SCI7jctPT0oUTLRdwSRirKm9dp9YC/EL+kZHOvYAUnztVGsOAPEFC3ECf/bVC927bDZBbRRzy/44OHfWmrCLcbcWqehRh5D14WnL3yLsumhiHDkyuxSlkBepauvMnNLtTOlRtmQ5Q5reoujfq2gzeCSOtLcfXgBMztJqohPdgMzjTQSbwB9Am8rMpHLsDbSdMNXmITvw==">>},
+                 {<<"Shards">>, [
+                     [
+                         {<<"ShardId">>, <<"shardId-000000000001">>},
+                         {<<"HashKeyRange">>, [
+                             {<<"EndingHashKey">>, <<"68056473384187692692674921486353642280">>},
+                             {<<"StartingHashKey">>, <<"34028236692093846346337460743176821145">>}
+                         ]},
+                         {<<"SequenceNumberRange">>, [
+                             {<<"StartingSequenceNumber">>, <<"49579844037727333356165064238440708846556371693205002258">>}
+                         ]}
+                     ], [
+                         {<<"ShardId">>, <<"shardId-000000000002">>},
+                         {<<"HashKeyRange">>, [
+                             {<<"EndingHashKey">>, <<"102084710076281539039012382229530463436">>},
+                             {<<"StartingHashKey">>, <<"68056473384187692692674921486353642281">>}
+                         ]},
+                         {<<"SequenceNumberRange">>, [
+                             {<<"StartingSequenceNumber">>, <<"49579844037749634101363594861582244564829020124710982690">>}
+                         ]}
+                     ], [
+                         {<<"ShardId">>, <<"shardId-000000000003">>},
+                         {<<"HashKeyRange">>, [
+                             {<<"EndingHashKey">>, <<"136112946768375385385349842972707284581">>},
+                             {<<"StartingHashKey">>, <<"102084710076281539039012382229530463437">>}
+                         ]},
+                         {<<"SequenceNumberRange">>, [
+                             {<<"StartingSequenceNumber">>, <<"49579844037771934846562125484723780283101668556216963122">>}
+                         ]}
+                     ]
+                ]}
+             ]}
+            }
+        )],
+
+    output_tests(?_f(erlcloud_kinesis:list_shards(<<"staging">>)), Tests).
 
 %% ListStreams test based on the API examples:
 %% http://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListStreams.html


### PR DESCRIPTION
Problem to solve:

- new list_shards kinesis endpoint solves rate limitation of describe_stream, but is not exposed

Proposed solution:

- expose it
    - list_shards' api is a bit more complex than previous kinesis ones, and does not adapt easily to the approach used by erlcloud_kinesis:describe_stream (for example, one can list a large number of shards similarly to describe_stream, or use continuation token). Thus anything beside stream name and aws config is specified via an option proplists.