### PR TITLE
DynamoDB: do not retry requests unless it's safe

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,6 +32,7 @@
 
 
 {profiles, [
-            {test, [{deps, [{meck, "0.8.13"}]}]}
+            {test, [{deps, [{meck, "0.8.13"}]},
+                    {cover_enabled, true}]}
            ,{warnings, [{erl_opts, [warnings_as_errors]}]}
            ]}.


### PR DESCRIPTION
Otherwise, non-idempotent operations like counter increments may result in unwanted side effects when retried.

Besides that, avoid retrying upon protocol, socket or network errors that are very unlikely to see recovery in the short term, like failed SSL negotiation (as was suggested in a previous TODO comment, now removed.)

I haven't yet had the chance to fully test the changes, but they pass the unit tests.
