### PR TITLE
Prepare for the future - OTP 23 (http_uri:parse/1)

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1738,7 +1738,7 @@ create_notification_param_xml({cloud_function, CF}, Acc) -> [{'CloudFunction', [
 -spec get_bucket_and_key(string()) -> {string(), string()}.
 
 get_bucket_and_key(Uri) ->
-  {ok, Parsed} = http_uri:parse(Uri),
+  {ok, Parsed} = erlcloud_util:uri_parse(Uri),
   {Host, Path} = extract_host_and_path(Parsed),
   extract_location_fields(Host, Path).
 

--- a/src/erlcloud_util.erl
+++ b/src/erlcloud_util.erl
@@ -16,7 +16,8 @@
     encode_object/2,
     encode_object_list/2,
     next_token/2,
-    filter_undef/1
+    filter_undef/1,
+    uri_parse/1
 ]).
 
 -define(MAX_ITEMS, 1000).
@@ -174,3 +175,25 @@ next_token(Path, XML) ->
 -spec filter_undef(proplists:proplist()) -> proplists:proplist().
 filter_undef(List) ->
     lists:filter(fun({_Name, Value}) -> Value =/= undefined end, List).
+
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 23).
+uri_parse(Uri) ->
+    URIMap = uri_string:parse(Uri),
+    DefaultScheme = "https",
+    DefaultPort = 443,
+    Scheme = list_to_atom(maps:get(scheme, URIMap, DefaultScheme)),
+    UserInfo = maps:get(userinfo, URIMap, ""),
+    Host = maps:get(host, URIMap, ""),
+    Port = maps:get(port, URIMap, DefaultPort),
+    Path = maps:get(path, URIMap, ""),
+    Query = maps:get(query, URIMap, ""),
+    {ok, {Scheme, UserInfo, Host, Port, Path, Query}}.
+-else.
+uri_parse(Uri) ->
+    http_uri:parse(Uri).
+-endif.
+-else.
+uri_parse(Uri) ->
+    http_uri:parse(Uri).
+-endif.

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -189,7 +189,7 @@ get_url_from_history([{_, {erlcloud_httpc, request, [Url, _, _, _, _, _]}, _}]) 
     Url.
 
 test_url(ExpScheme, ExpHost, ExpPort, ExpPath, Url) ->
-    {ok, {Scheme, _UserInfo, Host, Port, Path, _Query}} = http_uri:parse(Url),
+    {ok, {Scheme, _UserInfo, Host, Port, Path, _Query}} = erlcloud_util:uri_parse(Url),
     [?_assertEqual(ExpScheme, Scheme),
      ?_assertEqual(ExpHost, Host),
      ?_assertEqual(ExpPort, Port),

--- a/test/erlcloud_s3_tests.erl
+++ b/test/erlcloud_s3_tests.erl
@@ -41,7 +41,8 @@ operation_test_() ->
             fun get_bucket_encryption_test/1,
             fun get_bucket_encryption_not_found_test/1,
             fun delete_bucket_encryption_test/1,
-            fun hackney_proxy_put_validation_test/1
+            fun hackney_proxy_put_validation_test/1,
+            fun get_bucket_and_key/1
         ]}.
 
 start() ->
@@ -823,3 +824,7 @@ hackney_proxy_put_validation_test(_) ->
                   ,{"x-amz-version-id", "version_id"}
                   ], Result).
 
+get_bucket_and_key(_) ->
+    ErlcloudS3ExportExample = "https://s3.amazonaws.com/some_bucket/path_to_file",
+    Result = erlcloud_s3:get_bucket_and_key(ErlcloudS3ExportExample),
+    ?_assertEqual({"some_bucket","path_to_file"}, Result).


### PR DESCRIPTION
This PR fixes one of the classes of issues (the use of `http_uri:parse/1`) that I stumbled upon while `dialyzer`ing in OTP 23.

Some other "issues" persist and I'll get around to them if/when I have time.

I've added a very basic test, and `make eunit` is without error.

At any rate, `.travis.yml`, is not set for OTP 22 or 23.