### PR TITLE
Bucket tagging API added and HTTP/HTTPS Proxy configuration support #606

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -10,13 +10,13 @@
 
 -type(aws_assume_role() :: #aws_assume_role{}).
 
--record(http_client_options, {
+-record(hackney_client_options, {
 	  insecure = true :: boolean() | undefined,
 	  proxy = undefined :: binary() | {binary(), non_neg_integer()} | {socks5, binary(), binary()} | {connect, binary(), binary()} | undefined,
 	  proxy_auth = undefined :: {binary(), binary()} | undefined
 }).
 
--type(http_client_options() :: #http_client_options{}).
+-type(hackney_client_options() :: #hackney_client_options{}).
 
 -record(aws_config, {
           as_host="autoscaling.amazonaws.com"::string(),
@@ -165,7 +165,7 @@
           aws_region=undefined::string()|undefined,
           %% http proxy support
           http_proxy=undefined::string()|undefined,
-          http_client_options = #http_client_options{} :: http_client_options() %% The http client options
+          hackney_client_options = #hackney_client_options{} :: hackney_client_options() %% The hackney client options
           %% are used to specify the proxy, proxy_auth and insecure which is
           %% used to support proxy based requests to s3.
          }).

--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -10,6 +10,14 @@
 
 -type(aws_assume_role() :: #aws_assume_role{}).
 
+-record(http_client_options, {
+	  insecure = true :: boolean() | undefined,
+	  proxy = undefined :: binary() | {binary(), non_neg_integer()} | {socks5, binary(), binary()} | {connect, binary(), binary()} | undefined,
+	  proxy_auth = undefined :: {binary(), binary()} | undefined
+}).
+
+-type(http_client_options() :: #http_client_options{}).
+
 -record(aws_config, {
           as_host="autoscaling.amazonaws.com"::string(),
           ec2_host="ec2.amazonaws.com"::string(),
@@ -154,7 +162,12 @@
           assume_role = #aws_assume_role{} :: aws_assume_role(), %% If a role to be assumed is given
           %% then we will try to assume the role during the update_config
           %% region override for API gateway type requests
-          aws_region=undefined::string()|undefined
+          aws_region=undefined::string()|undefined,
+          %% http proxy support
+          http_proxy=undefined::string()|undefined,
+          http_client_options = #http_client_options{} :: http_client_options() %% The http client options
+          %% are used to specify the proxy, proxy_auth and insecure which is
+          %% used to support proxy based requests to s3.
          }).
 -type(aws_config() :: #aws_config{}).
 

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -43,10 +43,16 @@ request(URL, Method, Hdrs, Body, Timeout,
     when is_function(F, 6) ->
     F(URL, Method, Hdrs, Body, Timeout, Config).
 
-request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{lhttpc_pool = undefined}) ->
+request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{lhttpc_pool = undefined, http_proxy = undefined}) ->
     lhttpc:request(URL, Method, Hdrs, Body, Timeout, []);
-request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{lhttpc_pool = Pool}) ->
+request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{http_proxy = HttpProxy, lhttpc_pool = undefined}) ->
+    LHttpcOpts = [{proxy, HttpProxy}],
+    lhttpc:request(URL, Method, Hdrs, Body, Timeout, LHttpcOpts);
+request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{lhttpc_pool = Pool, http_proxy = undefined}) ->
     LHttpcOpts = [{pool, Pool}, {pool_ensure, true}],
+    lhttpc:request(URL, Method, Hdrs, Body, Timeout, LHttpcOpts);
+request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{lhttpc_pool = Pool, http_proxy = HttpProxy}) ->
+    LHttpcOpts = [{pool, Pool}, {pool_ensure, true}, {proxy, HttpProxy}],
     lhttpc:request(URL, Method, Hdrs, Body, Timeout, LHttpcOpts).
 
 %% Guard clause protects against empty bodied requests from being
@@ -70,7 +76,13 @@ request_httpc(URL, Method, Hdrs, Body, Timeout, _Config) ->
                                  [{timeout, Timeout}],
                                  [{body_format, binary}])).
 
-request_hackney(URL, Method, Hdrs, Body, Timeout, #aws_config{hackney_pool = Pool}) ->
+request_hackney(URL, Method, Hdrs, Body, Timeout,
+                #aws_config{hackney_pool = Pool,
+			    http_client_options = #http_client_options{
+						     insecure = Insecure,
+						     proxy = Proxy,
+						     proxy_auth = ProxyAuth}}
+	       ) ->
     BinURL = to_binary(URL),
     BinHdrs = [{to_binary(K), to_binary(V)} || {K, V} <- Hdrs],
     PoolOpt = if Pool =:= undefined ->
@@ -78,10 +90,12 @@ request_hackney(URL, Method, Hdrs, Body, Timeout, #aws_config{hackney_pool = Poo
                  true ->
                       [{pool, Pool}]
               end,
+    HttpProxyOpt = [{proxy, Proxy}, {proxy_auth, ProxyAuth}],
     response_hackney(hackney:request(Method,
                                      BinURL, BinHdrs,
                                      Body,
-                                     [{recv_timeout, Timeout}] ++ PoolOpt)).
+                                     [{recv_timeout, Timeout}, {insecure, Insecure}] ++
+                                         PoolOpt ++ HttpProxyOpt)).
 
 response_httpc({ok, {{_HTTPVer, Status, StatusLine}, Headers, Body}}) ->
     {ok, {{Status, StatusLine}, Headers, Body}};

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -78,7 +78,7 @@ request_httpc(URL, Method, Hdrs, Body, Timeout, _Config) ->
 
 request_hackney(URL, Method, Hdrs, Body, Timeout,
                 #aws_config{hackney_pool = Pool,
-			    http_client_options = #http_client_options{
+			    hackney_client_options = #hackney_client_options{
 						     insecure = Insecure,
 						     proxy = Proxy,
 						     proxy_auth = ProxyAuth}}

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -517,6 +517,7 @@ list_objects(BucketName, Options, Config)
     Params = [{"delimiter", proplists:get_value(delimiter, Options)},
               {"marker", proplists:get_value(marker, Options)},
               {"max-keys", proplists:get_value(max_keys, Options)},
+              {"encoding-type", proplists:get_value(encoding_type, Options)},
               {"prefix", proplists:get_value(prefix, Options)}],
     Doc = s3_xml_request(Config, get, BucketName, "/", "", Params, <<>>, []),
     Attributes = [{name, "Name", text},

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -825,6 +825,7 @@ get_or_head(Method, BucketName, Key, Options, Config) ->
      {content_encoding, proplists:get_value("content-encoding", Headers)},
      {delete_marker, list_to_existing_atom(proplists:get_value("x-amz-delete-marker", Headers, "false"))},
      {version_id, proplists:get_value("x-amz-version-id", Headers, "null")},
+     {tag_count, proplists:get_value("x-amz-tagging-count", Headers, "null")},
      {content, Body}|
      extract_metadata(Headers)].
 
@@ -1008,7 +1009,9 @@ put_object(BucketName, Key, Value, Options, HTTPHeaders, Config)
        is_list(Options) ->
     RequestHeaders = [{"x-amz-acl", encode_acl(proplists:get_value(acl, Options))}|HTTPHeaders]
         ++ [{"x-amz-meta-" ++ string:to_lower(MKey), MValue} ||
-               {MKey, MValue} <- proplists:get_value(meta, Options, [])],
+               {MKey, MValue} <- proplists:get_value(meta, Options, [])]
+        ++ [{"x-amz-tagging-" ++ MKey, MValue} ||
+               {MKey, MValue} <- proplists:get_value(tags, Options, [])],
     POSTData = iolist_to_binary(Value),
     {Headers, _Body} = s3_request(Config, put, BucketName, [$/|Key], "", [],
                                   POSTData, RequestHeaders),
@@ -1109,7 +1112,9 @@ start_multipart(BucketName, Key, Options, HTTPHeaders, Config)
 
     RequestHeaders = [{"x-amz-acl", encode_acl(proplists:get_value(acl, Options))}|HTTPHeaders]
         ++ [{"x-amz-meta-" ++ string:to_lower(MKey), MValue} ||
-               {MKey, MValue} <- proplists:get_value(meta, Options, [])],
+               {MKey, MValue} <- proplists:get_value(meta, Options, [])]
+        ++ [{"x-amz-tagging-" ++ MKey, MValue} ||
+               {MKey, MValue} <- proplists:get_value(tags, Options, [])],
     POSTData = <<>>,
     case s3_xml_request2(Config, post, BucketName, [$/|Key], "uploads", [],
                          POSTData, RequestHeaders) of


### PR DESCRIPTION
This PR contains following changes:
- Bucket tagging and Object tagging APIs.
- Tagging support in PUT and GET requests.
- Support for HTTP/HTTPS proxy configuration.

#606 