### PR TITLE
Prepare for the future - OTP 24 (crypto:hmac/3)

### DIFF
--- a/src/erlcloud_util.erl
+++ b/src/erlcloud_util.erl
@@ -21,12 +21,32 @@
 
 -define(MAX_ITEMS, 1000).
 
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 23).
+sha_mac(K, S) ->
+    crypto:mac(hmac, sha, K, S).
+-else.
 sha_mac(K, S) ->
     crypto:hmac(sha, K, S).
+-endif.
+-else.
+sha_mac(K, S) ->
+    crypto:hmac(sha, K, S).
+-endif.
 
 
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 23).
+sha256_mac(K, S) ->
+    crypto:mac(hmac, sha256, K, S).
+-else.
 sha256_mac(K, S) ->
     crypto:hmac(sha256, K, S).
+-endif.
+-else.
+sha256_mac(K, S) ->
+    crypto:hmac(sha256, K, S).
+-endif.
 
 sha256(V) ->
     crypto:hash(sha256, V).


### PR DESCRIPTION
This PR fixes one of the classes of issues (the use of `crypto:hmac/3`) that I stumbled upon while compiling on OTP 23.

Another "issue" persists and I'll get around to it if/when I have time.

At any rate, `.travis.yml`, is not (yet) set for OTP 23.