### PR TITLE
handle future non-integer msg attr values

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -396,7 +396,7 @@ decode_msg_attribute_value("MessageDeduplicationId", Value) -> Value;
 decode_msg_attribute_value(_Name, Value) ->
     try list_to_integer(Value)
     catch
-        _:_:_ ->
+        _:_ ->
             Value
     end.
 

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -393,7 +393,12 @@ decode_msg_attribute_name(Name) when is_list(Name) -> Name.
 decode_msg_attribute_value("SenderId", Value) -> Value;
 decode_msg_attribute_value("MessageGroupId", Value) -> Value;
 decode_msg_attribute_value("MessageDeduplicationId", Value) -> Value;
-decode_msg_attribute_value(_Name, Value) -> list_to_integer(Value).
+decode_msg_attribute_value(_Name, Value) ->
+    try list_to_integer(Value)
+    catch
+        _:_:_ ->
+            Value
+    end.
 
 decode_messages(Messages) ->
     [decode_message(Message) || Message <- Messages].


### PR DESCRIPTION
We got a message into our sqs queue that erlcloud crashed on and we couldn't receive it.

```erlang
{{"AWSTraceHeader",
  "Root=1-deadbeef-deadbeefdeadbeefdeadbeef;Parent=deadbeefdeadbeef;Sampled=0",
  {error,badarg,
         [{erlang,list_to_integer,
                  ["Root=1-deadbeef-deadbeefdeadbeefdeadbeef;Parent=deadbeefdeadbeef;Sampled=0"],
                  []},
          {erlcloud_sqs,decode_msg_attribute_value,2,
                        [{file,"src/erlcloud_sqs.erl"},{line,397}]},
          {erlcloud_sqs,'-decode_msg_attributes/1-lc$^0/1-0-',1,
                        [{file,"src/erlcloud_sqs.erl"},{line,465}]},
          {erlcloud_sqs,'-decode_msg_attributes/1-lc$^0/1-0-',1,
                        [{file,"src/erlcloud_sqs.erl"},{line,465}]},
          {erlcloud_xml,'-decode/2-fun-0-',3,
                        [{file,"src/erlcloud_xml.erl"},{line,12}]},
          {lists,foldl,3,[{file,"lists.erl"},{line,1263}]},
          {erlcloud_xml,decode,2,
                        [{file,"src/erlcloud_xml.erl"},{line,10}]},
          {erlcloud_sqs,'-decode_messages/1-lc$^0/1-0-',1,
                        [{file,"src/erlcloud_sqs.erl"},{line,404}]}]}}}
```

It seems that assuming all future message attributes are integers was a bit optimistic, and not very future proof. We don't know were this attribute came from in our queue, but we couldn't get rid of it because of erlcloud_sqs crashes.

This patch assumes that most attributes are integers, but it if fails, catch and just return the string.
