### PR TITLE
Add dialyzer checks to Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ eunit.coverage.xml
 ercloud.iml
 *[#]*[#]
 *[#]*
+.dialyzer_plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - make travis-install
 script:
   - make check_warnings
+  - make check
   - make eunit
 deploy:
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -57,23 +57,32 @@ else
 	@$(REBAR) eunit
 endif
 
+.dialyzer_plt:
+	dialyzer --build_plt -r deps \
+		--apps erts kernel stdlib inets crypto public_key ssl xmerl \
+		--fullpath \
+		--output_plt .dialyzer_plt
+
 check:
 ifeq ($(REBAR_VSN),2)
 	@$(REBAR) compile
-	dialyzer --verbose --no_check_plt --no_native --fullpath \
+	$(MAKE) .dialyzer_plt
+	dialyzer --no_check_plt --fullpath \
 		$(CHECK_FILES) \
-		-Wunmatched_returns \
-		-Werror_handling
+		-I include \
+		--plt .dialyzer_plt
 else
 	@$(REBAR) dialyzer
 endif
 
 check-eunit: eunit
 ifeq ($(REBAR_VSN),2)
-	dialyzer --verbose --no_check_plt --no_native --fullpath \
+	@$(REBAR) compile
+	$(MAKE) .dialyzer_plt
+	dialyzer --no_check_plt --fullpath \
 		$(CHECK_EUNIT_FILES) \
-		-Wunmatched_returns \
-		-Werror_handling
+		-I include \
+		--plt .dialyzer_plt
 else
 	@$(REBAR) dialyzer
 endif

--- a/rebar.config
+++ b/rebar.config
@@ -35,3 +35,5 @@
             {test, [{deps, [{meck, "0.8.13"}]}]}
            ,{warnings, [{erl_opts, [warnings_as_errors]}]}
            ]}.
+
+{post_hooks, [{clean, "rm -f .dialyzer_plt"}]}.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -819,7 +819,7 @@ get_host_vpc_endpoint(Service, Default) when is_binary(Service) ->
     %% resolve through ENV if any
     Endpoints = case ConfiguredEndpoints of
         {env, EnvVarName} when is_list(EnvVarName) ->
-            Es = string:split(os:getenv(EnvVarName, ""), ",", all),
+            Es = string_split(os:getenv(EnvVarName, ""), ","),
             % ignore "" env var or ",," cases
             [list_to_binary(E) || E <- Es, E /= ""];
         EndpointsList when is_list(EndpointsList) ->
@@ -827,6 +827,17 @@ get_host_vpc_endpoint(Service, Default) when is_binary(Service) ->
     end,
     % now match our AZ to configured ones
     pick_vpc_endpoint(Endpoints, Default).
+
+-ifdef(AT_LEAST_20).
+string_split(String, Char) ->
+    string:split(String, Char, all).
+-else.
+string_split(String, Char) ->
+    Subject = list_to_binary(String),
+    Pattern = list_to_binary(Char),
+    Options = [global],
+    [binary_to_list(Elem) || Elem <- binary:split(Subject, Pattern, Options)].
+-endif.
 
 pick_vpc_endpoint([], Default) -> Default;
 pick_vpc_endpoint(Endpoints, Default) ->

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -177,8 +177,8 @@ create_log_group(LogGroupName, Tags, Config) when is_list(Tags) ->
 
 -spec create_log_group(
         log_group_name(),
-        list(tag()),
-        kms_key_id(),
+        undefined | list(tag()),
+        undefined | kms_key_id(),
         aws_config()
 ) -> ok | error_result().
 create_log_group(LogGroupName, Tags, KmsKeyId, Config) ->


### PR DESCRIPTION
This Pull Request is an attempt at trying to prevent further dialyzer -related warnings/issues from creeping into the project.

I had to update the `Makefile` for rebar 2 to run with the current Travis matrix, only to find another issue: the use of `string:split` in OTP 19.3 (introduced in 90b7ee2, from Apr.04.20). This function was only [added in OTP 20.0](https://erlang.org/doc/man/string.html#split-2). This issue was fixed, since it derived from the original fix's context.