### PR TITLE
allow to use pre-configured VPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,24 @@ Example of such app.config:
 ].
 ```
 
+### VPC endpoints
+If you want to utilise AZ affinity for VPC endpoints you can configure those in application config via:
+```erlang
+{erlcloud, [
+    {services_vpc_endpoints, [
+        {<<"sqs">>, [<<"myAZ1.sqs-dns.amazonaws.com">>, <<"myAZ2.sqs-dns.amazonaws.com">>]},
+        {<<"kinesis">>, {env, "KINESIS_VPC_ENDPOINTS"}}
+    ]}
+]}
+```
+Two options supported:
+ - explicit lists of route53 AZ endpoints
+ - OS environment variable, comes handy for ECS deployments.
+ 
+Upon config generation, `erlcloud` will check the AZ of the deployment and match it to one of the pre-configured DNS records to use.
 
-### Basic use ###
+
+## Basic use ##
 Then you can start making API calls, like:
 ```
 erlcloud_ec2:describe_images().

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ If you want to utilise AZ affinity for VPC endpoints you can configure those in 
 ```
 Two options supported:
  - explicit lists of route53 AZ endpoints
- - OS environment variable, comes handy for ECS deployments.
+ - OS environment variable, comes handy for ECS deployments. Env should be of comma separated string like:`"myAZ1.sqs-dns.amazonaws.com,myAZ2.sqs-dns.amazonaws.com"`
  
-Upon config generation, `erlcloud` will check the AZ of the deployment and match it to one of the pre-configured DNS records to use.
+Upon config generation, `erlcloud` will check the AZ of the deployment and match it to the first one of the pre-configured DNS records to use.
 
 
 ## Basic use ##

--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ Two options supported:
  - explicit lists of route53 AZ endpoints
  - OS environment variable, comes handy for ECS deployments. Env should be of comma separated string like:`"myAZ1.sqs-dns.amazonaws.com,myAZ2.sqs-dns.amazonaws.com"`
  
-Upon config generation, `erlcloud` will check the AZ of the deployment and match it to the first one of the pre-configured DNS records to use.
+Upon config generation, `erlcloud` will check the AZ of the deployment 
+and match it to one of the pre-configured DNS records. First match is used and if not match found default is used. 
 
 
 ## Basic use ##

--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -18,7 +18,11 @@
                   %% hackney,
                   lhttpc]},
   {modules, []},
-  {env, []},
+  {env, [
+      % Example   [{<<"kinesis">>, [<<"myAZ1.amazonaws.com">>, <<"myAZ2.amazonaws.com">>]}]
+      % or vi ENV [{<<"kinesis">>, {env, "KINESIS_VPC_ENDPOINTS"}]
+      {services_vpc_endpoints, []}
+  ]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/erlcloud/erlcloud"}]}
  ]

--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -19,7 +19,7 @@
                   lhttpc]},
   {modules, []},
   {env, [
-      % Example   [{<<"kinesis">>, [<<"myAZ1.amazonaws.com">>, <<"myAZ2.amazonaws.com">>]}]
+      % Example    [{<<"kinesis">>, [<<"myAZ1.amazonaws.com">>, <<"myAZ2.amazonaws.com">>]}]
       % or via ENV [{<<"kinesis">>, {env, "KINESIS_VPC_ENDPOINTS"}]
       {services_vpc_endpoints, []}
   ]},

--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -20,7 +20,7 @@
   {modules, []},
   {env, [
       % Example   [{<<"kinesis">>, [<<"myAZ1.amazonaws.com">>, <<"myAZ2.amazonaws.com">>]}]
-      % or vi ENV [{<<"kinesis">>, {env, "KINESIS_VPC_ENDPOINTS"}]
+      % or via ENV [{<<"kinesis">>, {env, "KINESIS_VPC_ENDPOINTS"}]
       {services_vpc_endpoints, []}
   ]},
   {licenses, ["MIT"]},

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -827,7 +827,9 @@ get_host_vpc_endpoint(Service, Default) when is_binary(Service) ->
 
 pick_vpc_endpoint([], Default) -> Default;
 pick_vpc_endpoint(Endpoints, Default) ->
-    case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", default_config()) of
+    % it fine to use default here - no IAM is used, only for http client
+    % one cannot use auto_config()/default_cfg() as it creates an infinite recursion.
+    case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", #aws_config{}) of
         {ok, AZ} ->
             lists:foldl(
                 fun (E , Acc) ->

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -161,11 +161,14 @@ aws_region_from_host(Host) ->
         %% the second is the region identifier, the rest is ignored
         %% the exception (of course) is the dynamodb streams and the marketplace which follows a
         %% different format
+        %% another exception is VPC endpoints
         ["streams", "dynamodb", Value | _Rest] ->
             Value;
         [Prefix, "marketplace", Value | _Rest]
-            when Prefix =:= "metering"; Prefix =:= "entitlement" ->
-                Value;
+                when Prefix =:= "metering"; Prefix =:= "entitlement" ->
+            Value;
+        [_, _, Value, "vpce" | _Rest] ->
+            Value;
         [_, Value, _, _ | _Rest] ->
             Value;
         _ ->

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -831,7 +831,7 @@ pick_vpc_endpoint(Endpoints, Default) ->
     % one cannot use auto_config()/default_cfg() as it creates an infinite recursion.
     case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", #aws_config{}) of
         {ok, AZ} ->
-            lists:foldl(
+            AZEndpoint = lists:foldl(
                 fun (E , Acc) ->
                     case {binary:match(E, AZ), Acc == Default} of
                         {nomatch, _} -> Acc;
@@ -843,7 +843,8 @@ pick_vpc_endpoint(Endpoints, Default) ->
                 end,
                 Default,
                 Endpoints
-            );
+            ),
+            binary_to_list(AZEndpoint);
         {error, _} ->
             Default
     end.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -819,11 +819,15 @@ get_host_vpc_endpoint(Service, Default) when is_binary(Service) ->
     Endpoints = case ConfiguredEndpoints of
         {env, EnvVarName} when is_list(EnvVarName) ->
             Es = string:split(os:getenv(EnvVarName, ""), ",", all),
-            [list_to_binary(E) || E <- Es];
+            [list_to_binary(E) || E <- Es, E /= ""];
         EndpointsList when is_list(EndpointsList) ->
             EndpointsList
     end,
-    % now get our AZ and match
+    % now match our AZ to configured ones
+    pick_vpc_endpoint(Endpoints, Default).
+
+pick_vpc_endpoint([], Default) -> Default;
+pick_vpc_endpoint(Endpoints, Default) ->
     case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", default_config()) of
         {ok, AZ} ->
             lists:foldl(

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -802,8 +802,8 @@ service_host( Service, <<"cn-north-1">> = Region ) when is_binary(Service) ->
 service_host( Service, <<"cn-northwest-1">> = Region ) when is_binary(Service) ->
     binary_to_list( <<Service/binary, $., Region/binary, ".amazonaws.com.cn">> );
 service_host( Service, Region ) when is_binary(Service) andalso is_binary(Region) ->
-    Default = binary_to_list( <<Service/binary, $., Region/binary, ".amazonaws.com">> ),
-    get_host_vpc_endpoint(Service, Default).
+    Default = <<Service/binary, $., Region/binary, ".amazonaws.com">>,
+    binary_to_list(get_host_vpc_endpoint(Service, Default)).
 
 -spec get_host_vpc_endpoint(binary(), binary()) -> binary().
 % some services can have VPCe configured and we allow to mitigate cross-AZ traffic.
@@ -831,7 +831,7 @@ pick_vpc_endpoint(Endpoints, Default) ->
     % one cannot use auto_config()/default_cfg() as it creates an infinite recursion.
     case erlcloud_ec2_meta:get_instance_metadata("placement/availability-zone", #aws_config{}) of
         {ok, AZ} ->
-            AZEndpoint = lists:foldl(
+            lists:foldl(
                 fun (E , Acc) ->
                     case {binary:match(E, AZ), Acc == Default} of
                         {nomatch, _} -> Acc;
@@ -843,8 +843,7 @@ pick_vpc_endpoint(Endpoints, Default) ->
                 end,
                 Default,
                 Endpoints
-            ),
-            binary_to_list(AZEndpoint);
+            );
         {error, _} ->
             Default
     end.


### PR DESCRIPTION
problem: interface VPCe do not mitigate cross-AZ traffic in EC2/ECS environments.
original #637 
problem: some time VPCe need to be using in single AZ mode and not to pay for cross-AZ overhead. 


solution: allow top level app to configure it.
deliberately **not** doing ecs2 describe-vpe-endpoints nor ip magic in /etc/hosts since it has it's flaws with large number of instances.
instead configure it ones at startup on application level from application env

cc @kkuzmin @nalundgaard

might add add helper function to configure that via AZ.