### PR TITLE
Extend VPC description with cidr_block_association_set

### DIFF
--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -2459,10 +2459,30 @@ extract_vpc(Node) ->
       {dhcp_options_id, get_text("dhcpOptionsId", Node)},
       {instance_tenancy, get_text("instanceTenancy", Node)},
       {is_default, get_bool("isDefault", Node)},
-      {tag_set, 
+      {cidr_block_association_set, extract_cidr_block_association_set(Node)},
+      {tag_set,
         [extract_tag_item(Item)
          || Item <- xmerl_xpath:string("tagSet/item", Node)]}
- ].
+    ].
+
+extract_cidr_block_association_set(Node) ->
+    Items = xmerl_xpath:string("cidrBlockAssociationSet/item", Node),
+    [extract_cidr_block_association_item(Item) || Item <- Items].
+
+extract_cidr_block_association_item(Node) ->
+    [
+         {cidr_block, get_text("cidrBlock", Node)},
+         {association_id, get_text("associationId", Node)},
+         {cidr_block_state,
+            [{state, get_text("cidrBlockState/state", Node)}] ++
+            case get_text("cidrBlockState/statusMessage", Node, undefined) of
+                undefined ->
+                    [];
+                StatusMessage ->
+                    [{status_message, StatusMessage}]
+            end
+         }
+    ].
 
 -spec detach_internet_gateway(string(), string()) -> ok.
 detach_internet_gateway(GatewayID, VpcID) ->

--- a/test/erlcloud_ec2_tests.erl
+++ b/test/erlcloud_ec2_tests.erl
@@ -203,6 +203,14 @@ describe_vpcs_tests(_) ->
                                     <state>associated</state>
                                 </cidrBlockState>
                             </item>
+                            <item>
+                                <cidrBlock>10.1.0.0/16</cidrBlock>
+                                <associationId>vpc-cidr-assoc-00000000000000002</associationId>
+                                <cidrBlockState>
+                                    <state>test state</state>
+                                    <statusMessage>test status message</statusMessage>
+                                </cidrBlockState>
+                            </item>
                         </cidrBlockAssociationSet>
                         <tagSet>
                             <item>
@@ -228,6 +236,11 @@ describe_vpcs_tests(_) ->
                            {cidr_block, "10.0.0.0/16"},
                            {association_id, "vpc-cidr-assoc-00000000000000001"},
                            {cidr_block_state, [{state, "associated"}]}
+                        ],
+                        [
+                           {cidr_block, "10.1.0.0/16"},
+                           {association_id, "vpc-cidr-assoc-00000000000000002"},
+                           {cidr_block_state, [{state, "test state"}, {status_message, "test status message"}]}
                         ]
                     ]},
                     {tag_set, [

--- a/test/erlcloud_ec2_tests.erl
+++ b/test/erlcloud_ec2_tests.erl
@@ -38,6 +38,7 @@ describe_test_() ->
      fun start/0,
      fun stop/1,
      [
+      fun describe_vpcs_tests/1,
       fun describe_tags_input_tests/1,
       fun describe_tags_output_tests/1,
       fun request_spot_fleet_input_tests/1,
@@ -181,6 +182,62 @@ output_tests(Fun, Tests) ->
 %%% Actual test specifiers
 %%%===================================================================
 
+describe_vpcs_tests(_) ->
+    Tests = [
+        ?_ec2_test({
+            "Describe all the vpcs",
+            "<DescribeVpcsResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\">
+                <requestId>9a0571b9-6e91-47e7-b75f-785125322853</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-00000000000000001</vpcId>
+                        <ownerId>000000000001</ownerId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-00000001</dhcpOptionsId>
+                        <cidrBlockAssociationSet>
+                            <item>
+                                <cidrBlock>10.0.0.0/16</cidrBlock>
+                                <associationId>vpc-cidr-assoc-00000000000000001</associationId>
+                                <cidrBlockState>
+                                    <state>associated</state>
+                                </cidrBlockState>
+                            </item>
+                        </cidrBlockAssociationSet>
+                        <tagSet>
+                            <item>
+                                <key>Key</key>
+                                <value>Value</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>",
+            {ok, [
+                [
+                    {vpc_id, "vpc-00000000000000001"},
+                    {state, "available"},
+                    {cidr_block, "10.0.0.0/16"},
+                    {dhcp_options_id, "dopt-00000001"},
+                    {instance_tenancy, "default"},
+                    {is_default, false},
+                    {cidr_block_association_set, [
+                        [
+                           {cidr_block, "10.0.0.0/16"},
+                           {association_id, "vpc-cidr-assoc-00000000000000001"},
+                           {cidr_block_state, [{state, "associated"}]}
+                        ]
+                    ]},
+                    {tag_set, [
+                        [{key, "Key"}, {value, "Value"}]
+                    ]}
+                ]
+            ]}
+        })
+    ],
+    output_tests(?_f(erlcloud_ec2:describe_vpcs()), Tests).
 
 %% DescribeTags test based on the API examples:
 %% http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeTags.html


### PR DESCRIPTION
#### Problem
VPC description has missing information about CIDR block associations. Amazon VPC allows customers to expand their VPCs by adding secondary IPv4 address ranges to their VPCs. https://aws.amazon.com/about-aws/whats-new/2017/08/amazon-virtual-private-cloud-vpc-now-allows-customers-to-expand-their-existing-vpcs/

#### Solution
Extract the information about CIDR block associations based on https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpcs.html