### PR TITLE
Fixes for dialyzer (all warnings)

### DIFF
--- a/include/erlcloud_cloudformation.hrl
+++ b/include/erlcloud_cloudformation.hrl
@@ -13,7 +13,7 @@
     parameters = [] :: [cloudformation_parameter()],
     resource_types = [] :: [string()],
     role_arn :: string(),
-    rollback_configuration :: cloudformation_rollback_configuration(),
+    rollback_configuration :: undefined | cloudformation_rollback_configuration(),
     stack_name :: string(),
     stack_policy_body :: string(),
     stack_policy_url :: string(),

--- a/src/erlcloud_application_autoscaler.erl
+++ b/src/erlcloud_application_autoscaler.erl
@@ -61,6 +61,10 @@
 -type response_attribute() :: string() | integer().
 -type response_key() :: atom().
 -type response() :: [{response_key(), response_attribute()}].
+-type ok_error_response() :: {ok, jsx:json_term()}
+                           | {error, metadata_not_available
+                                   | container_credentials_unavailable
+                                   | erlcloud_aws:httpc_result_error()}.
 
 -type aws_aas_request_body() :: [proplist:proplist()].
 
@@ -318,9 +322,7 @@ delete_scaling_policy(Configuration, BodyConfiguration) ->
                             ScalableDimension :: binary(),
                             ScheduledActionName :: binary(),
                             ServiceNamespace :: binary()
-                        ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                           | container_credentials_unavailable
-                                                           | erlcloud_aws:httpc_result_error()}.
+                        ) -> ok_error_response().
 delete_scheduled_action(Configuration, ResourceId, ScalableDimension, ScheduledActionName, ServiceNamespace) ->
     BodyProps = [{<<"ScheduledActionName">>, ScheduledActionName},
                  {<<"ResourceId">>, ResourceId},
@@ -331,9 +333,7 @@ delete_scheduled_action(Configuration, ResourceId, ScalableDimension, ScheduledA
 
 -spec delete_scheduled_action(Configuration :: aws_config(),
                               BodyConfiguration :: aws_aas_request_body()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 delete_scheduled_action(Configuration, BodyConfiguration) ->
     request_with_action(Configuration, BodyConfiguration, "AnyScaleFrontendService.DeleteScheduledAction").
 
@@ -349,9 +349,7 @@ delete_scheduled_action(Configuration, BodyConfiguration) ->
                             ResourceId :: binary(),
                             ScalableDimension :: binary(),
                             ServiceNamespace :: binary()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 deregister_scalable_target(Configuration, ResourceId, ScalableDimension, ServiceNamespace) ->
     BodyProps = [{<<"ResourceId">>, ResourceId},
                  {<<"ScalableDimension">>, ScalableDimension},
@@ -361,9 +359,7 @@ deregister_scalable_target(Configuration, ResourceId, ScalableDimension, Service
 -spec deregister_scalable_target(
                             Configuration :: erlcloud_aws:aws_config(),
                             BodyConfiguration :: aws_aas_request_body()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 deregister_scalable_target(Configuration, BodyConfiguration) ->
     request_with_action(Configuration, BodyConfiguration, "AnyScaleFrontendService.DeregisterScalableTarget").
 
@@ -377,9 +373,7 @@ deregister_scalable_target(Configuration, BodyConfiguration) ->
 -spec describe_scalable_targets(
                             erlcloud_aws:aws_config(),
                             aws_aas_request_body() |  binary()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 describe_scalable_targets(Configuration, ServiceNamespace) when is_binary(ServiceNamespace)->
     describe_scalable_targets(Configuration, [{<<"ServiceNamespace">>, ServiceNamespace}]);
 describe_scalable_targets(Configuration, BodyConfiguration) ->
@@ -407,9 +401,7 @@ describe_scalable_targets(Configuration, BodyConfiguration) ->
 -spec describe_scaling_activities(
                             erlcloud_aws:aws_config(),
                             aws_aas_request_body() |  binary()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 describe_scaling_activities(Configuration, ServiceNamespace) when is_binary(ServiceNamespace) ->
     describe_scaling_activities(Configuration, [{<<"ServiceNamespace">>, ServiceNamespace}]);
 describe_scaling_activities(Configuration, BodyConfiguration) ->
@@ -438,9 +430,7 @@ describe_scaling_activities(Configuration, BodyConfiguration) ->
 -spec describe_scaling_policies(
                             erlcloud_aws:aws_config(),
                             aws_aas_request_body() |  binary()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 describe_scaling_policies(Configuration, ServiceNamespace) when is_binary(ServiceNamespace) ->
     describe_scaling_policies(Configuration, [{<<"ServiceNamespace">>, ServiceNamespace}]);
 describe_scaling_policies(Configuration, BodyConfiguration) ->
@@ -469,9 +459,7 @@ describe_scaling_policies(Configuration, BodyConfiguration) ->
 -spec describe_scheduled_actions(
                             erlcloud_aws:aws_config(),
                             aws_aas_request_body() |  binary()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 describe_scheduled_actions(Configuration, ServiceNamespace) when is_binary(ServiceNamespace) ->
     describe_scheduled_actions(Configuration, [{<<"ServiceNamespace">>, ServiceNamespace}]);
 describe_scheduled_actions(Configuration, BodyConfiguration) ->
@@ -503,9 +491,7 @@ describe_scheduled_actions(Configuration, BodyConfiguration) ->
                             ResourceId :: binary(),
                             ScalableDimension :: binary(),
                             ServiceNamespace :: binary()
-                        ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                           | container_credentials_unavailable
-                                                           | erlcloud_aws:httpc_result_error()}.
+                        ) -> ok_error_response().
 put_scaling_policy(Configuration, PolicyName, ResourceId, ScalableDimension, ServiceNamespace) ->
     BodyProps = [{<<"PolicyName">>, PolicyName},
                  {<<"ResourceId">>, ResourceId},
@@ -521,9 +507,7 @@ put_scaling_policy(Configuration, PolicyName, ResourceId, ScalableDimension, Ser
                             ServiceNamespace :: binary(),
                             PolicyType :: binary(),
                             Policy :: [proplist:proplist()]
-                        ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                           | container_credentials_unavailable
-                                                           | erlcloud_aws:httpc_result_error()}.
+                        ) -> ok_error_response().
 put_scaling_policy(Configuration, PolicyName, ResourceId, ScalableDimension, ServiceNamespace, PolicyType, Policy) ->
     BodyProps = [{<<"PolicyName">>, PolicyName},
                  {<<"ResourceId">>, ResourceId},
@@ -540,9 +524,7 @@ put_scaling_policy(Configuration, PolicyName, ResourceId, ScalableDimension, Ser
 -spec put_scaling_policy(
                             Configuration :: erlcloud_aws:aws_config(),
                             BodyConfiguration :: aws_aas_request_body()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 put_scaling_policy(Configuration, BodyConfiguration) ->
     case request_with_action(Configuration, BodyConfiguration, "AnyScaleFrontendService.PutScalingPolicy") of
         {ok, Result} ->
@@ -566,9 +548,7 @@ put_scaling_policy(Configuration, BodyConfiguration) ->
                             ScalableDimension :: binary(),
                             ServiceNamespace :: binary(),
                             ScheduledActionName :: binary()
-                        ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                           | container_credentials_unavailable
-                                                           | erlcloud_aws:httpc_result_error()}.
+                        ) -> ok_error_response().
 put_scheduled_action(Configuration, ResourceId, ScalableDimension, ServiceNamespace, ScheduledActionName) ->
     BodyProps = [{<<"ScheduledActionName">>, ScheduledActionName},
                  {<<"ResourceId">>, ResourceId},
@@ -583,9 +563,7 @@ put_scheduled_action(Configuration, ResourceId, ScalableDimension, ServiceNamesp
                             ServiceNamespace :: binary(),
                             ScheduledActionName :: binary(),
                             Schedule :: binary()
-                        ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                           | container_credentials_unavailable
-                                                           | erlcloud_aws:httpc_result_error()}.
+                        ) -> ok_error_response().
 put_scheduled_action(Configuration, ResourceId, ScalableDimension, ServiceNamespace, ScheduledActionName, Schedule) ->
     BodyProps = [{<<"ScheduledActionName">>, ScheduledActionName},
                  {<<"ResourceId">>, ResourceId},
@@ -602,9 +580,7 @@ put_scheduled_action(Configuration, ResourceId, ScalableDimension, ServiceNamesp
                             ScheduledActionName :: binary(),
                             Schedule :: binary(),
                             StartTime :: pos_integer()
-                        ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                           | container_credentials_unavailable
-                                                           | erlcloud_aws:httpc_result_error()}.
+                        ) -> ok_error_response().
 put_scheduled_action(Configuration, ResourceId, ScalableDimension, ServiceNamespace, ScheduledActionName, Schedule, StartTime) ->
     BodyProps = [{<<"ScheduledActionName">>, ScheduledActionName},
                  {<<"ResourceId">>, ResourceId},
@@ -623,9 +599,7 @@ put_scheduled_action(Configuration, ResourceId, ScalableDimension, ServiceNamesp
                             Schedule :: binary(),
                             StartTime :: pos_integer(),
                             EndTime :: pos_integer()
-                        ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                           | container_credentials_unavailable
-                                                           | erlcloud_aws:httpc_result_error()}.
+                        ) -> ok_error_response().
 put_scheduled_action(Configuration, ResourceId, ScalableDimension, ServiceNamespace, ScheduledActionName, Schedule, StartTime, EndTime) ->
     BodyProps = [{<<"ScheduledActionName">>, ScheduledActionName},
                  {<<"ResourceId">>, ResourceId},
@@ -638,9 +612,7 @@ put_scheduled_action(Configuration, ResourceId, ScalableDimension, ServiceNamesp
 
 -spec put_scheduled_action(Configuration :: aws_config(),
                               BodyConfiguration :: aws_aas_request_body()
-                            ) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                               | container_credentials_unavailable
-                                                               | erlcloud_aws:httpc_result_error()}.
+                            ) -> ok_error_response().
 put_scheduled_action(Configuration, BodyConfiguration) ->
     request_with_action(Configuration, BodyConfiguration, "AnyScaleFrontendService.PutScheduledAction").
 
@@ -654,9 +626,7 @@ put_scheduled_action(Configuration, BodyConfiguration) ->
 -spec register_scalable_target(Configuration :: aws_config(),
                                ResourceId :: binary(),
                                ScalableDimension :: binary(),
-                               ServiceNamespace :: binary()) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                                                              | container_credentials_unavailable
-                                                                                              | erlcloud_aws:httpc_result_error()}.
+                               ServiceNamespace :: binary()) -> ok_error_response().
 register_scalable_target(Configuration, ResourceId, ScalableDimension, ServiceNamespace) ->
     BodyProps = [{<<"ResourceId">>, ResourceId},
                  {<<"ScalableDimension">>, ScalableDimension},
@@ -667,9 +637,7 @@ register_scalable_target(Configuration, ResourceId, ScalableDimension, ServiceNa
                                ResourceId :: binary(),
                                ScalableDimension :: binary(),
                                ServiceNamespace :: binary(),
-                               ResourceARN :: binary()) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                                                         | container_credentials_unavailable
-                                                                                         | erlcloud_aws:httpc_result_error()}.
+                               ResourceARN :: binary()) -> ok_error_response().
 register_scalable_target(Configuration, ResourceId, ScalableDimension, ServiceNamespace, ResourceARN) ->
     BodyProps = [{<<"ResourceId">>, ResourceId},
                  {<<"ScalableDimension">>, ScalableDimension},
@@ -683,9 +651,7 @@ register_scalable_target(Configuration, ResourceId, ScalableDimension, ServiceNa
                                ServiceNamespace :: binary(),
                                ResourceARN :: binary(),
                                MinCapacity :: integer() | undefined,
-                               MaxCapacity :: integer() | undefined) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                                                                                      | container_credentials_unavailable
-                                                                                                      | erlcloud_aws:httpc_result_error()}.
+                               MaxCapacity :: integer() | undefined) -> ok_error_response().
 register_scalable_target(Configuration, ResourceId, ScalableDimension, ServiceNamespace, ResourceARN, MinCapacity, MaxCapacity) ->
     BodyProps = [{<<"ResourceId">>, ResourceId},
                  {<<"ScalableDimension">>, ScalableDimension},
@@ -704,9 +670,7 @@ register_scalable_target(Configuration, ResourceId, ScalableDimension, ServiceNa
 -spec register_scalable_target(
     Configuration :: erlcloud_aws:aws_config(),
     BodyConfiguration :: aws_aas_request_body()
-) -> {ok, jsx:json_term()} | {error, metadata_not_available
-                                   | container_credentials_unavailable
-                                   | erlcloud_aws:httpc_result_error()}.
+) -> ok_error_response().
 register_scalable_target(Configuration, BodyConfiguration) ->
     request_with_action(Configuration, BodyConfiguration, "AnyScaleFrontendService.RegisterScalableTarget").
 

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -602,13 +602,13 @@ update_config(#aws_config{} = Config) ->
 
 -spec clear_config(aws_config()) -> ok.
 clear_config(#aws_config{assume_role = #aws_assume_role{role_arn = Arn, external_id = ExtId}}) ->
-    application:unset_env(erlcloud, {role_credentials, Arn, ExtId}).
+    unset_env_for_role_credentials(Arn, ExtId).
 
 -spec clear_expired_configs() -> ok.
 clear_expired_configs() ->
     Env = application:get_all_env(erlcloud),
     Now = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
-    [application:unset_env(erlcloud, {role_credentials, Arn, ExtId}) ||
+    [unset_env_for_role_credentials(Arn, ExtId) ||
             {{role_credentials, Arn, ExtId},
               #role_credentials{expiration_gregorian_seconds = Ts}} <- Env,
         Ts < Now],
@@ -892,10 +892,7 @@ prop_to_list_defined( Name, Props ) ->
 
 -spec get_role_credentials(aws_config()) -> {ok, #role_credentials{}}.
 get_role_credentials(#aws_config{assume_role = AssumeRole} = Config) ->
-    case application:get_env(erlcloud,
-                             {role_credentials,
-                              AssumeRole#aws_assume_role.role_arn,
-                              AssumeRole#aws_assume_role.external_id}) of
+    case get_env_for_role_credentials(AssumeRole#aws_assume_role.role_arn, AssumeRole#aws_assume_role.external_id) of
         {ok, #role_credentials{expiration_gregorian_seconds = Expiration} = Credentials} ->
             Now = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
             %% Get new credentials if these will expire in less than 5 minutes
@@ -925,11 +922,7 @@ get_credentials_from_role(#aws_config{assume_role = AssumeRole} = Config) ->
         secret_access_key = proplists:get_value(secret_access_key, Creds),
         session_token = proplists:get_value(session_token, Creds),
         expiration_gregorian_seconds = ExpireAt},
-    application:set_env(erlcloud,
-                        {role_credentials,
-                         AssumeRole#aws_assume_role.role_arn,
-                         AssumeRole#aws_assume_role.external_id},
-                        Record),
+    set_env_for_role_credentials(AssumeRole#aws_assume_role.role_arn, AssumeRole#aws_assume_role.external_id, Record),
     {ok, Record}.
 
 port_to_str(Port) when is_integer(Port) ->
@@ -1368,3 +1361,29 @@ error_msg( Message ) ->
 error_msg( Format, Values ) ->
     Error = iolist_to_binary( io_lib:format( Format, Values ) ),
     throw( {error, Error} ).
+
+-dialyzer({nowarn_function, unset_env_for_role_credentials/2}).
+-spec unset_env_for_role_credentials(Arn, ExtId) -> ok
+      when Arn :: string() | undefined,
+           ExtId :: string() | undefined.
+unset_env_for_role_credentials(Arn, ExtId) ->
+     % application:unset_env is undocumented in regards to type(Par) =/= atom()
+    application:unset_env(erlcloud, {role_credentials, Arn, ExtId}).
+
+-dialyzer({nowarn_function, get_env_for_role_credentials/2}).
+-spec get_env_for_role_credentials(Arn, ExtId) -> undefined | {ok, Val}
+      when Arn :: string() | undefined,
+           ExtId :: string() | undefined,
+           Val :: term().
+get_env_for_role_credentials(Arn, ExtId) ->
+    % application:get_env is undocumented in regards to type(Par) =/= atom()
+    application:get_env(erlcloud, {role_credentials, Arn, ExtId}).
+
+-dialyzer({nowarn_function, set_env_for_role_credentials/3}).
+-spec set_env_for_role_credentials(Arn, ExtId, Val) -> ok
+      when Arn :: string() | undefined,
+           ExtId :: string() | undefined,
+           Val :: term().
+set_env_for_role_credentials(Arn, ExtId, Val) ->
+    % application:set_env is undocumented in regards to type(Par) =/= atom()
+    application:set_env(erlcloud, {role_credentials, Arn, ExtId}, Val).

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -600,10 +600,12 @@ update_config(#aws_config{} = Config) ->
                    security_token = Credentials#metadata_credentials.security_token}}
     end.
 
+-dialyzer({no_return, clear_config/1}).
 -spec clear_config(aws_config()) -> ok.
 clear_config(#aws_config{assume_role = #aws_assume_role{role_arn = Arn, external_id = ExtId}}) ->
     unset_env_for_role_credentials(Arn, ExtId).
 
+-dialyzer({no_match, clear_expired_configs/0}).
 -spec clear_expired_configs() -> ok.
 clear_expired_configs() ->
     Env = application:get_all_env(erlcloud),
@@ -890,6 +892,7 @@ prop_to_list_defined( Name, Props ) ->
     end.
 
 
+-dialyzer({no_return, get_role_credentials/1}).
 -spec get_role_credentials(aws_config()) -> {ok, #role_credentials{}}.
 get_role_credentials(#aws_config{assume_role = AssumeRole} = Config) ->
     case get_env_for_role_credentials(AssumeRole#aws_assume_role.role_arn, AssumeRole#aws_assume_role.external_id) of
@@ -904,6 +907,7 @@ get_role_credentials(#aws_config{assume_role = AssumeRole} = Config) ->
             get_credentials_from_role(Config)
     end.
 
+-compile({nowarn_unused_function, get_credentials_from_role/1}).
 -spec get_credentials_from_role(aws_config()) -> {ok, #role_credentials{}}.
 get_credentials_from_role(#aws_config{assume_role = AssumeRole} = Config) ->
     %% We have to reset the assume role to make sure we do not

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -549,7 +549,7 @@ config_env() ->
         _ -> {error, environment_config_unavailable}
     end.
 
--spec config_metadata(task_credentials | instance_metadata) -> {ok, #metadata_credentials{}} | {error, metadata_not_available | container_credentials_unavailable | httpc_result_error()}.
+-spec config_metadata(task_credentials | instance_metadata) -> {ok, aws_config()} | {error, metadata_not_available | container_credentials_unavailable | httpc_result_error()}.
 config_metadata(Source) ->
     Config = #aws_config{},
     case get_metadata_credentials( Source, Config ) of

--- a/src/erlcloud_cloudformation.erl
+++ b/src/erlcloud_cloudformation.erl
@@ -841,9 +841,7 @@ cloudformation_rollback_configuration_fields(#cloudformation_rollback_configurat
                 RollbackConfig#cloudformation_rollback_configuration.rollback_triggers
             )
         )
-    ]);
-cloudformation_rollback_configuration_fields(_) ->
-    [].
+    ]).
 
 cloudformation_rollback_triggers_fields(RollbackTriggers) ->
     lists:map(fun cloudformation_rollback_trigger_fields/1, RollbackTriggers).

--- a/src/erlcloud_cloudformation.erl
+++ b/src/erlcloud_cloudformation.erl
@@ -841,7 +841,9 @@ cloudformation_rollback_configuration_fields(#cloudformation_rollback_configurat
                 RollbackConfig#cloudformation_rollback_configuration.rollback_triggers
             )
         )
-    ]).
+    ]);
+cloudformation_rollback_configuration_fields(_) ->
+    [].
 
 cloudformation_rollback_triggers_fields(RollbackTriggers) ->
     lists:map(fun cloudformation_rollback_trigger_fields/1, RollbackTriggers).

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -42,7 +42,10 @@
 -type metric_filters() :: jsx:json_term().
 
 -type tag():: {binary(), binary()}.
--type tags_return() :: jsx:json_term().
+-type tags_return() :: {error, metadata_not_available
+                             | container_credentials_unavailable
+                             | erlcloud_aws:httpc_result_error()}
+                     | {ok, jsx:json_term()}.
 
 
 %% Library initialization
@@ -483,7 +486,9 @@ list_tags_log_group(LogGroup, Config) ->
 -spec tag_log_group(
     log_group_name(),
     list(tag())
-) -> ok.
+) -> {ok, []}
+   | {ok, jsx:json_term()}
+   | {error, erlcloud_aws:httpc_result_error()}.
 
 tag_log_group(LogGroup, Tags) when is_list(Tags) ->
     tag_log_group(LogGroup, Tags, default_config()).
@@ -493,7 +498,9 @@ tag_log_group(LogGroup, Tags) when is_list(Tags) ->
     log_group_name(),
     list(tag()),
     aws_config()
-) -> ok.
+) -> {ok, []}
+   | {ok, jsx:json_term()}
+   | {error, erlcloud_aws:httpc_result_error()}.
 
 tag_log_group(LogGroup, Tags, Config) when is_list(Tags) ->
     Params = [{<<"logGroupName">>, LogGroup},

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -3446,7 +3446,8 @@ tag_resource(ResourceArn, Tags, Config) ->
                            projection_expression_opt().
 -type transact_get_items_opts() :: [transact_get_items_transact_item_opts()].
 
--type transact_get_items_get_item() :: {table_name(), key(), transact_get_items_transact_item_opts()}.
+-type transact_get_items_get_item() :: {table_name(), key()}
+                                     | {table_name(), key(), transact_get_items_opts()}.
 
 -type transact_get_items_get() :: {get, transact_get_items_get_item()}.
 
@@ -3456,7 +3457,7 @@ tag_resource(ResourceArn, Tags, Config) ->
 -type transact_get_items_return() :: ddb_return(#ddb2_transact_get_items{}, out_item()).
 
 -spec dynamize_transact_get_items_transact_items(transact_write_items_transact_items())
-                                          -> json_pair().
+                                          -> [jsx:json_term()].
 dynamize_transact_get_items_transact_items(TransactItems) ->
     dynamize_maybe_list(fun dynamize_transact_get_items_transact_item/1, TransactItems).
 
@@ -3605,7 +3606,7 @@ dynamize_transact_write_items_transact_item({update, {TableName, Key, UpdateExpr
     [{<<"Update">>, [{<<"TableName">>, TableName}, {<<"Key">>, dynamize_key(Key)}, {<<"UpdateExpression">>, dynamize_expression(UpdateExpression)} | AwsOpts]}].
 
 -spec dynamize_transact_write_items_transact_items(transact_write_items_transact_items())
-                                          -> json_pair().
+                                          -> [jsx:json_term()].
 dynamize_transact_write_items_transact_items(TransactItems) ->
     dynamize_maybe_list(fun dynamize_transact_write_items_transact_item/1, TransactItems).
 
@@ -3677,7 +3678,6 @@ transact_write_items(TransactItems, Opts, Config) ->
     case out(Return,
              fun(Json, UOpts) -> undynamize_record(transact_write_items_record(), Json, UOpts) end, DdbOpts,
              #ddb2_transact_write_items.attributes, {ok, []}) of
-        {simple, Record} -> {ok, Record};
         {ok, _} = Out -> Out;
         {error, _} = Out -> Out
     end.
@@ -4338,11 +4338,8 @@ dynamize_replica_auto_scaling_updates(ReplicaUpdates) ->
                          Update) || Update <- ReplicaUpdates].
 
 -spec maybe_update_config_timeout(aws_config(), MinDesiredTimeout :: pos_integer()) -> aws_config().
-maybe_update_config_timeout(Config, MinDesiredTimeout) ->
-    UpdatedTimeout = case erlcloud_aws:get_timeout(Config) of
-                         undefined -> MinDesiredTimeout;
-                         ProvidedTimeout -> ProvidedTimeout
-                     end,
+maybe_update_config_timeout(Config, _MinDesiredTimeout) ->
+    UpdatedTimeout = erlcloud_aws:get_timeout(Config),
     Config#aws_config{timeout = UpdatedTimeout}.
 
 -type update_table_replica_auto_scaling_opt() :: {global_secondary_index_updates, [global_secondary_index_auto_scaling_update_opts()]}|

--- a/src/erlcloud_ddb_util.erl
+++ b/src/erlcloud_ddb_util.erl
@@ -513,7 +513,7 @@ batch_write_retry(RequestItems, Config) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec wait_for_table_active(table_name(), pos_integer() | infinity, non_neg_integer(), aws_config()) ->
+-spec wait_for_table_active(table_name(), pos_integer() | infinity, non_neg_integer() | infinity, aws_config()) ->
     ok | {error, deleting | retry_threshold_exceeded | any()}.
 wait_for_table_active(Table, Interval, RetryTimes, Config) when is_binary(Table), Interval > 0, RetryTimes >= 0 ->
     case erlcloud_ddb2:describe_table(Table, [{out, record}], Config) of

--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -540,8 +540,6 @@ describe_all(Fun, AwsConfig, Marker, Acc) ->
     case Fun(Marker, AwsConfig) of
         {ok, Res} ->
             {ok, lists:append(Acc, Res)};
-        {ok, Res, NewMarker} ->
-            describe_all(Fun, AwsConfig, NewMarker, lists:append(Acc, Res));
         {{paged, NewMarker}, Res} ->
             describe_all(Fun, AwsConfig, NewMarker, lists:append(Acc, Res));
         {error, Reason} ->

--- a/src/erlcloud_guardduty.erl
+++ b/src/erlcloud_guardduty.erl
@@ -82,8 +82,8 @@ list_detectors(Config) ->
 list_detectors(Marker, MaxItems) ->
     list_detectors(Marker, MaxItems, default_config()).
 
--spec list_detectors(Marker   :: binary(),
-                     MaxItems :: integer(),
+-spec list_detectors(Marker   :: undefined | binary(),
+                     MaxItems :: undefined | integer(),
                      Config   :: aws_config()) -> gd_return().
 list_detectors(Marker, MaxItems, Config) ->
     Path = "/detector",
@@ -123,11 +123,7 @@ guardduty_request_no_update(Config, Method, Path, Body, QParam) ->
     end.
 
 encode_body(undefined) ->
-    <<>>;
-encode_body([]) ->
-    <<"{}">>;
-encode_body(Body) ->
-    jsx:encode(Body).
+    <<>>.
 
 headers(Method, Uri, Config, Body, QParam) ->
     Headers = [{"host", Config#aws_config.guardduty_host},

--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -786,7 +786,7 @@ list_virtual_mfa_devices(AssignmentStatus, Marker, #aws_config{} = Config) ->
 list_virtual_mfa_devices(AssignmentStatus, Marker, MaxItems) ->
     list_virtual_mfa_devices(AssignmentStatus, Marker, MaxItems, default_config()).
 
--spec list_virtual_mfa_devices(string(), string(), string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} | {error, any()}.
+-spec list_virtual_mfa_devices(undefined | string(), undefined | string(), undefined | string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} | {error, any()}.
 list_virtual_mfa_devices(AssignmentStatus, Marker, MaxItems, #aws_config{} = Config) ->
     Params = make_list_virtual_mfa_devices_params(AssignmentStatus, Marker, MaxItems),
     ItemPath = "/ListVirtualMFADevicesResponse/ListVirtualMFADevicesResult/VirtualMFADevices/member",
@@ -803,7 +803,7 @@ list_virtual_mfa_devices_all(#aws_config{} = Config) ->
 list_virtual_mfa_devices_all(AssignmentStatus) ->
     list_virtual_mfa_devices_all(AssignmentStatus, default_config()).
 
--spec list_virtual_mfa_devices_all(string(), aws_config()) -> {ok, proplist()} | {error, any()}.
+-spec list_virtual_mfa_devices_all(undefined | string(), aws_config()) -> {ok, proplist()} | {error, any()}.
 list_virtual_mfa_devices_all(AssignmentStatus, #aws_config{} = Config) ->
     Params = make_list_virtual_mfa_devices_params(AssignmentStatus, undefined, undefined),
     ItemPath = "/ListVirtualMFADevicesResponse/ListVirtualMFADevicesResult/VirtualMFADevices/member",

--- a/src/erlcloud_states.erl
+++ b/src/erlcloud_states.erl
@@ -539,7 +539,7 @@ start_execution(StateMachineArn, Options) ->
     start_execution(StateMachineArn, Options, default_config()).
 
 -spec start_execution(StateMachineArn   :: binary(),
-                      Options           :: list(),
+                      Options           :: list() | map(),
                       Config            :: aws_config()) ->
     {ok, map()} | {error, any()}.
 start_execution(StateMachineArn, Options, Config)
@@ -573,7 +573,7 @@ stop_execution(ExecutionArn, Options) ->
     stop_execution(ExecutionArn, Options, default_config()).
 
 -spec stop_execution(ExecutionArn   :: binary(),
-                     Options           :: list(),
+                     Options           :: list() | map(),
                      Config            :: aws_config()) ->
     {ok, map()} | {error, any()}.
 stop_execution(ExecutionArn, Options, Config)

--- a/src/erlcloud_states.erl
+++ b/src/erlcloud_states.erl
@@ -539,7 +539,7 @@ start_execution(StateMachineArn, Options) ->
     start_execution(StateMachineArn, Options, default_config()).
 
 -spec start_execution(StateMachineArn   :: binary(),
-                      Options           :: list() | map(),
+                      Options           :: map(),
                       Config            :: aws_config()) ->
     {ok, map()} | {error, any()}.
 start_execution(StateMachineArn, Options, Config)
@@ -573,7 +573,7 @@ stop_execution(ExecutionArn, Options) ->
     stop_execution(ExecutionArn, Options, default_config()).
 
 -spec stop_execution(ExecutionArn   :: binary(),
-                     Options           :: list() | map(),
+                     Options           :: map(),
                      Config            :: aws_config()) ->
     {ok, map()} | {error, any()}.
 stop_execution(ExecutionArn, Options, Config)

--- a/src/erlcloud_util.erl
+++ b/src/erlcloud_util.erl
@@ -110,14 +110,14 @@ query_all(QueryFun, Config, Action, Params, MaxItems, Marker, Acc) ->
     end.
 
 -spec encode_list(string(), [term()]) ->
-    {ok, proplists:proplist()}.
+    proplists:proplist().
 encode_list(ElementName, Elements) ->
     Numbered = lists:zip(lists:seq(1, length(Elements)), Elements),
     [{ElementName ++ ".member." ++ integer_to_list(N), Element} ||
         {N, Element} <- Numbered].
 
 -spec encode_object(string(), proplists:proplist()) ->
-    {ok, proplists:proplist()}.
+    proplists:proplist().
 encode_object(ElementName, ElementParameters) ->
     lists:map(
         fun({Key, Value}) ->
@@ -127,7 +127,7 @@ encode_object(ElementName, ElementParameters) ->
     ).
 
 -spec encode_object_list(string(), [proplists:proplist()]) ->
-    {ok, proplists:proplist()}.
+    proplists:proplist().
 encode_object_list(Prefix, ElementParameterList) ->
     lists:flatten(lists:foldl(
         fun(ElementMap, Acc) ->


### PR DESCRIPTION
I pulled `master`, ran `make check` and fixed all dialyzer issues.

I'm comfortable with all commits except for the last one, 9c93a76, where I explicitly hand pick certain `dialyzer` warnings to have them ignored, for the sake of a "clean" run.

This means that if these functions are changed, in the future, to something that might cause those issues, they will still be ignored (they are all caused by invalid - as per documentation - calls to `application:`).

In the end, I ran `make eunit` which caused the "Revert previous change..." commit.