### PR TITLE
Adding the CustomVerificationTemplate API

### DIFF
--- a/src/erlcloud_ses.erl
+++ b/src/erlcloud_ses.erl
@@ -55,9 +55,8 @@
           list_custom_verification_email_templates/0,
           list_custom_verification_email_templates/1]).
 
-
--include("../include/erlcloud.hrl").
--include("../include/erlcloud_aws.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
 
 -define(API_VERSION, "2010-12-01").
 

--- a/src/erlcloud_ses.erl
+++ b/src/erlcloud_ses.erl
@@ -146,6 +146,7 @@ delete_identity(Identity, Config) ->
     end.
 
 %%%------------------------------------------------------------------------------
+%%%
 %%% Custom Verification Templates
 %%%
 %%% Template attributes:
@@ -158,6 +159,11 @@ delete_identity(Identity, Config) ->
 %%%
 %%% On template creation, all attributes are mandatory.
 %%% On template updates, only include the attributes you need to modify
+%%%
+%%%
+%%% Please consult: https://docs.aws.amazon.com/ses/latest/APIReference/API_GetCustomVerificationEmailTemplate.html
+%%% for a full reference to these APIs
+%%%
 %%%------------------------------------------------------------------------------
 
 -type custom_template_attribute_names() :: template_name | from_email_address | template_subject | template_content | success_redirect_url | failure_redirect_url .

--- a/src/erlcloud_ses.erl
+++ b/src/erlcloud_ses.erl
@@ -21,8 +21,13 @@
 -module(erlcloud_ses).
 
 -export([configure/2, configure/3, new/2, new/3]).
+-export([create_custom_verification_email_template/6, create_custom_verification_email_template/7]).
+
+-export([delete_custom_verification_email_template/1, delete_custom_verification_email_template/2]).
 
 -export([delete_identity/1, delete_identity/2]).
+
+-export([get_custom_verification_email_template/1, get_custom_verification_email_template/2]).
 
 -export([get_identity_dkim_attributes/1, get_identity_dkim_attributes/2]).
 -export([get_identity_notification_attributes/1, get_identity_notification_attributes/2]).
@@ -31,7 +36,11 @@
 -export([get_send_quota/0, get_send_quota/1]).
 -export([get_send_statistics/0, get_send_statistics/1]).
 
+-export([list_custom_verification_email_templates/0, list_custom_verification_email_templates/1]).
+
 -export([list_identities/0, list_identities/1, list_identities/2]).
+
+-export([send_custom_verification_email/2, send_custom_verification_email/3]).
 
 -export([send_email/4, send_email/5, send_email/6]).
 
@@ -39,16 +48,12 @@
 -export([set_identity_feedback_forwarding_enabled/2, set_identity_feedback_forwarding_enabled/3]).
 -export([set_identity_notification_topic/3, set_identity_notification_topic/4]).
 
+-export([update_custom_verification_email_template/2, update_custom_verification_email_template/3]).
+
 -export([verify_domain_dkim/1, verify_domain_dkim/2]).
 -export([verify_email_identity/1, verify_email_identity/2]).
 -export([verify_domain_identity/1, verify_domain_identity/2]).
 
--export([create_custom_verification_email_template/6, create_custom_verification_email_template/7]).
--export([update_custom_verification_email_template/2, update_custom_verification_email_template/3]).
--export([send_custom_verification_email/2, send_custom_verification_email/3]).
--export([delete_custom_verification_email_template/1, delete_custom_verification_email_template/2]).
--export([get_custom_verification_email_template/1, get_custom_verification_email_template/2]).
--export([list_custom_verification_email_templates/0, list_custom_verification_email_templates/1]).
 
 -include("erlcloud.hrl").
 -include("erlcloud_aws.hrl").
@@ -58,6 +63,9 @@
 %%%------------------------------------------------------------------------------
 %%% Common types
 %%%------------------------------------------------------------------------------
+
+-type custom_template_attribute_names() :: template_name | from_email_address | template_subject | template_content | success_redirect_url | failure_redirect_url .
+-type custom_template_attributes() :: [{custom_template_attribute_names(), string()}].
 
 -type identity() :: string() | binary().
 
@@ -73,15 +81,11 @@
 
 -type verification_status() :: pending | success | failed | temporary_failure | not_started.
 
--export_type([identity/0, identities/0,
+-export_type([custom_template_attribute_names/0, custom_template_attributes/0,
+              identity/0, identities/0,
               email/0, emails/0,
               domain/0,
               verification_status/0]).
-
--type custom_template_attribute_names() :: template_name | from_email_address | template_subject | template_content | success_redirect_url | failure_redirect_url .
--type custom_template_attributes() :: [{custom_template_attribute_names(), string()}].
-
--export_type([custom_template_attribute_names/0, custom_template_attributes/0]).
 
 %%%------------------------------------------------------------------------------
 %%% Library initialization

--- a/src/erlcloud_ses.erl
+++ b/src/erlcloud_ses.erl
@@ -145,26 +145,33 @@ delete_identity(Identity, Config) ->
         {error, Reason} -> {error, Reason}
     end.
 
-%%%------------------------------------------------------------------------------
-%%%
-%%% Custom Verification Templates
-%%%
-%%% Template attributes:
-%%%   { template_name , string() }
-%%%   { from_email_address , string() }
-%%%   { template_subject , string() }
-%%%   { template_content , string() }     -- please see notes in API Guide on what is allowed
-%%%   { success_redirect_url , string() }
-%%%   { failure_redirect_url , string() }
-%%%
-%%% On template creation, all attributes are mandatory.
-%%% On template updates, only include the attributes you need to modify
-%%%
-%%%
-%%% Please consult: https://docs.aws.amazon.com/ses/latest/APIReference/API_GetCustomVerificationEmailTemplate.html
-%%% for a full reference to these APIs
-%%%
-%%%------------------------------------------------------------------------------
+%%------------------------------------------------------------------------------
+%% @doc
+%% Custom Verification Templates
+%% SES API:
+%% [https://docs.aws.amazon.com/ses/latest/APIReference/API_GetCustomVerificationEmailTemplate.html]
+%%
+%% Template attributes:
+%%   { template_name , string() }
+%%   { from_email_address , string() }
+%%   { template_subject , string() }
+%%   { template_content , string() }     -- please see notes in API Guide on what is allowed
+%%   { success_redirect_url , string() }
+%%   { failure_redirect_url , string() }
+%%
+%% On template creation, all attributes are mandatory.
+%% On template updates, only include the attributes you need to modify
+%% When listing templates, all attributes are included except template_content, use the get function to retrieve it
+%%
+%%  create_custom_verification_email_template
+%%  update_custom_verification_email_template
+%%  send_custom_verification_email
+%%  delete_custom_verification_email_template
+%%  get_custom_verification_email_template
+%%  list_custom_verification_email_templates
+%%
+%% @end
+%%------------------------------------------------------------------------------
 
 -type custom_template_attribute_names() :: template_name | from_email_address | template_subject | template_content | success_redirect_url | failure_redirect_url .
 -type custom_template_attributes() :: [ { custom_template_attribute_names() , string() } ].

--- a/src/erlcloud_ses.erl
+++ b/src/erlcloud_ses.erl
@@ -110,6 +110,80 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
 
 default_config() -> erlcloud_aws:default_config().
 
+%%------------------------------------------------------------------------------
+%% @doc
+%% SES API:
+%% [https://docs.aws.amazon.com/ses/latest/APIReference/API_CreateCustomVerificationEmailTemplate.html]
+%%
+%% ===Example===
+%%
+%% Creates a new custom verification email template.
+%%
+%% `
+%%  ok = erlcloud_ses:create_custom_verification_email_template_result(
+%%          "templaneName",
+%%          "support@example.com",
+%%          "Welcome to support",
+%%          "limited html content",
+%%          "https://www.example.com/success",
+%%          "https://www.example.com/failure" ).
+%% '
+%%
+%% Please consult the following for what is and not allowed in the HTML content parameter
+%% [https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html#custom-verification-emails-faq]
+%% @end
+%%------------------------------------------------------------------------------
+
+-type create_custom_verification_email_template_result() :: ok | { error, term() }.
+
+-spec create_custom_verification_email_template( string(), string(), string(), string(), string(), string() ) -> create_custom_verification_email_template_result().
+create_custom_verification_email_template(TemplateName, FromEmailAddress, TemplateSubject, TemplateContent, SuccessRedirectionURL, FailureRedirectionURL) ->
+  create_custom_verification_email_template(TemplateName, FromEmailAddress, TemplateSubject, TemplateContent, SuccessRedirectionURL, FailureRedirectionURL ,default_config()).
+
+-spec create_custom_verification_email_template(string(), string(), string(), string(), string(), string(), aws_config()) ->
+  create_custom_verification_email_template_result().
+create_custom_verification_email_template(TemplateName, FromEmailAddress, TemplateSubject, TemplateContent, SuccessRedirectionURL, FailureRedirectionURL, Config) ->
+  Params = encode_params([{template_name, TemplateName},
+    {from_email_address, FromEmailAddress},
+    {template_subject, TemplateSubject},
+    {template_content, TemplateContent},
+    {success_redirect_url, SuccessRedirectionURL},
+    {failure_redirect_url, FailureRedirectionURL}]),
+  case ses_request(Config, "CreateCustomVerificationEmailTemplate", Params) of
+    {ok, _Doc} -> ok;
+    {error, Reason} -> {error, Reason}
+  end.
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% SES API:
+%% [https://docs.aws.amazon.com/ses/latest/APIReference/API_DeleteCustomVerificationEmailTemplate.html]
+%%
+%% ===Example===
+%%
+%% Deletes an existing custom verification email template.
+%%
+%% `
+%%  ok = erlcloud_ses:delete_custom_verification_email_template("templaneName").
+%% '
+%%
+%% @end
+%%------------------------------------------------------------------------------
+
+-type delete_custom_verification_email_template_result() :: ok | {error,term()}.
+
+-spec delete_custom_verification_email_template(string()) -> delete_custom_verification_email_template_result().
+delete_custom_verification_email_template(TemplateName) ->
+  delete_custom_verification_email_template(TemplateName, default_config()).
+
+-spec delete_custom_verification_email_template(string(), aws_config()) -> delete_custom_verification_email_template_result().
+delete_custom_verification_email_template(TemplateName, Config) ->
+  Params = encode_params([{template_name, TemplateName }]),
+  case ses_request(Config, "DeleteCustomVerificationEmailTemplate", Params) of
+    {ok, _Doc} -> ok;
+    {error, Reason} -> {error, Reason}
+  end.
+
 
 %%%------------------------------------------------------------------------------
 %%% DeleteIdentity
@@ -146,95 +220,28 @@ delete_identity(Identity, Config) ->
 
 %%------------------------------------------------------------------------------
 %% @doc
-%% Custom Verification Templates
 %% SES API:
 %% [https://docs.aws.amazon.com/ses/latest/APIReference/API_GetCustomVerificationEmailTemplate.html]
 %%
-%% Template attributes:
-%%   { template_name , string() }
-%%   { from_email_address , string() }
-%%   { template_subject , string() }
-%%   { template_content , string() }     -- please see notes in API Guide on what is allowed
-%%   { success_redirect_url , string() }
-%%   { failure_redirect_url , string() }
+%% ===Example===
 %%
-%% On template creation, all attributes are mandatory.
-%% On template updates, only include the attributes you need to modify
-%% When listing templates, all attributes are included except template_content, use the get function to retrieve it
+%% Returns the custom email verification template for the template name you specify.
 %%
-%%  create_custom_verification_email_template
-%%  update_custom_verification_email_template
-%%  send_custom_verification_email
-%%  delete_custom_verification_email_template
-%%  get_custom_verification_email_template
-%%  list_custom_verification_email_templates
+%% `
+%%  {ok,[{template_name,"templateName"},
+%%     {from_email_address,"support@example.com"},
+%%     {template_subject,"Welcome to Example.com"},
+%%     {template_content,"<html>\n<head></head>\n <body style=\"font-family:sans-serif;\">\n<h1 style=
+%%          \"text-align:center\">Ready to start with Example.com</h1>\n<p>Example.com is very happy to
+%%          welcome you to the ACME system Please click\non the link below to activate
+%%          your account.</p>\n</body>\n</html>"},
+%%     {success_redirect_url,"https://www.example.com/success"},
+%%     {failure_redirect_url,"http://example.arilia.com"}]} =
+%%        erlcloud_ses:delete_custom_verification_email_template("templaneName").
+%% '
 %%
 %% @end
 %%------------------------------------------------------------------------------
-
--type create_custom_verification_email_template_result() :: ok | { error, term() }.
-
--spec create_custom_verification_email_template( string(), string(), string(), string(), string(), string() ) -> create_custom_verification_email_template_result().
-create_custom_verification_email_template(TemplateName, FromEmailAddress, TemplateSubject, TemplateContent, SuccessRedirectionURL, FailureRedirectionURL) ->
-  create_custom_verification_email_template(TemplateName, FromEmailAddress, TemplateSubject, TemplateContent, SuccessRedirectionURL, FailureRedirectionURL ,default_config()).
-
--spec create_custom_verification_email_template(string(), string(), string(), string(), string(), string(), aws_config()) ->
-        create_custom_verification_email_template_result().
-create_custom_verification_email_template(TemplateName, FromEmailAddress, TemplateSubject, TemplateContent, SuccessRedirectionURL, FailureRedirectionURL, Config) ->
-  Params = encode_params([{template_name, TemplateName},
-                          {from_email_address, FromEmailAddress},
-                          {template_subject, TemplateSubject},
-                          {template_content, TemplateContent},
-                          {success_redirect_url, SuccessRedirectionURL},
-                          {failure_redirect_url, FailureRedirectionURL}]),
-  case ses_request(Config, "CreateCustomVerificationEmailTemplate", Params) of
-    {ok, _Doc} -> ok;
-    {error, Reason} -> {error, Reason}
-  end.
-
--type update_custom_verification_email_template_result() :: ok | { error, term() }.
-
--spec update_custom_verification_email_template(string(), [{atom(), string()}]) -> update_custom_verification_email_template_result().
-update_custom_verification_email_template(TemplateName, Attributes) ->
-  update_custom_verification_email_template(TemplateName, Attributes,default_config()).
-
--spec update_custom_verification_email_template(string(), [{atom(), string()}], aws_config()) -> update_custom_verification_email_template_result().
-update_custom_verification_email_template(TemplateName, Attributes, Config) ->
-  Params = encode_params([{template_name, TemplateName} | Attributes]),
-  case ses_request(Config, "UpdateCustomVerificationEmailTemplate", Params) of
-    {ok, _Doc} -> ok ;
-    {error, Reason} -> {error, Reason}
-  end.
-
--type send_custom_verification_email_result() :: {ok, term()} | {error, term()}.
-
--spec send_custom_verification_email(string(), string()) -> send_custom_verification_email_result().
-send_custom_verification_email(EmailAddress, TemplateName) ->
-  send_custom_verification_email(EmailAddress, TemplateName, default_config()).
-
--spec send_custom_verification_email(string(), string(), aws_config()) -> send_custom_verification_email_result().
-send_custom_verification_email(EmailAddress, TemplateName, Config) ->
-  Params = encode_params([{email_address, EmailAddress},
-                          {template_name, TemplateName}]),
-  case ses_request(Config, "SendCustomVerificationEmail", Params) of
-    {ok, Doc} ->
-      {ok, erlcloud_xml:decode([{message_id, "SendCustomVerificationEmailResult/MessageId", text}], Doc)};
-    {error, Reason} -> {error, Reason}
-  end.
-
--type delete_custom_verification_email_template_result() :: ok | {error,term()}.
-
--spec delete_custom_verification_email_template(string()) -> delete_custom_verification_email_template_result().
-delete_custom_verification_email_template(TemplateName) ->
-  delete_custom_verification_email_template(TemplateName, default_config()).
-
--spec delete_custom_verification_email_template(string(), aws_config()) -> delete_custom_verification_email_template_result().
-delete_custom_verification_email_template(TemplateName, Config) ->
-  Params = encode_params([{template_name, TemplateName }]),
-  case ses_request(Config, "DeleteCustomVerificationEmailTemplate", Params) of
-    {ok, _Doc} -> ok;
-    {error, Reason} -> {error, Reason}
-  end.
 
 -type get_custom_verification_email_template_result() :: {ok, custom_template_attributes()} | {error, term()}.
 
@@ -248,31 +255,14 @@ get_custom_verification_email_template(TemplateName, Config) ->
   case ses_request(Config, "GetCustomVerificationEmailTemplate", Params) of
     { ok , Doc } ->
       {ok, erlcloud_xml:decode(
-           [{template_name, "GetCustomVerificationEmailTemplateResult/TemplateName", text},
-            {from_email_address, "GetCustomVerificationEmailTemplateResult/FromEmailAddress", text},
-            {template_subject, "GetCustomVerificationEmailTemplateResult/TemplateSubject", text},
-            {template_content, "GetCustomVerificationEmailTemplateResult/TemplateContent", text},
-            {success_redirect_url, "GetCustomVerificationEmailTemplateResult/SuccessRedirectionURL", text},
-            {failure_redirect_url, "GetCustomVerificationEmailTemplateResult/FailureRedirectionURL", text}],
-            Doc)};
-    {error, Reason} -> {error, Reason}
-  end.
-
--type list_custom_verification_email_templates_result() :: {ok, [{custom_templates, [custom_template_attributes()]}]} | {error , term()}.
-
--spec list_custom_verification_email_templates() -> list_custom_verification_email_templates_result().
-list_custom_verification_email_templates() ->
-  list_custom_verification_email_templates(default_config()).
-
--spec list_custom_verification_email_templates(aws_config()) -> list_custom_verification_email_templates_result().
-list_custom_verification_email_templates(Config) ->
-  Params = [{"MaxResults",50}],
-  case ses_request(Config, "ListCustomVerificationEmailTemplates", Params) of
-    { ok , Doc } ->
-      {ok, erlcloud_xml:decode([{custom_templates, "ListCustomVerificationEmailTemplatesResult/CustomVerificationEmailTemplates/member", fun decode_custom_template_entry/1},
-        {next_token, "ListCustomVerificationEmailTemplatesResult/NextToken", optional_text}],
+        [{template_name, "GetCustomVerificationEmailTemplateResult/TemplateName", text},
+          {from_email_address, "GetCustomVerificationEmailTemplateResult/FromEmailAddress", text},
+          {template_subject, "GetCustomVerificationEmailTemplateResult/TemplateSubject", text},
+          {template_content, "GetCustomVerificationEmailTemplateResult/TemplateContent", text},
+          {success_redirect_url, "GetCustomVerificationEmailTemplateResult/SuccessRedirectionURL", text},
+          {failure_redirect_url, "GetCustomVerificationEmailTemplateResult/FailureRedirectionURL", text}],
         Doc)};
-    {error, Reason } -> {error, Reason}
+    {error, Reason} -> {error, Reason}
   end.
 
 %%%------------------------------------------------------------------------------
@@ -510,6 +500,48 @@ get_send_statistics(Config) ->
         {error, Reason} -> {error, Reason}
     end.
 
+%%------------------------------------------------------------------------------
+%% @doc
+%% SES API:
+%% [https://docs.aws.amazon.com/ses/latest/APIReference/API_ListCustomVerificationEmailTemplates.html]
+%%
+%% ===Example===
+%%
+%% Lists the existing custom verification email templates for your account in the current AWS Region.
+%%
+%% `
+%%  {ok,[{custom_templates,[[{template_name,"template1"},
+%%                         {from_email_address,"support@example.com"},
+%%                         {template_subject,"Welcome to support"},
+%%                         {success_redirect_url,"https://www.example.com/success"},
+%%                         {failure_redirect_url,"https://www.example.com/failure"}],
+%%                        [{template_name,"template2"},
+%%                         {from_email_address,"applications@example.com"},
+%%                         {template_subject,"Welcome to Applications"},
+%%                         {success_redirect_url,"https://www.example.com/success"},
+%%                         {failure_redirect_url,"https://www.example.com/failure"}]]}]} =
+%%                  erlcloud_ses:list_custom_verification_email_templates().
+%% '
+%%
+%% @end
+%%------------------------------------------------------------------------------
+
+-type list_custom_verification_email_templates_result() :: {ok, [{custom_templates, [custom_template_attributes()]}]} | {error , term()}.
+
+-spec list_custom_verification_email_templates() -> list_custom_verification_email_templates_result().
+list_custom_verification_email_templates() ->
+  list_custom_verification_email_templates(default_config()).
+
+-spec list_custom_verification_email_templates(aws_config()) -> list_custom_verification_email_templates_result().
+list_custom_verification_email_templates(Config) ->
+  Params = [{"MaxResults",50}],
+  case ses_request(Config, "ListCustomVerificationEmailTemplates", Params) of
+    { ok , Doc } ->
+      {ok, erlcloud_xml:decode([{custom_templates, "ListCustomVerificationEmailTemplatesResult/CustomVerificationEmailTemplates/member", fun decode_custom_template_entry/1},
+        {next_token, "ListCustomVerificationEmailTemplatesResult/NextToken", optional_text}],
+        Doc)};
+    {error, Reason } -> {error, Reason}
+  end.
 
 %%%------------------------------------------------------------------------------
 %%% ListIdentities
@@ -573,6 +605,38 @@ list_identities(Opts, Config) ->
         {error, Reason} -> {error, Reason}
     end.
 
+%%------------------------------------------------------------------------------
+%% @doc
+%% SES API:
+%% [https://docs.aws.amazon.com/ses/latest/APIReference/API_SendCustomVerificationEmail.html]
+%%
+%% ===Example===
+%%
+%% Send a custom verification email.
+%%
+%% `
+%%  {ok, [{message_id, "abcdefghijkllkjdlkj"}]} =
+%%            erlcloud_ses:send_custom_verification_email_result("newclient@newco.com", "templateName").
+%% '
+%%
+%% @end
+%%------------------------------------------------------------------------------
+
+-type send_custom_verification_email_result() :: {ok, term()} | {error, term()}.
+
+-spec send_custom_verification_email(string(), string()) -> send_custom_verification_email_result().
+send_custom_verification_email(EmailAddress, TemplateName) ->
+  send_custom_verification_email(EmailAddress, TemplateName, default_config()).
+
+-spec send_custom_verification_email(string(), string(), aws_config()) -> send_custom_verification_email_result().
+send_custom_verification_email(EmailAddress, TemplateName, Config) ->
+  Params = encode_params([{email_address, EmailAddress},
+    {template_name, TemplateName}]),
+  case ses_request(Config, "SendCustomVerificationEmail", Params) of
+    {ok, Doc} ->
+      {ok, erlcloud_xml:decode([{message_id, "SendCustomVerificationEmailResult/MessageId", text}], Doc)};
+    {error, Reason} -> {error, Reason}
+  end.
 
 %%%------------------------------------------------------------------------------
 %%% SendEmail
@@ -784,6 +848,46 @@ set_identity_notification_topic(Identity, NotificationType, SnsTopic, Config) ->
         {error, Reason} -> {error, Reason}
     end.
 
+%%------------------------------------------------------------------------------
+%% @doc
+%% SES API:
+%% [https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateCustomVerificationEmailTemplate.html]
+%%
+%%  Template attributes
+%%   { template_name , string() }
+%%   { from_email_address , string() }
+%%   { template_subject , string() }
+%%   { template_content , string() }
+%%   { success_redirect_url , string() }
+%%   { failure_redirect_url , string() }
+%%
+%% ===Example===
+%%
+%% Updates an existing custom verification email template.
+%%
+%% `
+%%  ok = erlcloud_ses:update_custom_verification_email_template("templateName",
+%%                                                     [{template_subject, "New subject"},
+%%                                                      {from_email_address, "support2@example.com"}]).
+%% '
+%% Please consult the following for what is and not allowed in the HTML content parameter
+%% [https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html#custom-verification-emails-faq]
+%% @end
+%%------------------------------------------------------------------------------
+
+-type update_custom_verification_email_template_result() :: ok | { error, term() }.
+
+-spec update_custom_verification_email_template(string(), [{atom(), string()}]) -> update_custom_verification_email_template_result().
+update_custom_verification_email_template(TemplateName, Attributes) ->
+  update_custom_verification_email_template(TemplateName, Attributes,default_config()).
+
+-spec update_custom_verification_email_template(string(), [{atom(), string()}], aws_config()) -> update_custom_verification_email_template_result().
+update_custom_verification_email_template(TemplateName, Attributes, Config) ->
+  Params = encode_params([{template_name, TemplateName} | Attributes]),
+  case ses_request(Config, "UpdateCustomVerificationEmailTemplate", Params) of
+    {ok, _Doc} -> ok ;
+    {error, Reason} -> {error, Reason}
+  end.
 
 %%%------------------------------------------------------------------------------
 %%% VerifyDomainDkim
@@ -859,7 +963,6 @@ verify_domain_identity(Domain, Config) ->
             {ok, erlcloud_xml:decode([{verification_token, "VerifyDomainIdentityResult/VerificationToken", text}], Doc)};
         {error, Reason} -> {error, Reason}
     end.
-
 
 %%%------------------------------------------------------------------------------
 %%% VerifyEmailIdentity


### PR DESCRIPTION
First time I contribute - so be gentle...

Just added support for the whole CustomVerificationTemplate API. This includes Create, Update, List, Delete, Get as well as SendCustomVerificationEmail. Added corresponding error codes. Tried to add specs & types. I tested this as much as I could. No actual tests were added.

This is the [API](https://docs.aws.amazon.com/ses/latest/APIReference/API_GetCustomVerificationEmailTemplate.htm)

Thanks