### PR TITLE
add cloudformation create stack function

### DIFF
--- a/include/erlcloud_cloudformation.hrl
+++ b/include/erlcloud_cloudformation.hrl
@@ -1,5 +1,5 @@
--ifndef(erlcloud_ec2_hrl).
--define(erlcloud_ec2_hrl, 0).
+-ifndef(erlcloud_cloudformation_hrl).
+-define(erlcloud_cloudformation_hrl, 0).
 
 -include("erlcloud.hrl").
 

--- a/include/erlcloud_cloudformation.hrl
+++ b/include/erlcloud_cloudformation.hrl
@@ -23,6 +23,13 @@
     timeout_in_minutes :: integer()
 }).
 
+-record(cloudformation_delete_stack_input, {
+    client_request_token :: string(),
+    retain_resources = [] :: [string()],
+    role_arn :: string(),
+    stack_name :: string()
+}).
+
 -record(cloudformation_parameter, {
     parameter_key :: string(),
     parameter_value :: string(),
@@ -46,6 +53,7 @@
 }).
 
 -type(cloudformation_create_stack_input() :: #cloudformation_create_stack_input{}).
+-type(cloudformation_delete_stack_input() :: #cloudformation_delete_stack_input{}).
 -type(cloudformation_parameter() :: #cloudformation_parameter{}).
 -type(cloudformation_rollback_configuration() :: #cloudformation_rollback_configuration{}).
 -type(cloudformation_rollback_trigger() :: #cloudformation_rollback_trigger{}).

--- a/include/erlcloud_cloudformation.hrl
+++ b/include/erlcloud_cloudformation.hrl
@@ -4,20 +4,20 @@
 -include("erlcloud.hrl").
 
 -record(cloudformation_create_stack_input, {
-    capabilities :: [string()], %% list containing CAPABILITY_IAM | CAPABILITY_NAMED_IAM | CAPABILITY_AUTO_EXPAND
+    capabilities = [] :: [string()], %% list containing CAPABILITY_IAM | CAPABILITY_NAMED_IAM | CAPABILITY_AUTO_EXPAND
     client_request_token :: string(),
     disable_rollback :: boolean(),
     enable_termination_protection :: boolean(),
-    notification_arns :: [string()],
+    notification_arns = [] :: [string()],
     on_failure = "ROLLBACK" :: string(), %% DO_NOTHING | ROLLBACK | DELETE
-    parameters :: [cloudformation_parameter()],
-    resource_types :: [string()],
+    parameters = [] :: [cloudformation_parameter()],
+    resource_types = [] :: [string()],
     role_arn :: string(),
     rollback_configuration :: cloudformation_rollback_configuration(),
     stack_name :: string(),
     stack_policy_body :: string(),
     stack_policy_url :: string(),
-    tags :: [cloudformation_tag()],
+    tags = []:: [cloudformation_tag()],
     template_body :: string(),
     template_url :: string(),
     timeout_in_minutes :: integer()

--- a/include/erlcloud_cloudformation.hrl
+++ b/include/erlcloud_cloudformation.hrl
@@ -1,0 +1,54 @@
+-ifndef(erlcloud_ec2_hrl).
+-define(erlcloud_ec2_hrl, 0).
+
+-include("erlcloud.hrl").
+
+-record(cloudformation_create_stack_input, {
+    capabilities :: [string()], %% list containing CAPABILITY_IAM | CAPABILITY_NAMED_IAM | CAPABILITY_AUTO_EXPAND
+    client_request_token :: string(),
+    disable_rollback :: boolean(),
+    enable_termination_protection :: boolean(),
+    notification_arns :: [string()],
+    on_failure = "ROLLBACK" :: string(), %% DO_NOTHING | ROLLBACK | DELETE
+    parameters :: [cloudformation_parameter()],
+    resource_types :: [string()],
+    role_arn :: string(),
+    rollback_configuration :: cloudformation_rollback_configuration(),
+    stack_name :: string(),
+    stack_policy_body :: string(),
+    stack_policy_url :: string(),
+    tags :: [cloudformation_tag()],
+    template_body :: string(),
+    template_url :: string(),
+    timeout_in_minutes :: integer()
+}).
+
+-record(cloudformation_parameter, {
+    parameter_key :: string(),
+    parameter_value :: string(),
+    resolved_value :: string(),
+    use_previous_value :: boolean()
+}).
+
+-record(cloudformation_rollback_configuration, {
+    monitoring_time_in_minutes :: integer(),
+    rollback_triggers:: [cloudformation_rollback_trigger()]
+}).
+
+-record(cloudformation_rollback_trigger, {
+    arn :: string(),
+    type:: string()
+}).
+
+-record(cloudformation_tag, {
+    key :: string(),
+    value :: string()
+}).
+
+-type(cloudformation_create_stack_input() :: #cloudformation_create_stack_input{}).
+-type(cloudformation_parameter() :: #cloudformation_parameter{}).
+-type(cloudformation_rollback_configuration() :: #cloudformation_rollback_configuration{}).
+-type(cloudformation_rollback_trigger() :: #cloudformation_rollback_trigger{}).
+-type(cloudformation_tag() :: #cloudformation_tag{}).
+
+-endif.

--- a/include/erlcloud_cloudformation.hrl
+++ b/include/erlcloud_cloudformation.hrl
@@ -23,6 +23,25 @@
     timeout_in_minutes :: integer()
 }).
 
+-record(cloudformation_update_stack_input, {
+    capabilities = [] :: [string()], %% list containing CAPABILITY_IAM | CAPABILITY_NAMED_IAM | CAPABILITY_AUTO_EXPAND
+    client_request_token :: string(),
+    notification_arns = [] :: [string()],
+    parameters = [] :: [cloudformation_parameter()],
+    resource_types = [] :: [string()],
+    role_arn :: string(),
+    rollback_configuration :: cloudformation_rollback_configuration(),
+    stack_name :: string(),
+    stack_policy_body :: string(),
+    stack_policy_during_update_body :: string(),
+    stack_policy_during_update_url :: string(),
+    stack_policy_url :: string(),
+    tags = []:: [cloudformation_tag()],
+    template_body :: string(),
+    template_url :: string(),
+    use_previous_template :: boolean()
+}).
+
 -record(cloudformation_delete_stack_input, {
     client_request_token :: string(),
     retain_resources = [] :: [string()],
@@ -53,6 +72,7 @@
 }).
 
 -type(cloudformation_create_stack_input() :: #cloudformation_create_stack_input{}).
+-type(cloudformation_update_stack_input() :: #cloudformation_update_stack_input{}).
 -type(cloudformation_delete_stack_input() :: #cloudformation_delete_stack_input{}).
 -type(cloudformation_parameter() :: #cloudformation_parameter{}).
 -type(cloudformation_rollback_configuration() :: #cloudformation_rollback_configuration{}).

--- a/src/erlcloud_cloudformation.erl
+++ b/src/erlcloud_cloudformation.erl
@@ -170,17 +170,13 @@ delete_stack(Spec = #cloudformation_delete_stack_input{}) ->
     delete_stack(Spec, default_config()).
 
 -spec delete_stack(cloudformation_delete_stack_input(), aws_config()) ->
-    {ok, string()} | {error, error_reason()}.
+    ok | {error, error_reason()}.
 delete_stack(Spec = #cloudformation_delete_stack_input{}, Config = #aws_config{}) ->
 
     Params = delete_stack_input_to_params(Spec),
     case cloudformation_request(Config, "DeleteStack", Params) of
-        {ok, XmlNode} ->
-            RequestId = erlcloud_xml:get_text(
-                    "/DeleteStackResponse/DeleteStackResult/RequestId",
-                    XmlNode,
-                    undefined),
-            {ok, RequestId};
+        {ok, _XmlNode} ->
+            ok;
         {error, Error} ->
             {error, Error}
     end.

--- a/test/erlcloud_cloudformation_tests.erl
+++ b/test/erlcloud_cloudformation_tests.erl
@@ -22,6 +22,9 @@ describe_cloudformation_test_() ->
         fun create_stack_input_with_tags_tests/1,
         fun create_stack_input_with_rollback_config_tests/1,
         fun list_stacks_all_output_tests/1,
+        fun delete_stack_input_tests/1,
+        fun delete_stack_input_with_retain_resources_tests/1,
+        fun delete_stack_input_with_client_request_token_tests/1,
         fun list_stack_resources_output_tests/1,
         fun get_template_summary_output_tests/1,
         fun get_template_output_tests/1,
@@ -218,6 +221,72 @@ list_stacks_all_input_tests(_) ->
     input_test(Response, ?_cloudformation_test({"Test list all stacks input",
         ?_f(erlcloud_cloudformation:list_stacks_all([], #aws_config{})),
         ExpectedParams})).
+
+delete_stack_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<DeleteStackResponse>null</DeleteStackResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action", "DeleteStack"},
+        {"Version", "2010-05-15"},
+        {"StackName", "TestStack"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test Delete Stack input",
+            ?_f(erlcloud_cloudformation:delete_stack(
+                #cloudformation_delete_stack_input{stack_name="TestStack"},
+                #aws_config{}
+            )),
+            ExpectedParams})).
+
+delete_stack_input_with_retain_resources_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<DeleteStackResponse>null</DeleteStackResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action", "DeleteStack"},
+        {"Version", "2010-05-15"},
+        {"StackName", "TestStack"},
+        {"RetainResources.member.1", "arn::ec2::MyTestInstance1"},
+        {"RetainResources.member.2", "arn::ec2::MyTestInstance2"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test Delete Stack input",
+            ?_f(erlcloud_cloudformation:delete_stack(
+                #cloudformation_delete_stack_input{
+                    stack_name="TestStack",
+                    retain_resources = [
+                        "arn::ec2::MyTestInstance1",
+                        "arn::ec2::MyTestInstance2"
+                    ]
+                },
+                #aws_config{}
+            )),
+            ExpectedParams})).
+
+delete_stack_input_with_client_request_token_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<DeleteStackResponse>null</DeleteStackResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","DeleteStack"},
+        {"Version","2010-05-15"},
+        {"StackName","TestStack"},
+        {"ClientRequestToken","TestClientRequestToken"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test Delete Stack input",
+            ?_f(erlcloud_cloudformation:delete_stack(
+                #cloudformation_delete_stack_input{
+                    stack_name="TestStack",
+                    client_request_token="TestClientRequestToken"
+                },
+                #aws_config{}
+            )),
+            ExpectedParams})).
 
 list_stack_resources_input_tests(_) ->
     Response = {ok, element(1, xmerl_scan:string(

--- a/test/erlcloud_cloudformation_tests.erl
+++ b/test/erlcloud_cloudformation_tests.erl
@@ -22,6 +22,10 @@ describe_cloudformation_test_() ->
         fun create_stack_input_with_tags_tests/1,
         fun create_stack_input_with_rollback_config_tests/1,
         fun list_stacks_all_output_tests/1,
+        fun update_stack_input_tests/1,
+        fun update_stack_input_with_parameters_tests/1,
+        fun update_stack_input_with_tags_tests/1,
+        fun update_stack_input_with_rollback_config_tests/1,
         fun delete_stack_input_tests/1,
         fun delete_stack_input_with_retain_resources_tests/1,
         fun delete_stack_input_with_client_request_token_tests/1,
@@ -220,6 +224,110 @@ list_stacks_all_input_tests(_) ->
 
     input_test(Response, ?_cloudformation_test({"Test list all stacks input",
         ?_f(erlcloud_cloudformation:list_stacks_all([], #aws_config{})),
+        ExpectedParams})).
+
+update_stack_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<UpdateStackResponse>null</UpdateStackResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","UpdateStack"},
+        {"Version","2010-05-15"},
+        {"StackName","TestStack"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test update stack input",
+        ?_f(erlcloud_cloudformation:update_stack(#cloudformation_update_stack_input{stack_name="TestStack"}, #aws_config{})),
+        ExpectedParams})).
+
+
+update_stack_input_with_parameters_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<UpdateStackResponse>null</UpdateStackResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","UpdateStack"},
+        {"Version","2010-05-15"},
+        {"StackName","TestStack"},
+        {"Parameters.member.1.ParameterKey", "TestParamKey1"},
+        {"Parameters.member.1.ParameterValue", "TestParamVal1"},
+        {"Parameters.member.2.ParameterKey", "TestParamKey2"},
+        {"Parameters.member.2.ParameterValue", "TestParamVal2"},
+        {"Parameters.member.3.ParameterKey", "TestParamKey3"},
+        {"Parameters.member.3.ParameterValue", "TestParamVal3"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test update stack input with parameters",
+        ?_f(erlcloud_cloudformation:update_stack(
+            #cloudformation_update_stack_input{
+                stack_name="TestStack",
+                parameters=[
+                    #cloudformation_parameter{parameter_key="TestParamKey1", parameter_value="TestParamVal1"},
+                    #cloudformation_parameter{parameter_key="TestParamKey2", parameter_value="TestParamVal2"},
+                    #cloudformation_parameter{parameter_key="TestParamKey3", parameter_value="TestParamVal3"}
+                ]
+            },
+            #aws_config{}
+        )),
+        ExpectedParams})).
+
+update_stack_input_with_tags_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<UpdateStackResponse>null</UpdateStackResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","UpdateStack"},
+        {"Version","2010-05-15"},
+        {"StackName","TestStack"},
+        {"Tags.member.1.Key", "TagKey1"},
+        {"Tags.member.1.Value", "TagVal1"},
+        {"Tags.member.2.Key", "TagKey2"},
+        {"Tags.member.2.Value", "TagVal2"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test update stack input with tags",
+        ?_f(erlcloud_cloudformation:update_stack(
+            #cloudformation_update_stack_input{
+                stack_name="TestStack",
+                tags=[
+                    #cloudformation_tag{key="TagKey0", value="TagVal0"},
+                    #cloudformation_tag{key="TagKey1", value="TagVal1"}
+                ]
+            },
+            #aws_config{}
+        )),
+        ExpectedParams})).
+
+update_stack_input_with_rollback_config_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<UpdateStackResponse>null</UpdateStackResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","UpdateStack"},
+        {"Version","2010-05-15"},
+        {"StackName","TestStack"},
+        {"RollbackConfiguration.MonitoringTimeInMinutes", 10},
+        {"RollbackConfiguration.RollbackTriggers.member.1.Arn", "TestARN"},
+        {"RollbackConfiguration.RollbackTriggers.member.1.Type", "TestType"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test update stack input with rollback configuration",
+        ?_f(erlcloud_cloudformation:update_stack(
+            #cloudformation_update_stack_input{
+                stack_name="TestStack",
+                rollback_configuration = #cloudformation_rollback_configuration{
+                    monitoring_time_in_minutes = 10,
+                    rollback_triggers = [
+                        #cloudformation_rollback_trigger{arn="TestARN", type="TestType"}
+                    ]
+                }
+            },
+            #aws_config{}
+        )),
         ExpectedParams})).
 
 delete_stack_input_tests(_) ->

--- a/test/erlcloud_cloudformation_tests.erl
+++ b/test/erlcloud_cloudformation_tests.erl
@@ -5,6 +5,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("erlcloud.hrl").
 -include("erlcloud_aws.hrl").
+-include("erlcloud_cloudformation.hrl").
 
 -define(_cloudformation_test(T), {?LINE, T}).
 
@@ -16,6 +17,10 @@
 
 describe_cloudformation_test_() ->
     {foreach, fun start/0, fun stop/1, [
+        fun create_stack_input_tests/1,
+        fun create_stack_input_with_parameters_tests/1,
+        fun create_stack_input_with_tags_tests/1,
+        fun create_stack_input_with_rollback_config_tests/1,
         fun list_stacks_all_output_tests/1,
         fun list_stack_resources_output_tests/1,
         fun get_template_summary_output_tests/1,
@@ -95,6 +100,113 @@ input_test(Response, {Line, {Description, Fun, Params}})
 %%==============================================================================
 %% Input Tests
 %%==============================================================================
+
+create_stack_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<CreateStacksResponse>null</CreateStacksResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","CreateStack"},
+        {"Version","2010-05-15"},
+        {"OnFailure","ROLLBACK"},
+        {"StackName","TestStack"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test create stack input",
+        ?_f(erlcloud_cloudformation:create_stack(#cloudformation_create_stack_input{stack_name="TestStack"}, #aws_config{})),
+        ExpectedParams})).
+
+create_stack_input_with_parameters_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<CreateStacksResponse>null</CreateStacksResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","CreateStack"},
+        {"Version","2010-05-15"},
+        {"OnFailure","ROLLBACK"},
+        {"StackName","TestStack"},
+        {"Parameters.member.1.ParameterKey", "TestParamKey1"},
+        {"Parameters.member.1.ParameterValue", "TestParamVal1"},
+        {"Parameters.member.2.ParameterKey", "TestParamKey2"},
+        {"Parameters.member.2.ParameterValue", "TestParamVal2"},
+        {"Parameters.member.3.ParameterKey", "TestParamKey3"},
+        {"Parameters.member.3.ParameterValue", "TestParamVal3"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test create stack input",
+        ?_f(erlcloud_cloudformation:create_stack(
+            #cloudformation_create_stack_input{
+                stack_name="TestStack",
+                parameters=[
+                    #cloudformation_parameter{parameter_key="TestParamKey1", parameter_value="TestParamVal1"},
+                    #cloudformation_parameter{parameter_key="TestParamKey2", parameter_value="TestParamVal2"},
+                    #cloudformation_parameter{parameter_key="TestParamKey3", parameter_value="TestParamVal3"}
+                ]
+            },
+            #aws_config{}
+        )),
+        ExpectedParams})).
+
+create_stack_input_with_tags_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<CreateStacksResponse>null</CreateStacksResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","CreateStack"},
+        {"Version","2010-05-15"},
+        {"OnFailure","ROLLBACK"},
+        {"StackName","TestStack"},
+        {"Tags.member.1.Key", "TagKey1"},
+        {"Tags.member.1.Value", "TagVal1"},
+        {"Tags.member.2.Key", "TagKey2"},
+        {"Tags.member.2.Value", "TagVal2"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test create stack input",
+        ?_f(erlcloud_cloudformation:create_stack(
+            #cloudformation_create_stack_input{
+                stack_name="TestStack",
+                tags=[
+                    #cloudformation_tag{key="TagKey0", value="TagVal0"},
+                    #cloudformation_tag{key="TagKey1", value="TagVal1"}
+                ]
+            },
+            #aws_config{}
+        )),
+        ExpectedParams})).
+
+create_stack_input_with_rollback_config_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<CreateStacksResponse>null</CreateStacksResponse>">>)
+        ))},
+
+    ExpectedParams = [
+        {"Action","CreateStack"},
+        {"Version","2010-05-15"},
+        {"OnFailure","ROLLBACK"},
+        {"StackName","TestStack"},
+        {"RollbackConfiguration.MonitoringTimeInMinutes", 10},
+        {"RollbackConfiguration.RollbackTriggers.member.1.Arn", "TestARN"},
+        {"RollbackConfiguration.RollbackTriggers.member.1.Type", "TestType"}
+    ],
+
+    input_test(Response, ?_cloudformation_test({"Test create stack input",
+        ?_f(erlcloud_cloudformation:create_stack(
+            #cloudformation_create_stack_input{
+                stack_name="TestStack",
+                rollback_configuration = #cloudformation_rollback_configuration{
+                    monitoring_time_in_minutes = 10,
+                    rollback_triggers = [
+                        #cloudformation_rollback_trigger{arn="TestARN", type="TestType"}
+                    ]
+                }
+            },
+            #aws_config{}
+        )),
+        ExpectedParams})).
 
 list_stacks_all_input_tests(_) ->
     Response = {ok, element(1, xmerl_scan:string(


### PR DESCRIPTION
## Change
Add support for cloudformation service `create_stack` api: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html

Example Usage:
```erlang
create_my_stack() ->
    {ok, AwsConfig} = erlcloud_aws:profile(),
    Spec = #cloudformation_create_stack_input{
        stack_name="TestStack",
        template_url="https://example-domain.net/cloudformation-template.json"
    },
    {ok, StackId} = erlcloud_cloudformation:create_stack(Spec, AwsConfig).
```