### PR TITLE
allow using configured VPCe

### DIFF
--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -19,6 +19,7 @@
                   lhttpc]},
   {modules, []},
   {env, [
+      % Example [{<<"kinesis">>, <<"myAZdnsentry.amazonaws.com">>}]
       {services_vpc_endpoints, []}
   ]},
   {licenses, ["MIT"]},

--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -18,7 +18,9 @@
                   %% hackney,
                   lhttpc]},
   {modules, []},
-  {env, []},
+  {env, [
+      {services_vpc_endpoints, []}
+  ]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/erlcloud/erlcloud"}]}
  ]

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -14,7 +14,7 @@
          default_config_region/2, default_config_override/1,
          update_config/1,clear_config/1, clear_expired_configs/0,
          service_config/3, service_host/2,
-         configure_vpce/2, get_vpce/0,
+         configure_vpc_endpoints/2, get_vpc_endpoints/0,
          configure/1, format_timestamp/1,
          http_headers_body/1,
          http_body/1,
@@ -812,9 +812,9 @@ service_host( Service, Region ) when is_binary(Service) ->
         application:get_env(erlcloud, services_vpc_endpoints, []),
             Default).
 
--spec configure_vpce(binary(), list(binary())) -> ok.
+-spec configure_vpc_endpoints(binary(), list(binary())) -> ok.
 % take the list of possible endpoints and pick the one suites from our AZ.
-configure_vpce(Service, Endpoints) when is_binary(Service) ->
+configure_vpc_endpoints(Service, Endpoints) when is_binary(Service) ->
     %% default config is fine. no IAM is used
     case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", erlcloud_aws:default_config()) of
         {ok, AZ} ->
@@ -829,8 +829,8 @@ configure_vpce(Service, Endpoints) when is_binary(Service) ->
             Err
     end.
 
--spec get_vpce () -> list({binary(), binary()}).
-get_vpce() ->
+-spec get_vpc_endpoints () -> list({binary(), binary()}).
+get_vpc_endpoints() ->
     application:get_env(erlcloud, services_vpc_endpoints, []).
 
 -spec configure(aws_config()) -> {ok, aws_config()}.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -812,11 +812,11 @@ service_host( Service, Region ) when is_binary(Service) ->
         application:get_env(erlcloud, services_vpc_endpoints, []),
             Default).
 
--spec configure_vpc_endpoints(binary(), list(binary())) -> ok.
+-spec configure_vpc_endpoints(binary(), list(binary())) -> ok | {error, httpc_result_error()}.
 % take the list of possible endpoints and pick the one suites from our AZ.
 configure_vpc_endpoints(Service, Endpoints) when is_binary(Service) ->
     %% default config is fine. no IAM is used
-    case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", erlcloud_aws:default_config()) of
+    case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", default_config()) of
         {ok, AZ} ->
             case [{binary:match(AZ, E), E} || E <- Endpoints, is_binary(E)] of
                 [] ->  ok;

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -818,7 +818,7 @@ configure_vpc_endpoints(Service, Endpoints) when is_binary(Service) ->
     %% default config is fine. no IAM is used
     case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", default_config()) of
         {ok, AZ} ->
-            case [{binary:match(AZ, E), E} || E <- Endpoints, is_binary(E)] of
+            case [{binary:match(E, AZ), E} || E <- Endpoints, is_binary(E)] of
                 [{nomatch, _}] ->  ok;
                 % take the first match
                 [{_, Endpoint} | _ ] ->


### PR DESCRIPTION
problem: interface VPCe do not mitigate cross-AZ traffic in EC2/ECS environments.

solution: allow top level app to configure it. 
deliberately not doing ecs2 describe-vpe-endpoints nor ip magic in /etc/hosts since it has it's flaws with large number of instances. 
instead configure it ones at startup on application level from application env

cc @kkuzmin @nalundgaard 

might add add helper function to configure that via AZ. 