### PR TITLE
Be stricter on eunit compilation-based warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ otp_release:
   - 20.3
   - 21.3
   - 22.3
+  - 23.0
 env:
   global:
   - MAIN_OTP=20.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ install:
   - make travis-install
 script:
   - make check_warnings
+  - make eunit_warnings
   - make check
+  - make check-eunit
   - make eunit
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ branches:
 install:
   - make travis-install
 script:
-  - make check_warnings
-  - make eunit_warnings
+  - make warnings
   - make check
-  - make check-eunit
   - make eunit
 deploy:
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ ifeq ($(REBAR_VSN),2)
 	$(MAKE) .dialyzer_plt
 	dialyzer --no_check_plt --fullpath \
 		$(CHECK_EUNIT_FILES) \
-		$(CHECK_FILES) \
 		-I include \
 		--plt .dialyzer_plt
 else

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,10 @@ else
 	@$(REBAR) as warnings compile
 endif
 
-eunit_warnings: deps
+warnings: deps
 ifeq ($(REBAR_VSN),2)
-	@$(REBAR) compile_only=true eunit
+	@WARNINGS_AS_ERRORS=true $(REBAR) compile
+	@WARNINGS_AS_ERRORS=true $(REBAR) compile_only=true eunit
 else
 	@$(REBAR) as test compile
 endif
@@ -74,22 +75,11 @@ endif
 check: deps
 ifeq ($(REBAR_VSN),2)
 	$(MAKE) compile
-	$(MAKE) .dialyzer_plt
-	dialyzer --no_check_plt --fullpath \
-		$(CHECK_FILES) \
-		-I include \
-		--plt .dialyzer_plt
-else
-	@$(REBAR) dialyzer
-endif
-
-check-eunit: deps
-ifeq ($(REBAR_VSN),2)
-	$(MAKE) compile
-	$(MAKE) .dialyzer_plt
 	@$(REBAR) compile_only=true eunit
+	$(MAKE) .dialyzer_plt
 	dialyzer --no_check_plt --fullpath \
 		$(CHECK_EUNIT_FILES) \
+		$(CHECK_FILES) \
 		-I include \
 		--plt .dialyzer_plt
 else

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ CHECK_FILES=\
 	ebin/*.beam
 
 CHECK_EUNIT_FILES=\
-	$(CHECK_FILES) \
 	.eunit/*.beam
 
 
@@ -49,6 +48,13 @@ else
 	@$(REBAR) as warnings compile
 endif
 
+eunit_warnings:
+ifeq ($(REBAR_VSN),2)
+	@echo skip checking warnings
+else
+	@$(REBAR) as test compile
+endif
+
 eunit:
 ifeq ($(REBAR_VSN),2)
 	@$(REBAR) compile
@@ -75,7 +81,7 @@ else
 	@$(REBAR) dialyzer
 endif
 
-check-eunit: eunit
+check-eunit:
 ifeq ($(REBAR_VSN),2)
 	@$(REBAR) compile
 	$(MAKE) .dialyzer_plt
@@ -84,7 +90,7 @@ ifeq ($(REBAR_VSN),2)
 		-I include \
 		--plt .dialyzer_plt
 else
-	@$(REBAR) dialyzer
+	@$(REBAR) as test dialyzer
 endif
 
 doc:

--- a/Makefile
+++ b/Makefile
@@ -41,23 +41,25 @@ else
 	$(REBAR) shell
 endif
 
-check_warnings:
+deps: get-deps
+
+check_warnings: deps
 ifeq ($(REBAR_VSN),2)
-	@echo skip checking warnings
+	@$(REBAR) compile
 else
 	@$(REBAR) as warnings compile
 endif
 
-eunit_warnings:
+eunit_warnings: deps
 ifeq ($(REBAR_VSN),2)
-	@echo skip checking warnings
+	@$(REBAR) compile_only=true eunit
 else
 	@$(REBAR) as test compile
 endif
 
-eunit:
+eunit: deps
 ifeq ($(REBAR_VSN),2)
-	@$(REBAR) compile
+	$(MAKE) compile
 	@$(REBAR) eunit skip_deps=true
 else
 	@$(REBAR) eunit
@@ -69,9 +71,9 @@ endif
 		--fullpath \
 		--output_plt .dialyzer_plt
 
-check:
+check: deps
 ifeq ($(REBAR_VSN),2)
-	@$(REBAR) compile
+	$(MAKE) compile
 	$(MAKE) .dialyzer_plt
 	dialyzer --no_check_plt --fullpath \
 		$(CHECK_FILES) \
@@ -81,10 +83,11 @@ else
 	@$(REBAR) dialyzer
 endif
 
-check-eunit:
+check-eunit: deps
 ifeq ($(REBAR_VSN),2)
-	@$(REBAR) compile
+	$(MAKE) compile
 	$(MAKE) .dialyzer_plt
+	@$(REBAR) compile_only=true eunit
 	dialyzer --no_check_plt --fullpath \
 		$(CHECK_EUNIT_FILES) \
 		-I include \

--- a/include/erlcloud.hrl
+++ b/include/erlcloud.hrl
@@ -5,7 +5,7 @@
 -type datetime() :: {{pos_integer(), 1..12, 1..31}, {0..23, 0..59, 0..60}}.
 -type paging_token() :: binary() | undefined.
 
--type success_result_paged(ObjectType) :: {ok, [ObjectType]}.
+-type success_result_paged(ObjectType) :: {ok, ObjectType}.
 -type error_result() :: {error, Reason :: term()}.
 -type result_paged(ObjectType) :: success_result_paged(ObjectType) | error_result().
 -type result(ObjectType) :: {ok, [ObjectType]} | error_result().

--- a/include/erlcloud_as.hrl
+++ b/include/erlcloud_as.hrl
@@ -26,15 +26,15 @@
 -record(aws_autoscaling_group, {
           group_name :: string(),
           availability_zones :: undefined | list(string()),
-          load_balancer_names :: list(string()),
+          load_balancer_names :: undefined | list(string()),
           tags :: list(aws_autoscaling_tag()),
           desired_capacity :: undefined | integer(),
           min_size :: undefined | integer(),
           max_size :: undefined | integer(),
           launch_configuration_name :: undefined | string(),
           vpc_zone_id :: undefined | list(string()),
-          instances :: list(aws_autoscaling_instance()),
-          status :: string()
+          instances :: undefined | list(aws_autoscaling_instance()),
+          status :: undefined | string()
          }).
 -type(aws_autoscaling_group() :: #aws_autoscaling_group{}).
 
@@ -42,7 +42,7 @@
           name :: string(),
           image_id :: string(),
           instance_type :: string(),
-          tenancy :: string(),
+          tenancy :: undefined | string(),
           user_data :: undefined | string(),
           security_groups = [] :: list(string()),
           public_ip_address = false :: undefined | boolean(),
@@ -61,7 +61,7 @@
           status_code :: string(),
           status_msg :: string(),
           start_time :: datetime(),
-          end_time :: datetime(),
+          end_time :: undefined | datetime(),
           progress :: integer()
          }).
 -type(aws_autoscaling_activity() :: #aws_autoscaling_activity{}).

--- a/include/erlcloud_cloudformation.hrl
+++ b/include/erlcloud_cloudformation.hrl
@@ -5,55 +5,55 @@
 
 -record(cloudformation_create_stack_input, {
     capabilities = [] :: [string()], %% list containing CAPABILITY_IAM | CAPABILITY_NAMED_IAM | CAPABILITY_AUTO_EXPAND
-    client_request_token :: string(),
-    disable_rollback :: boolean(),
-    enable_termination_protection :: boolean(),
+    client_request_token :: undefined | string(),
+    disable_rollback :: undefined | boolean(),
+    enable_termination_protection :: undefined | boolean(),
     notification_arns = [] :: [string()],
     on_failure = "ROLLBACK" :: string(), %% DO_NOTHING | ROLLBACK | DELETE
     parameters = [] :: [cloudformation_parameter()],
     resource_types = [] :: [string()],
-    role_arn :: string(),
+    role_arn :: undefined | string(),
     rollback_configuration :: undefined | cloudformation_rollback_configuration(),
     stack_name :: string(),
-    stack_policy_body :: string(),
-    stack_policy_url :: string(),
+    stack_policy_body :: undefined | string(),
+    stack_policy_url :: undefined | string(),
     tags = []:: [cloudformation_tag()],
-    template_body :: string(),
-    template_url :: string(),
-    timeout_in_minutes :: integer()
+    template_body :: undefined | string(),
+    template_url :: undefined | string(),
+    timeout_in_minutes :: undefined | integer()
 }).
 
 -record(cloudformation_update_stack_input, {
     capabilities = [] :: [string()], %% list containing CAPABILITY_IAM | CAPABILITY_NAMED_IAM | CAPABILITY_AUTO_EXPAND
-    client_request_token :: string(),
+    client_request_token :: undefined | string(),
     notification_arns = [] :: [string()],
     parameters = [] :: [cloudformation_parameter()],
     resource_types = [] :: [string()],
-    role_arn :: string(),
-    rollback_configuration :: cloudformation_rollback_configuration(),
+    role_arn :: undefined | string(),
+    rollback_configuration :: undefined | cloudformation_rollback_configuration(),
     stack_name :: string(),
-    stack_policy_body :: string(),
-    stack_policy_during_update_body :: string(),
-    stack_policy_during_update_url :: string(),
-    stack_policy_url :: string(),
+    stack_policy_body :: undefined | string(),
+    stack_policy_during_update_body :: undefined | string(),
+    stack_policy_during_update_url :: undefined | string(),
+    stack_policy_url :: undefined | string(),
     tags = []:: [cloudformation_tag()],
-    template_body :: string(),
-    template_url :: string(),
-    use_previous_template :: boolean()
+    template_body :: undefined | string(),
+    template_url :: undefined | string(),
+    use_previous_template :: undefined | boolean()
 }).
 
 -record(cloudformation_delete_stack_input, {
-    client_request_token :: string(),
+    client_request_token :: undefined | string(),
     retain_resources = [] :: [string()],
-    role_arn :: string(),
-    stack_name :: string()
+    role_arn :: undefined | string(),
+    stack_name :: undefined | string()
 }).
 
 -record(cloudformation_parameter, {
     parameter_key :: string(),
     parameter_value :: string(),
-    resolved_value :: string(),
-    use_previous_value :: boolean()
+    resolved_value :: undefined | string(),
+    use_previous_value :: undefined | boolean()
 }).
 
 -record(cloudformation_rollback_configuration, {

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -279,16 +279,16 @@
 -record(ddb2_q, 
         {consumed_capacity :: undefined | #ddb2_consumed_capacity{},
          count :: undefined | non_neg_integer(),
-         items :: undefined | [erlcloud_ddb2:out_item()],
-         last_evaluated_key :: undefined | erlcloud_ddb2:key(),
+         items :: undefined | [erlcloud_ddb2:out_item()] | [binary()],
+         last_evaluated_key :: undefined | erlcloud_ddb2:key() | binary(),
          scanned_count :: undefined | non_neg_integer()
         }).
 
 -record(ddb2_scan, 
         {consumed_capacity :: undefined | #ddb2_consumed_capacity{},
          count :: undefined | non_neg_integer(),
-         items :: undefined | [erlcloud_ddb2:out_item()],
-         last_evaluated_key :: undefined | erlcloud_ddb2:key(),
+         items :: undefined | [erlcloud_ddb2:out_item()] | [binary()],
+         last_evaluated_key :: undefined | erlcloud_ddb2:key() | binary(),
          scanned_count :: undefined | non_neg_integer()
         }).
 

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -361,7 +361,7 @@
          provisioned_throughput :: undefined | #ddb2_provisioned_throughput{},
          table_arn :: undefined | binary(),
          table_creation_date_time :: undefined | number(),
-         table_id :: undefined | number() | binary(),
+         table_id :: undefined | binary(),
          table_name :: undefined | binary(),
          table_size_bytes :: undefined | integer()
         }).

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -279,7 +279,7 @@
 -record(ddb2_q, 
         {consumed_capacity :: undefined | #ddb2_consumed_capacity{},
          count :: undefined | non_neg_integer(),
-         items :: undefined | [erlcloud_ddb2:out_item()] | [binary()],
+         items :: undefined | [erlcloud_ddb2:out_item()],
          last_evaluated_key :: undefined | erlcloud_ddb2:key() | binary(),
          scanned_count :: undefined | non_neg_integer()
         }).
@@ -287,7 +287,7 @@
 -record(ddb2_scan, 
         {consumed_capacity :: undefined | #ddb2_consumed_capacity{},
          count :: undefined | non_neg_integer(),
-         items :: undefined | [erlcloud_ddb2:out_item()] | [binary()],
+         items :: undefined | [erlcloud_ddb2:out_item()],
          last_evaluated_key :: undefined | erlcloud_ddb2:key() | binary(),
          scanned_count :: undefined | non_neg_integer()
         }).

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -113,8 +113,8 @@
         {last_decrease_date_time :: undefined | date_time(),
          last_increase_date_time :: undefined | date_time(),
          number_of_decreases_today :: undefined | integer(),
-         read_capacity_units :: undefined | non_neg_integer(),
-         write_capacity_units :: undefined | non_neg_integer()
+         read_capacity_units :: undefined | pos_integer(),
+         write_capacity_units :: undefined | pos_integer()
         }).
 
 -record(ddb2_global_secondary_index_description,

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -280,7 +280,7 @@
         {consumed_capacity :: undefined | #ddb2_consumed_capacity{},
          count :: undefined | non_neg_integer(),
          items :: undefined | [erlcloud_ddb2:out_item()],
-         last_evaluated_key :: undefined | erlcloud_ddb2:key() | binary(),
+         last_evaluated_key :: undefined | erlcloud_ddb2:key(),
          scanned_count :: undefined | non_neg_integer()
         }).
 
@@ -288,7 +288,7 @@
         {consumed_capacity :: undefined | #ddb2_consumed_capacity{},
          count :: undefined | non_neg_integer(),
          items :: undefined | [erlcloud_ddb2:out_item()],
-         last_evaluated_key :: undefined | erlcloud_ddb2:key() | binary(),
+         last_evaluated_key :: undefined | erlcloud_ddb2:key(),
          scanned_count :: undefined | non_neg_integer()
         }).
 

--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -47,8 +47,14 @@
         {index_name :: undefined | binary(),
          provisioned_throughput_override :: undefined | #ddb2_provisioned_throughput_override{}}).
 
+-record(ddb2_replica_global_secondary_index_auto_scaling_description,
+        {index_name :: undefined | binary(),
+         index_status :: undefined | index_status(),
+         provisioned_read_capacity_auto_scaling_settings :: undefined | #ddb2_auto_scaling_settings_description{},
+         provisioned_write_capacity_auto_scaling_settings :: undefined | #ddb2_auto_scaling_settings_description{}}).
+
 -record(ddb2_replica_auto_scaling_description,
-        {global_secondary_indexes :: undefined | [#ddb2_replica_global_secondary_index_description{}],
+        {global_secondary_indexes :: undefined | [#ddb2_replica_global_secondary_index_auto_scaling_description{}],
          region_name :: undefined | binary(),
          replica_provisioned_read_capacity_auto_scaling_settings :: undefined | #ddb2_auto_scaling_settings_description{},
          replica_provisioned_write_capacity_auto_scaling_settings :: undefined | #ddb2_auto_scaling_settings_description{},
@@ -72,15 +78,13 @@
          provisioned_write_capacity_auto_scaling_settings :: undefined | #ddb2_auto_scaling_settings_description{},
          provisioned_write_capacity_units :: undefined | pos_integer()}).
 
--record(ddb2_replica_global_secondary_index_auto_scaling_description,
-        {index_name :: undefined | binary(),
-         index_status :: undefined | binary(),
-         provisioned_read_capacity_auto_scaling_settings :: undefined | #ddb2_auto_scaling_settings_description{},
-         provisioned_write_capacity_auto_scaling_settings :: undefined | #ddb2_auto_scaling_settings_description{}}).
+-record(ddb2_billing_mode_summary,
+        {billing_mode :: undefined | erlcloud_ddb2:billing_mode(),
+        last_update_to_pay_per_request_date_time :: undefined | date_time()}).
 
 -record(ddb2_replica_settings_description,
         {region_name :: undefined | binary(),
-         replica_billing_mode_summary :: undefined | binary(),
+         replica_billing_mode_summary :: undefined | #ddb2_billing_mode_summary{},
          replica_global_secondary_index_settings :: undefined | [#ddb2_replica_global_secondary_index_settings_description{}],
          replica_provisioned_read_capacity_auto_scaling_settings :: undefined | #ddb2_auto_scaling_settings_description{},
          replica_provisioned_read_capacity_units :: undefined | number(),
@@ -105,16 +109,12 @@
          replication_group :: undefined | [#ddb2_replica{}]
         }).
 
--record(ddb2_billing_mode_summary,
-       {billing_mode :: undefined | erlcloud_ddb2:billing_mode(),
-        last_update_to_pay_per_request_date_time :: undefined | date_time()}).
-
 -record(ddb2_provisioned_throughput_description,
         {last_decrease_date_time :: undefined | date_time(),
          last_increase_date_time :: undefined | date_time(),
          number_of_decreases_today :: undefined | integer(),
-         read_capacity_units :: undefined | pos_integer(),
-         write_capacity_units :: undefined | pos_integer()
+         read_capacity_units :: undefined | non_neg_integer(),
+         write_capacity_units :: undefined | non_neg_integer()
         }).
 
 -record(ddb2_global_secondary_index_description,
@@ -361,7 +361,7 @@
          provisioned_throughput :: undefined | #ddb2_provisioned_throughput{},
          table_arn :: undefined | binary(),
          table_creation_date_time :: undefined | number(),
-         table_id :: undefined | number(),
+         table_id :: undefined | number() | binary(),
          table_name :: undefined | binary(),
          table_size_bytes :: undefined | integer()
         }).
@@ -388,7 +388,7 @@
         {global_secondary_indexes :: undefined | [#ddb2_global_secondary_index_info{}],
          local_secondary_indexes  :: undefined | [#ddb2_local_secondary_index_info{}],
          sse_description :: undefined | erlcloud_ddb2:sse_description(),
-         stream_description :: undefined | #ddb2_stream_description{},
+         stream_description :: undefined | #ddb2_stream_description{} | {boolean(), erlcloud_ddb2:stream_view_type()},
          time_to_live_description :: undefined | #ddb2_time_to_live_description{}
         }).
 

--- a/include/erlcloud_ec2.hrl
+++ b/include/erlcloud_ec2.hrl
@@ -29,24 +29,24 @@
           image_id::string(),
           min_count=1::pos_integer(),
           max_count=1::pos_integer(),
-          key_name::string(),
+          key_name::undefined | string(),
           group_set=["default"]::[string()],
           user_data::undefined|binary(),
           instance_type::string(),
-          availability_zone::string(),
-          placement_group::string(),
-          kernel_id::string(),
-          ramdisk_id::string(),
+          availability_zone::undefined | string(),
+          placement_group::undefined | string(),
+          kernel_id::undefined | string(),
+          ramdisk_id::undefined | string(),
           block_device_mapping=[]::[ec2_block_device_mapping()],
           monitoring_enabled=false::boolean(),
           subnet_id::string(),
           disable_api_termination=false::boolean(),
-          instance_initiated_shutdown_behavior::ec2_shutdown_behavior(),
+          instance_initiated_shutdown_behavior::undefined | ec2_shutdown_behavior(),
           net_if=[] :: [#ec2_net_if{}],
           ebs_optimized = false :: boolean(),
-          iam_instance_profile_name = undefined :: string(),
-          spot_price::string(),
-          weighted_capacity::number()
+          iam_instance_profile_name :: undefined | string(),
+          spot_price::undefined | string(),
+          weighted_capacity::undefined | number()
          }).
 -record(ec2_image_spec, {
           image_location::string(),
@@ -70,15 +70,15 @@
          }).
 -record(spot_fleet_request_config_spec, {
           allocation_strategy::undefined|lowest_price|diversified,
-          client_token::string(),
-          excess_capacity_termination_policy::no_termination|default,
+          client_token::undefined|string(),
+          excess_capacity_termination_policy::undefined|no_termination|default,
           iam_fleet_role::string(),
           launch_specification=[]::[#ec2_instance_spec{}],
           spot_price::string(),
           target_capacity::pos_integer(),
-          terminate_instances_with_expiration::true|false,
-          valid_from::datetime(),
-          valid_until::datetime()
+          terminate_instances_with_expiration::undefined|true|false,
+          valid_from::undefined|datetime(),
+          valid_until::undefined|datetime()
          }).
 -record(ec2_spot_fleet_request, {
           spot_fleet_request_config::#spot_fleet_request_config_spec{}

--- a/include/erlcloud_ecs.hrl
+++ b/include/erlcloud_ecs.hrl
@@ -38,14 +38,14 @@
 }).
 
 -record(ecs_deployment, {
-    created_at :: undefined | pos_integer(),
+    created_at :: undefined | pos_integer() | float(),
     desired_count :: undefined | pos_integer(),
     id :: undefined | binary(),
-    pending_count :: undefined | pos_integer(),
-    running_count :: undefined | pos_integer(),
+    pending_count :: undefined | non_neg_integer(),
+    running_count :: undefined | non_neg_integer(),
     status :: undefined | binary(),
     task_definition:: undefined | binary(),
-    updated_at :: undefined | pos_integer()
+    updated_at :: undefined | float()
 }).
 
 -record(ecs_event, {
@@ -62,12 +62,12 @@
 }).
 
 -record(ecs_cluster, {
-    active_services_count :: undefined | pos_integer(),
+    active_services_count :: undefined | non_neg_integer(),
     cluster_arn :: undefined | binary(),
     cluster_name :: undefined | binary(),
-    pending_tasks_count :: undefined | pos_integer(),
-    registered_container_instances_count :: undefined | pos_integer(),
-    running_tasks_count :: undefined | pos_integer(),
+    pending_tasks_count :: undefined | non_neg_integer(),
+    registered_container_instances_count :: undefined | non_neg_integer(),
+    running_tasks_count :: undefined | non_neg_integer(),
     status :: undefined | binary()
 }).
 
@@ -79,9 +79,9 @@
     desired_count :: undefined | pos_integer(),
     events :: undefined | [#ecs_event{}],
     load_balancers :: undefined | [#ecs_load_balancer{}],
-    pending_count :: undefined | pos_integer(),
+    pending_count :: undefined | non_neg_integer(),
     role_arn :: undefined | binary(),
-    running_count :: undefined | pos_integer(),
+    running_count :: undefined | non_neg_integer(),
     service_arn :: undefined | binary(),
     service_name :: undefined | binary(),
     status :: undefined | binary(),
@@ -89,11 +89,11 @@
 }).
 
 -record(ecs_resource, {
-   double_value :: undefined | pos_integer(),
-   integer_value :: undefined | pos_integer(),
-   long_value :: undefined | pos_integer(),
+   double_value :: undefined | non_neg_integer(),
+   integer_value :: undefined | non_neg_integer(),
+   long_value :: undefined | non_neg_integer(),
    name :: undefined | binary(),
-   string_set_value :: undefined | binary(),
+   string_set_value :: undefined | [binary()],
    type :: undefined | binary()
 }).
 
@@ -109,10 +109,10 @@
     attributes :: undefined | [#ecs_attribute{}],
     container_instance_arn :: undefined | binary(),
     ec2_instance_id :: undefined | binary(),
-    pending_tasks_count :: undefined | pos_integer(),
+    pending_tasks_count :: undefined | non_neg_integer(),
     registered_resources :: undefined | [#ecs_resource{}],
     remaining_resources :: undefined | [#ecs_resource{}],
-    running_tasks_count :: undefined | pos_integer(),
+    running_tasks_count :: undefined | non_neg_integer(),
     status :: undefined | binary(),
     version_info :: undefined | #ecs_version_info{}
 }).
@@ -210,7 +210,7 @@
 -record(ecs_task_definition, {
     container_definitions :: undefined | [#ecs_container_definition{}],
     family :: undefined | binary(),
-    network_mode :: undefined | binary(),
+    network_mode :: undefined | ecs_network_mode(),
     requires_attributes :: undefined | [#ecs_attribute{}],
     revision :: undefined | pos_integer(),
     status :: undefined | binary(),

--- a/include/erlcloud_ecs.hrl
+++ b/include/erlcloud_ecs.hrl
@@ -38,14 +38,14 @@
 }).
 
 -record(ecs_deployment, {
-    created_at :: undefined | pos_integer() | float(),
+    created_at :: undefined | pos_integer(),
     desired_count :: undefined | pos_integer(),
     id :: undefined | binary(),
     pending_count :: undefined | non_neg_integer(),
     running_count :: undefined | non_neg_integer(),
     status :: undefined | binary(),
     task_definition:: undefined | binary(),
-    updated_at :: undefined | float()
+    updated_at :: undefined | pos_integer()
 }).
 
 -record(ecs_event, {

--- a/include/erlcloud_ecs.hrl
+++ b/include/erlcloud_ecs.hrl
@@ -38,18 +38,18 @@
 }).
 
 -record(ecs_deployment, {
-    created_at :: undefined | pos_integer(),
+    created_at :: undefined | number(),
     desired_count :: undefined | pos_integer(),
     id :: undefined | binary(),
     pending_count :: undefined | non_neg_integer(),
     running_count :: undefined | non_neg_integer(),
     status :: undefined | binary(),
     task_definition:: undefined | binary(),
-    updated_at :: undefined | pos_integer()
+    updated_at :: undefined | number()
 }).
 
 -record(ecs_event, {
-    created_at :: undefined | pos_integer(),
+    created_at :: undefined | number(),
     id :: undefined | binary(),
     message :: undefined | binary()
 }).
@@ -73,7 +73,7 @@
 
 -record(ecs_service, {
     cluster_arn :: undefined | binary(),
-    created_at :: undefined | pos_integer(),
+    created_at :: undefined | number(),
     deployment_configuration :: undefined | #ecs_deployment_configuration{},
     deployments :: undefined | [#ecs_deployment{}],
     desired_count :: undefined | pos_integer(),
@@ -251,7 +251,7 @@
     cluster_arn :: undefined | binary(),
     container_instance_arn :: undefined | binary(),
     containers :: undefined | [#ecs_container{}],
-    created_at :: undefined | pos_integer(),
+    created_at :: undefined | number(),
     desired_status:: undefined | binary(),
     last_status :: undefined | binary(),
     overrides :: undefined | #ecs_task_override{},

--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
 
 
 {profiles, [
-            {test, [{deps, [{meck, "0.8.13"}]}]}
+            {test, [{deps, [{meck, "0.8.13"}]}, {erl_opts, [warnings_as_errors]}]}
            ,{warnings, [{erl_opts, [warnings_as_errors]}]}
            ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
 
 
 {profiles, [
-            {test, [{deps, [{meck, "0.8.13"}]}, {erl_opts, [warnings_as_errors]}]}
+            {test, [{deps, [{meck, "0.9.0"}]}, {erl_opts, [warnings_as_errors]}]}
            ,{warnings, [{erl_opts, [warnings_as_errors]}]}
            ]}.
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,7 +5,7 @@ case erlang:function_exported(rebar3, main, 1) of
     false -> % rebar 2.x or older
         %% Use git-based deps
         %% profiles
-        [{deps, [{meck, ".*",{git, "https://github.com/eproxus/meck.git", {tag, "0.8.13"}}},
+        [{deps, [{meck, ".*",{git, "https://github.com/eproxus/meck.git", {tag, "0.9.0"}}},
                  {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.11.0"}}},
                  %% {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.2.0"}}},
                  {eini, ".*", {git, "https://github.com/erlcloud/eini.git", {tag, "1.2.7"}}},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,11 +5,21 @@ case erlang:function_exported(rebar3, main, 1) of
     false -> % rebar 2.x or older
         %% Use git-based deps
         %% profiles
+        CONFIG_DEPS =
         [{deps, [{meck, ".*",{git, "https://github.com/eproxus/meck.git", {tag, "0.9.0"}}},
                  {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.11.0"}}},
                  %% {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.2.0"}}},
                  {eini, ".*", {git, "https://github.com/erlcloud/eini.git", {tag, "1.2.7"}}},
                  {lhttpc, ".*", {git, "git://github.com/erlcloud/lhttpc", {tag, "1.6.2"}}},
                  {base16, ".*", {git, "https://github.com/goj/base16.git", {tag, "1.0.0"}}}]}
-         | lists:keydelete(deps, 1, CONFIG)]
+         | lists:keydelete(deps, 1, CONFIG)],
+        CONFIG_NEW =
+            case os:getenv("WARNINGS_AS_ERRORS") of
+                "true" ->
+                    [{erl_opts, [warnings_as_errors | proplists:get_value(erl_opts, CONFIG_DEPS)]}
+                     | lists:keydelete(erl_opts, 1, CONFIG_DEPS)];
+                _ ->
+                    CONFIG_DEPS
+            end,
+        CONFIG_NEW
 end.

--- a/src/erlcloud_application_autoscaler.erl
+++ b/src/erlcloud_application_autoscaler.erl
@@ -66,7 +66,7 @@
                                    | container_credentials_unavailable
                                    | erlcloud_aws:httpc_result_error()}.
 
--type aws_aas_request_body() :: [proplist:proplist()].
+-type aws_aas_request_body() :: proplists:proplist().
 
 -spec extract_alarm(J :: proplist()) -> response().
 extract_alarm(J) ->
@@ -317,7 +317,7 @@ delete_scaling_policy(Configuration, BodyConfiguration) ->
 %%------------------------------------------------------------------------------
 
 -spec delete_scheduled_action(
-                            Configuration :: erlcloud_aws:aws_config(),
+                            Configuration :: aws_config(),
                             ResourceId :: binary(),
                             ScalableDimension :: binary(),
                             ScheduledActionName :: binary(),
@@ -345,7 +345,7 @@ delete_scheduled_action(Configuration, BodyConfiguration) ->
 %%------------------------------------------------------------------------------
 
 -spec deregister_scalable_target(
-                            Configuration :: erlcloud_aws:aws_config(),
+                            Configuration :: aws_config(),
                             ResourceId :: binary(),
                             ScalableDimension :: binary(),
                             ServiceNamespace :: binary()
@@ -357,7 +357,7 @@ deregister_scalable_target(Configuration, ResourceId, ScalableDimension, Service
     deregister_scalable_target(Configuration, BodyProps).
 
 -spec deregister_scalable_target(
-                            Configuration :: erlcloud_aws:aws_config(),
+                            Configuration :: aws_config(),
                             BodyConfiguration :: aws_aas_request_body()
                             ) -> ok_error_response().
 deregister_scalable_target(Configuration, BodyConfiguration) ->
@@ -371,7 +371,7 @@ deregister_scalable_target(Configuration, BodyConfiguration) ->
 %%------------------------------------------------------------------------------
 
 -spec describe_scalable_targets(
-                            erlcloud_aws:aws_config(),
+                            aws_config(),
                             aws_aas_request_body() |  binary()
                             ) -> ok_error_response().
 describe_scalable_targets(Configuration, ServiceNamespace) when is_binary(ServiceNamespace)->
@@ -399,7 +399,7 @@ describe_scalable_targets(Configuration, BodyConfiguration) ->
 %%------------------------------------------------------------------------------
 
 -spec describe_scaling_activities(
-                            erlcloud_aws:aws_config(),
+                            aws_config(),
                             aws_aas_request_body() |  binary()
                             ) -> ok_error_response().
 describe_scaling_activities(Configuration, ServiceNamespace) when is_binary(ServiceNamespace) ->
@@ -428,7 +428,7 @@ describe_scaling_activities(Configuration, BodyConfiguration) ->
 %%------------------------------------------------------------------------------
 
 -spec describe_scaling_policies(
-                            erlcloud_aws:aws_config(),
+                            aws_config(),
                             aws_aas_request_body() |  binary()
                             ) -> ok_error_response().
 describe_scaling_policies(Configuration, ServiceNamespace) when is_binary(ServiceNamespace) ->
@@ -457,7 +457,7 @@ describe_scaling_policies(Configuration, BodyConfiguration) ->
 %%------------------------------------------------------------------------------
 
 -spec describe_scheduled_actions(
-                            erlcloud_aws:aws_config(),
+                            aws_config(),
                             aws_aas_request_body() |  binary()
                             ) -> ok_error_response().
 describe_scheduled_actions(Configuration, ServiceNamespace) when is_binary(ServiceNamespace) ->
@@ -506,7 +506,7 @@ put_scaling_policy(Configuration, PolicyName, ResourceId, ScalableDimension, Ser
                             ScalableDimension :: binary(),
                             ServiceNamespace :: binary(),
                             PolicyType :: binary(),
-                            Policy :: [proplist:proplist()]
+                            Policy :: [proplists:proplist()]
                         ) -> ok_error_response().
 put_scaling_policy(Configuration, PolicyName, ResourceId, ScalableDimension, ServiceNamespace, PolicyType, Policy) ->
     BodyProps = [{<<"PolicyName">>, PolicyName},
@@ -522,7 +522,7 @@ put_scaling_policy(Configuration, PolicyName, ResourceId, ScalableDimension, Ser
     end.
 
 -spec put_scaling_policy(
-                            Configuration :: erlcloud_aws:aws_config(),
+                            Configuration :: aws_config(),
                             BodyConfiguration :: aws_aas_request_body()
                             ) -> ok_error_response().
 put_scaling_policy(Configuration, BodyConfiguration) ->
@@ -668,7 +668,7 @@ register_scalable_target(Configuration, ResourceId, ScalableDimension, ServiceNa
     register_scalable_target(Configuration, BodyProps ++ MaybeBodyWithMax ++ MaybeBodyWithMin).
 
 -spec register_scalable_target(
-    Configuration :: erlcloud_aws:aws_config(),
+    Configuration :: aws_config(),
     BodyConfiguration :: aws_aas_request_body()
 ) -> ok_error_response().
 register_scalable_target(Configuration, BodyConfiguration) ->

--- a/src/erlcloud_as.erl
+++ b/src/erlcloud_as.erl
@@ -331,18 +331,16 @@ create_launch_config(#aws_launch_config{
                      },
                      Config) ->
     Params = 
-        lists:concat([
           [
            {"LaunchConfigurationName", LCName},
            {"ImageId", ImageId},
            {"InstanceType", Type}
-          ],
-          when_defined(UserData, [{"UserData", UserData}], []),
-          when_defined(PublicIP, [{"AssociatePublicIpAddress", atom_to_list(PublicIP)}], []),
-          when_defined(Monitoring, [{"InstanceMonitoring.Enabled", atom_to_list(Monitoring)}], []),
-          member_params("SecurityGroups.member.", SGroups),
-          when_defined(KeyPair, [{"KeyName", KeyPair}], [])
-    ]),
+          ]
+          ++ when_defined(UserData, [{"UserData", UserData}], [])
+          ++ when_defined(PublicIP, [{"AssociatePublicIpAddress", atom_to_list(PublicIP)}], [])
+          ++ when_defined(Monitoring, [{"InstanceMonitoring.Enabled", atom_to_list(Monitoring)}], [])
+          ++ member_params("SecurityGroups.member.", SGroups)
+          ++ when_defined(KeyPair, [{"KeyName", KeyPair}], []),
     io:format("~p ~n", [Params]),
     create_launch_config(Params, Config);
 
@@ -373,23 +371,21 @@ create_auto_scaling_group(#aws_autoscaling_group{
                           },
                           Config) ->
     ProcessedTags = lists:flatten([tag_to_member_param(T, Idx) || {T, Idx} <- lists:zip(Tags, lists:seq(1, length(Tags)))]),
-    Params = lists:concat([
-                 [
+    Params = [
                   {"AutoScalingGroupName", GName},
                   {"LaunchConfigurationName", LaunchName},
                   {"MaxSize", integer_to_list(MaxSize)},
                   {"MinSize", integer_to_list(MinSize)}
-                 ],
-                 case VpcZoneIds of
+             ]
+             ++ case VpcZoneIds of
                      undefined -> [];
                      _         ->[{"VPCZoneIdentifier", string:join(VpcZoneIds, ",")}]
-                 end,
-                 case AZones of
+                end
+             ++ case AZones of
                      undefined -> [];
                      _         -> member_params("AvailabilityZones.member.", AZones)
-                 end,
-                 ProcessedTags
-             ]),
+                end
+             ++ ProcessedTags,
     create_auto_scaling_group(Params, Config);
 
 create_auto_scaling_group(Params, Config) ->
@@ -418,35 +414,33 @@ update_auto_scaling_group(#aws_autoscaling_group{
                               availability_zones = AZones
                           },
                           Config) ->
-    Params = lists:concat([
-                 [
+    Params = [
                   {"AutoScalingGroupName", GName}
-                 ],
-                 case LaunchName of
+             ]
+             ++ case LaunchName of
                      undefined -> [];
                      _         -> [{"LaunchConfigurationName", LaunchName}]
-                 end,
-                 case DesiredCapacity of
+                end
+             ++ case DesiredCapacity of
                      undefined -> [];
                      _         -> [{"DesiredCapacity", integer_to_list(DesiredCapacity)}]
-                 end,
-                 case MaxSize of
+                end
+             ++ case MaxSize of
                      undefined -> [];
                      _         -> [{"MaxSize", integer_to_list(MaxSize)}]
-                 end,
-                 case MinSize of
+                end
+             ++ case MinSize of
                      undefined -> [];
                      _         -> [{"MinSize", integer_to_list(MinSize)}]
-                 end,
-                 case VpcZoneIds of
+                end
+             ++ case VpcZoneIds of
                      undefined -> [];
                      _         ->[{"VPCZoneIdentifier", string:join(VpcZoneIds, ",")}]
-                 end,
-                 case AZones of
+                end
+             ++ case AZones of
                      undefined -> [];
                      _         -> member_params("AvailabilityZones.member.", AZones)
-                 end
-             ]),
+                end,
     update_auto_scaling_group(Params, Config);
 
 update_auto_scaling_group(Params, Config) ->

--- a/src/erlcloud_cloudfront.erl
+++ b/src/erlcloud_cloudfront.erl
@@ -181,7 +181,7 @@ list_distributions(Config) when
     list_distributions(?MAX_RESULTS, undefined, Config).
 
 
--spec list_distributions(integer(), string()) -> ok_error(proplist(), string()).
+-spec list_distributions(integer(), undefined | string()) -> ok_error(proplist(), string()).
 list_distributions(MaxResults, Marker) ->
     list_distributions(MaxResults, Marker, erlcloud_aws:default_config()).
 

--- a/src/erlcloud_cloudsearch.erl
+++ b/src/erlcloud_cloudsearch.erl
@@ -56,7 +56,7 @@
 -type cloudsearch_domain_tag() :: [{TagKey :: binary(), TagValue :: string()}].
 -type cloudsearch_index_field_option() :: {
         OptionName :: binary(),
-        OptionValue :: boolean() | string() | null | integer() | float() | list()
+        OptionValue :: boolean() | string() | null | integer() | float() | list() | binary()
 }.
 -type cloudsearch_index_field() :: [cloudsearch_index_field_option()].
 

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -118,38 +118,38 @@ describe_trails(Trails, IncludeShadowTrails, Config) ->
         end,
     ct_request("DescribeTrails", Json, Config).
 
--spec get_trail_status([string()] ) -> ct_return().
+-spec get_trail_status(string() ) -> ct_return().
 get_trail_status(Trail) ->
     get_trail_status(Trail, default_config()).
 
--spec get_trail_status([string()], aws_config()) -> ct_return().
+-spec get_trail_status(string(), aws_config()) -> ct_return().
 get_trail_status(Trail, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}],
     ct_request("GetTrailStatus", Json, Config).
 
--spec get_event_selectors([string()]) -> ct_return().
+-spec get_event_selectors(string()) -> ct_return().
 get_event_selectors(Trail) ->
     get_event_selectors(Trail, default_config()).
 
--spec get_event_selectors([string()], aws_config()) -> ct_return().
+-spec get_event_selectors(string(), aws_config()) -> ct_return().
 get_event_selectors(Trail, Config) ->
     Json = [{<<"TrailName">>, list_to_binary(Trail)}],
     ct_request("GetEventSelectors", Json, Config).
 
--spec start_logging([string()] ) -> ct_return().
+-spec start_logging(string() ) -> ct_return().
 start_logging(Trail) ->
     start_logging(Trail, default_config()).
 
--spec start_logging([string()], aws_config()) -> ct_return().
+-spec start_logging(string(), aws_config()) -> ct_return().
 start_logging(Trail, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}],
     ct_request("StartLogging", Json, Config).
 
--spec stop_logging([string()] ) -> ct_return().
+-spec stop_logging(string() ) -> ct_return().
 stop_logging(Trail) ->
     stop_logging(Trail, default_config()).
 
--spec stop_logging([string()], aws_config()) -> ct_return().
+-spec stop_logging(string(), aws_config()) -> ct_return().
 stop_logging(Trail, Config) ->
     Json = [{<<"Name">>, list_to_binary(Trail)}],
     ct_request("StopLogging", Json, Config).

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -465,7 +465,7 @@ log_stream_order_by(last_event_time) -> <<"LastEventTime">>.
     log_stream_name(),
     seq_token(),
     events()
-) -> datum:either( seq_token() ).
+) -> {ok, seq_token()} | {error, erlcloud_aws:httpc_result_error()}.
 
 put_logs_events(LogGroup, LogStream, SeqToken, Events) ->
     put_logs_events(LogGroup, LogStream, SeqToken, Events, default_config()).
@@ -477,7 +477,7 @@ put_logs_events(LogGroup, LogStream, SeqToken, Events) ->
     seq_token(),
     events(),
     aws_config()
-) -> datum:either( seq_token() ).
+) -> {ok, seq_token()} | {error, erlcloud_aws:httpc_result_error()}.
 
 put_logs_events(LogGroup, LogStream, SeqToken, Events, Config) ->
     case

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -1874,9 +1874,9 @@ dynamize_sse_specification({enabled, Enabled}) when is_boolean(Enabled) ->
 -type create_table_opt() :: {billing_mode, billing_mode()} |
                             {local_secondary_indexes, local_secondary_indexes()} |
                             {global_secondary_indexes, global_secondary_indexes()} |
+                            {provisioned_throughput, {read_units(), write_units()}} |
                             {sse_specification, sse_specification()} |
-                            {stream_specification, stream_specification()} |
-                            {provisioned_throughput, {read_units(), write_units()}}.
+                            {stream_specification, stream_specification()}.
 -type create_table_opts() :: [create_table_opt()].
 
 -spec create_table_opts(key_schema()) -> opt_table().

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -1875,7 +1875,8 @@ dynamize_sse_specification({enabled, Enabled}) when is_boolean(Enabled) ->
                             {local_secondary_indexes, local_secondary_indexes()} |
                             {global_secondary_indexes, global_secondary_indexes()} |
                             {sse_specification, sse_specification()} |
-                            {stream_specification, stream_specification()}.
+                            {stream_specification, stream_specification()} |
+                            {provisioned_throughput, {read_units(), write_units()}}.
 -type create_table_opts() :: [create_table_opt()].
 
 -spec create_table_opts(key_schema()) -> opt_table().
@@ -3443,7 +3444,9 @@ tag_resource(ResourceArn, Tags, Config) ->
 %%%-----------------------------------------------------------------------------
 
 -type transact_get_items_transact_item_opts() :: expression_attribute_names_opt() |
-                           projection_expression_opt().
+                           projection_expression_opt() |
+                           return_consumed_capacity_opt() |
+                           {out, record}.
 -type transact_get_items_opts() :: [transact_get_items_transact_item_opts()].
 
 -type transact_get_items_get_item() :: {table_name(), key()}
@@ -3456,7 +3459,7 @@ tag_resource(ResourceArn, Tags, Config) ->
 
 -type transact_get_items_return() :: ddb_return(#ddb2_transact_get_items{}, out_item()).
 
--spec dynamize_transact_get_items_transact_items(transact_write_items_transact_items())
+-spec dynamize_transact_get_items_transact_items(transact_get_items_transact_items())
                                           -> [jsx:json_term()].
 dynamize_transact_get_items_transact_items(TransactItems) ->
     dynamize_maybe_list(fun dynamize_transact_get_items_transact_item/1, TransactItems).
@@ -3563,9 +3566,12 @@ return_value_on_condition_check_failure_opt() ->
                            expression_attribute_values_opt() |
                            condition_expression_opt() |
                            return_value_on_condition_check_failure_opt().
--type transact_write_items_condition_check_item() :: {table_name(), key(), transact_write_items_transact_item_opt()}.
--type transact_write_items_delete_item() :: {table_name(), key(), transact_write_items_transact_item_opts()}.
--type transact_write_items_put_item() :: {table_name(), in_item(), transact_write_items_transact_item_opts()}.
+-type transact_write_items_condition_check_item() :: {table_name(), key(), transact_write_items_transact_item_opts()}
+                                                   | {table_name(), key(), binary(), transact_write_items_transact_item_opts()}.
+-type transact_write_items_delete_item() :: {table_name(), key()}
+                                       | {table_name(), key(), transact_write_items_transact_item_opts()}.
+-type transact_write_items_put_item() :: {table_name(), in_item()}
+                                       | {table_name(), in_item(), transact_write_items_transact_item_opts()}.
 -type transact_write_items_update_item() :: {table_name(), key(), expression(), transact_write_items_transact_item_opts()}.
 
 -type transact_write_items_condition_check() :: {condition_check, transact_write_items_condition_check_item()}.

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -3446,7 +3446,7 @@ tag_resource(ResourceArn, Tags, Config) ->
 -type transact_get_items_transact_item_opts() :: expression_attribute_names_opt() |
                            projection_expression_opt() |
                            return_consumed_capacity_opt() |
-                           {out, record}.
+                           out_opt().
 -type transact_get_items_opts() :: [transact_get_items_transact_item_opts()].
 
 -type transact_get_items_get_item() :: {table_name(), key()}

--- a/src/erlcloud_ddb_util.erl
+++ b/src/erlcloud_ddb_util.erl
@@ -51,7 +51,7 @@
 -type range_key_name() :: erlcloud_ddb2:range_key_name().
 -type table_name() :: erlcloud_ddb2:table_name().
 
--type items_return() :: {ok, [out_item()]}
+-type items_return() :: {ok, [out_item() | binary()]}
                       | {ok, non_neg_integer()}
                       | {error, term()}.
 

--- a/src/erlcloud_ddb_util.erl
+++ b/src/erlcloud_ddb_util.erl
@@ -51,7 +51,7 @@
 -type range_key_name() :: erlcloud_ddb2:range_key_name().
 -type table_name() :: erlcloud_ddb2:table_name().
 
--type items_return() :: {ok, [out_item() | binary()]}
+-type items_return() :: {ok, [out_item()]}
                       | {ok, non_neg_integer()}
                       | {error, term()}.
 

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -229,7 +229,7 @@
 -define(FLOWS_MR_MIN, 1).
 -define(FLOWS_MR_MAX, 1000).
 
--type filter_list() :: [{string() | atom(),[string()]}] | none.
+-type filter_list() :: [{string() | atom(),[string()] | string()}] | none.
 -type ec2_param_list() :: [{string(),string()}].
 -type ec2_selector() :: proplist().
 -type ec2_token() :: string() | undefined.

--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -678,7 +678,8 @@ container_definition_opts() ->
         {working_directory, <<"workingDirectory">>, fun to_binary/1}
     ].
 
--spec encode_container_definitions(Defs :: container_definition_opts()) -> [aws_opts()].
+-spec encode_container_definitions(Defs :: container_definition_opts()
+                                         | [container_definition_opts()]) -> [aws_opts()].
 encode_container_definitions(Defs) ->
     encode_maybe_list(fun container_definition_opts/0, Defs).
     
@@ -1177,7 +1178,8 @@ decode_container_overrides_list(V, Opts) ->
 %%%------------------------------------------------------------------------------
 %% CreateCluster
 %%%------------------------------------------------------------------------------
--type create_cluster_opt() :: {cluster_name, string_param()}.
+-type create_cluster_opt() :: {cluster_name, string_param()} |
+                              {out, record}.
 -type create_cluster_opts() :: [create_cluster_opt()].
 
 -spec create_cluster_opts() -> opt_table().
@@ -1227,7 +1229,8 @@ create_cluster(Opts, #aws_config{} = Config) ->
                               cluster_opt() |
                               deployment_configuration() |
                               load_balancers_opt() |
-                              role_opt().
+                              role_opt() |
+                              {out, record}.
 -type create_service_opts() :: [create_service_opt()].
 
 -spec create_service_opts() -> opt_table().
@@ -1329,7 +1332,8 @@ delete_cluster(ClusterName, Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 %% DeleteService
 %%%------------------------------------------------------------------------------
--type delete_service_opt() :: {cluster, string_param()}.
+-type delete_service_opt() :: {cluster, string_param()} |
+                              {out, record}.
 -type delete_service_opts() :: [delete_service_opt()].
 
 -spec delete_service_opts() -> opt_table().
@@ -1381,7 +1385,8 @@ delete_service(ServiceName, Opts, #aws_config{} = Config) ->
 %% DeregisterContainerInstance
 %%%------------------------------------------------------------------------------
 -type deregister_container_instance_opt() :: {cluster, string_param()} |
-                                             {force, boolean()}.
+                                             {force, boolean()} |
+                                             {out, record}.
 -type deregister_container_instance_opts() :: [deregister_container_instance_opt()].
 
 -spec deregister_container_instance_opts() -> opt_table().
@@ -1483,7 +1488,8 @@ deregister_task_definition(TaskDefinition, Opts, Config) ->
 %%%------------------------------------------------------------------------------
 %% DescribeClusters
 %%%------------------------------------------------------------------------------
--type describe_clusters_opt() :: {clusters, [string_param()]}.
+-type describe_clusters_opt() :: {clusters, [string_param()]} |
+                                 {out, record}.
 -type describe_clusters_opts() :: [describe_clusters_opt()].
 
 -spec describe_clusters_opts() -> opt_table().
@@ -1536,7 +1542,8 @@ describe_clusters(Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 %% DescribeContainerInstances
 %%%------------------------------------------------------------------------------
--type describe_container_instances_opt() :: {cluster, string_param()}.
+-type describe_container_instances_opt() :: {cluster, string_param()} |
+                                            {out, record}.
 -type describe_container_instances_opts() :: [describe_container_instances_opt()].
 
 -spec describe_container_instances_opts() -> opt_table().
@@ -1594,7 +1601,8 @@ describe_container_instances(Instances, Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 %% DescribeServices
 %%%------------------------------------------------------------------------------
--type describe_services_opt() :: {cluster, string_param()}.
+-type describe_services_opt() :: {cluster, string_param()} |
+                                 {out, record}.
 -type describe_services_opts() :: [describe_services_opt()].
 
 -spec describe_services_opts() -> opt_table().
@@ -1696,7 +1704,7 @@ describe_task_definition(TaskDefinition, Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 %% DescribeTasks
 %%%------------------------------------------------------------------------------
--type describe_tasks_opt() :: {cluster, string_param()}.
+-type describe_tasks_opt() :: {cluster, string_param()} | {out, record}.
 -type describe_tasks_opts() :: [describe_tasks_opt()].
 
 -spec describe_tasks_opts() -> opt_table().
@@ -1756,7 +1764,8 @@ describe_tasks(Tasks, Opts, #aws_config{} = Config) ->
 %% ListClusters 
 %%%------------------------------------------------------------------------------
 -type list_clusters_opt() :: {max_results, 1..100} | 
-                             {next_token, binary()}.
+                             {next_token, binary()} |
+                             {out, record}.
 
 -type list_clusters_opts() :: [list_clusters_opt()].
 
@@ -1808,7 +1817,8 @@ list_clusters(Opts, Config) ->
 %%%------------------------------------------------------------------------------
 -type list_container_instances_opt() :: {cluster, string_param()} |
                                         {max_results, 1..100} |
-                                        {next_token, binary()}.
+                                        {next_token, binary()} |
+                                        {out, record}.
 
 -type list_container_instances_opts() :: [list_container_instances_opt()].
 
@@ -1861,7 +1871,8 @@ list_container_instances(Opts, Config) ->
 %%%------------------------------------------------------------------------------
 -type list_services_opt() :: {cluster, string_param()} |
                                         {max_results, 1..100} |
-                                        {next_token, binary()}.
+                                        {next_token, binary()} |
+                                        {out, record}.
 
 -type list_services_opts() :: [list_services_opt()].
 
@@ -1915,7 +1926,8 @@ list_services(Opts, Config) ->
 -type list_task_definition_families_opt() :: {family_prefix, string_param()} |
                                              {status, active | inactive | all} |
                                              {max_results, 1..100} |
-                                             {next_token, binary()}.
+                                             {next_token, binary()} |
+                                             {out, record}.
 
 -type list_task_definition_families_opts() :: [list_task_definition_families_opt()].
 
@@ -1975,7 +1987,8 @@ list_task_definition_families(Opts, Config) ->
                                      {status, active | inactive} |
                                      {sort, asc | desc} |
                                      {max_results, 1..100} |
-                                     {next_token, binary()}.
+                                     {next_token, binary()} |
+                                     {out, record}.
 
 -type list_task_definitions_opts() :: [list_task_definitions_opt()].
 
@@ -2036,7 +2049,8 @@ list_task_definitions(Opts, Config) ->
                           {family, string_param()} |
                           {sort, asc | desc} |
                           {max_results, 1..100} |
-                          {next_token, binary()}.
+                          {next_token, binary()} |
+                          {out, record}.
 
 -type list_tasks_opts() :: [list_tasks_opt()].
 
@@ -2097,7 +2111,8 @@ list_tasks(Opts, Config) ->
 %%%------------------------------------------------------------------------------
 -type register_task_definition_opt() :: {network_mode, ecs_network_mode()} |
                                         {task_role_arn, string_param()} |
-                                        volumes().
+                                        volumes() |
+                                        {out, record}.
 -type register_task_definition_opts() :: [register_task_definition_opt()].
 
 -spec register_task_definition_opts() -> opt_table().
@@ -2163,8 +2178,9 @@ register_task_definition(ContainerDefinitions, Family, Opts, Config) ->
 -type run_task_opt() :: {cluster, string_param()} |
                         {count, pos_integer()} |
                         task_overrides_opt() |
-                        placement_strategy_opt() |
-                        {started_by, string_param()}.
+                        placement_strategy() |
+                        {started_by, string_param()} |
+                        {out, record}.
 
 -type run_task_opts() :: [run_task_opt()].
 -spec run_task_opts() -> opt_table().
@@ -2227,7 +2243,8 @@ run_task(TaskDefinition, Opts, Config) ->
 %%%------------------------------------------------------------------------------
 -type start_task_opt() :: {cluster, string_param()} |
                           task_overrides_opt() |
-                          {started_by, string_param()}.
+                          {started_by, string_param()} |
+                          {out, record}.
 
 -type start_task_opts() :: [start_task_opt()].
 -spec start_task_opts() -> opt_table().
@@ -2295,7 +2312,8 @@ start_task(TaskDefinition, ContainerInstances, Opts, Config) ->
 %% StopTask
 %%%------------------------------------------------------------------------------
 -type stop_task_opt() :: {cluster, string_param()} |
-                         {reason, string_param()}.
+                         {reason, string_param()} |
+                         {out, record}.
 -type stop_task_opts() :: [stop_task_opt()].
 -spec stop_task_opts() -> opt_table().
 stop_task_opts() ->
@@ -2342,7 +2360,7 @@ stop_task(Task, Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 %% UpdateContainerAgent 
 %%%------------------------------------------------------------------------------
--type update_container_agent_opts() :: [{cluster, string_param()}].
+-type update_container_agent_opts() :: [{cluster, string_param()} | {out, record}].
 -spec update_container_agent_opts() -> opt_table().
 update_container_agent_opts() ->
     [{cluster, <<"cluster">>, fun to_binary/1}].
@@ -2393,7 +2411,8 @@ update_container_agent(ContainerInstance, Opts, Config) ->
 -type update_service_opt() :: {cluster, string_param()} |
                               deployment_configuration() |
                               {desired_count, pos_integer()} |
-                              {task_definition, string_param()}.
+                              {task_definition, string_param()} |
+                              {out, record}.
 -type update_service_opts() :: [update_service_opt()].
 -spec update_service_opts() -> opt_table().
 update_service_opts() ->

--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -1179,7 +1179,7 @@ decode_container_overrides_list(V, Opts) ->
 %% CreateCluster
 %%%------------------------------------------------------------------------------
 -type create_cluster_opt() :: {cluster_name, string_param()} |
-                              {out, record}.
+                              out_opt().
 -type create_cluster_opts() :: [create_cluster_opt()].
 
 -spec create_cluster_opts() -> opt_table().
@@ -1230,7 +1230,7 @@ create_cluster(Opts, #aws_config{} = Config) ->
                               deployment_configuration() |
                               load_balancers_opt() |
                               role_opt() |
-                              {out, record}.
+                              out_opt().
 -type create_service_opts() :: [create_service_opt()].
 
 -spec create_service_opts() -> opt_table().
@@ -1333,7 +1333,7 @@ delete_cluster(ClusterName, Opts, #aws_config{} = Config) ->
 %% DeleteService
 %%%------------------------------------------------------------------------------
 -type delete_service_opt() :: {cluster, string_param()} |
-                              {out, record}.
+                              out_opt().
 -type delete_service_opts() :: [delete_service_opt()].
 
 -spec delete_service_opts() -> opt_table().
@@ -1386,7 +1386,7 @@ delete_service(ServiceName, Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 -type deregister_container_instance_opt() :: {cluster, string_param()} |
                                              {force, boolean()} |
-                                             {out, record}.
+                                             out_opt().
 -type deregister_container_instance_opts() :: [deregister_container_instance_opt()].
 
 -spec deregister_container_instance_opts() -> opt_table().
@@ -1489,7 +1489,7 @@ deregister_task_definition(TaskDefinition, Opts, Config) ->
 %% DescribeClusters
 %%%------------------------------------------------------------------------------
 -type describe_clusters_opt() :: {clusters, [string_param()]} |
-                                 {out, record}.
+                                 out_opt().
 -type describe_clusters_opts() :: [describe_clusters_opt()].
 
 -spec describe_clusters_opts() -> opt_table().
@@ -1543,7 +1543,7 @@ describe_clusters(Opts, #aws_config{} = Config) ->
 %% DescribeContainerInstances
 %%%------------------------------------------------------------------------------
 -type describe_container_instances_opt() :: {cluster, string_param()} |
-                                            {out, record}.
+                                            out_opt().
 -type describe_container_instances_opts() :: [describe_container_instances_opt()].
 
 -spec describe_container_instances_opts() -> opt_table().
@@ -1602,7 +1602,7 @@ describe_container_instances(Instances, Opts, #aws_config{} = Config) ->
 %% DescribeServices
 %%%------------------------------------------------------------------------------
 -type describe_services_opt() :: {cluster, string_param()} |
-                                 {out, record}.
+                                 out_opt().
 -type describe_services_opts() :: [describe_services_opt()].
 
 -spec describe_services_opts() -> opt_table().
@@ -1704,7 +1704,7 @@ describe_task_definition(TaskDefinition, Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 %% DescribeTasks
 %%%------------------------------------------------------------------------------
--type describe_tasks_opt() :: {cluster, string_param()} | {out, record}.
+-type describe_tasks_opt() :: {cluster, string_param()} | out_opt().
 -type describe_tasks_opts() :: [describe_tasks_opt()].
 
 -spec describe_tasks_opts() -> opt_table().
@@ -1765,7 +1765,7 @@ describe_tasks(Tasks, Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 -type list_clusters_opt() :: {max_results, 1..100} | 
                              {next_token, binary()} |
-                             {out, record}.
+                             out_opt().
 
 -type list_clusters_opts() :: [list_clusters_opt()].
 
@@ -1818,7 +1818,7 @@ list_clusters(Opts, Config) ->
 -type list_container_instances_opt() :: {cluster, string_param()} |
                                         {max_results, 1..100} |
                                         {next_token, binary()} |
-                                        {out, record}.
+                                        out_opt().
 
 -type list_container_instances_opts() :: [list_container_instances_opt()].
 
@@ -1872,7 +1872,7 @@ list_container_instances(Opts, Config) ->
 -type list_services_opt() :: {cluster, string_param()} |
                                         {max_results, 1..100} |
                                         {next_token, binary()} |
-                                        {out, record}.
+                                        out_opt().
 
 -type list_services_opts() :: [list_services_opt()].
 
@@ -1927,7 +1927,7 @@ list_services(Opts, Config) ->
                                              {status, active | inactive | all} |
                                              {max_results, 1..100} |
                                              {next_token, binary()} |
-                                             {out, record}.
+                                        out_opt().
 
 -type list_task_definition_families_opts() :: [list_task_definition_families_opt()].
 
@@ -1988,7 +1988,7 @@ list_task_definition_families(Opts, Config) ->
                                      {sort, asc | desc} |
                                      {max_results, 1..100} |
                                      {next_token, binary()} |
-                                     {out, record}.
+                                     out_opt().
 
 -type list_task_definitions_opts() :: [list_task_definitions_opt()].
 
@@ -2050,7 +2050,7 @@ list_task_definitions(Opts, Config) ->
                           {sort, asc | desc} |
                           {max_results, 1..100} |
                           {next_token, binary()} |
-                          {out, record}.
+                          out_opt().
 
 -type list_tasks_opts() :: [list_tasks_opt()].
 
@@ -2112,7 +2112,7 @@ list_tasks(Opts, Config) ->
 -type register_task_definition_opt() :: {network_mode, ecs_network_mode()} |
                                         {task_role_arn, string_param()} |
                                         volumes() |
-                                        {out, record}.
+                                        out_opt().
 -type register_task_definition_opts() :: [register_task_definition_opt()].
 
 -spec register_task_definition_opts() -> opt_table().
@@ -2180,7 +2180,7 @@ register_task_definition(ContainerDefinitions, Family, Opts, Config) ->
                         task_overrides_opt() |
                         placement_strategy() |
                         {started_by, string_param()} |
-                        {out, record}.
+                        out_opt().
 
 -type run_task_opts() :: [run_task_opt()].
 -spec run_task_opts() -> opt_table().
@@ -2244,7 +2244,7 @@ run_task(TaskDefinition, Opts, Config) ->
 -type start_task_opt() :: {cluster, string_param()} |
                           task_overrides_opt() |
                           {started_by, string_param()} |
-                          {out, record}.
+                          out_opt().
 
 -type start_task_opts() :: [start_task_opt()].
 -spec start_task_opts() -> opt_table().
@@ -2313,7 +2313,7 @@ start_task(TaskDefinition, ContainerInstances, Opts, Config) ->
 %%%------------------------------------------------------------------------------
 -type stop_task_opt() :: {cluster, string_param()} |
                          {reason, string_param()} |
-                         {out, record}.
+                         out_opt().
 -type stop_task_opts() :: [stop_task_opt()].
 -spec stop_task_opts() -> opt_table().
 stop_task_opts() ->
@@ -2360,7 +2360,7 @@ stop_task(Task, Opts, #aws_config{} = Config) ->
 %%%------------------------------------------------------------------------------
 %% UpdateContainerAgent 
 %%%------------------------------------------------------------------------------
--type update_container_agent_opts() :: [{cluster, string_param()} | {out, record}].
+-type update_container_agent_opts() :: [{cluster, string_param()} | out_opt()].
 -spec update_container_agent_opts() -> opt_table().
 update_container_agent_opts() ->
     [{cluster, <<"cluster">>, fun to_binary/1}].
@@ -2412,7 +2412,7 @@ update_container_agent(ContainerInstance, Opts, Config) ->
                               deployment_configuration() |
                               {desired_count, pos_integer()} |
                               {task_definition, string_param()} |
-                              {out, record}.
+                              out_opt().
 -type update_service_opts() :: [update_service_opt()].
 -spec update_service_opts() -> opt_table().
 update_service_opts() ->

--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -678,11 +678,11 @@ get_account_authorization_details(#aws_config{} = Config) ->
         {error, _} = Error -> Error
     end.
 
--spec get_account_summary() -> {ok, proplist()} |  {error, any()}.
+-spec get_account_summary() -> {ok, [proplist()]} |  {error, any()}.
 get_account_summary() ->
     get_account_summary(default_config()).
 
--spec get_account_summary(aws_config()) -> {ok, proplist()} |  {error, any()}.
+-spec get_account_summary(aws_config()) -> {ok, [proplist()]} |  {error, any()}.
 get_account_summary(#aws_config{} = Config) ->
     case iam_query(Config, "GetAccountSummary", []) of
         {ok, Doc} ->
@@ -764,46 +764,46 @@ simulate_custom_policy(ActionNames, PolicyInputList, ContextEntries, #aws_config
     iam_query_all(Config, "SimulateCustomPolicy", Params,
                   ItemPath, data_type("EvaluationResult")).
 
--spec list_virtual_mfa_devices() -> {ok, proplist()} | {ok, proplist(), string()} | {error, any()}.
+-spec list_virtual_mfa_devices() -> {ok, [proplist()]} | {ok, [proplist()], string()} | {error, any()}.
 list_virtual_mfa_devices() ->
     list_virtual_mfa_devices(default_config()).
 
--spec list_virtual_mfa_devices(string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} | {error, any()}.
+-spec list_virtual_mfa_devices(string() | aws_config()) -> {ok, [proplist()]} | {ok, [proplist()], string()} | {error, any()}.
 list_virtual_mfa_devices(#aws_config{} = Config) ->
     list_virtual_mfa_devices(undefined, undefined, undefined, Config);
 list_virtual_mfa_devices(AssignmentStatus) ->
     list_virtual_mfa_devices(AssignmentStatus, undefined, undefined, default_config()).
 
--spec list_virtual_mfa_devices(string(), string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} | {error, any()}.
+-spec list_virtual_mfa_devices(string(), string() | aws_config()) -> {ok, [proplist()]} | {ok, [proplist()], string()} | {error, any()}.
 list_virtual_mfa_devices(AssignmentStatus, #aws_config{} = Config) ->
     list_virtual_mfa_devices(AssignmentStatus, undefined, undefined, Config);
 list_virtual_mfa_devices(AssignmentStatus, Marker) ->
     list_virtual_mfa_devices(AssignmentStatus, Marker, undefined, default_config()).
 
--spec list_virtual_mfa_devices(string(), string(), string()| aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} | {error, any()}.
+-spec list_virtual_mfa_devices(string(), string(), string()| aws_config()) -> {ok, [proplist()]} | {ok, [proplist()], string()} | {error, any()}.
 list_virtual_mfa_devices(AssignmentStatus, Marker, #aws_config{} = Config) ->
     list_virtual_mfa_devices(AssignmentStatus, Marker, undefined, Config);
 list_virtual_mfa_devices(AssignmentStatus, Marker, MaxItems) ->
     list_virtual_mfa_devices(AssignmentStatus, Marker, MaxItems, default_config()).
 
--spec list_virtual_mfa_devices(undefined | string(), undefined | string(), undefined | string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} | {error, any()}.
+-spec list_virtual_mfa_devices(undefined | string(), undefined | string(), undefined | string(), aws_config()) -> {ok, [proplist()]} | {ok, [proplist()], string()} | {error, any()}.
 list_virtual_mfa_devices(AssignmentStatus, Marker, MaxItems, #aws_config{} = Config) ->
     Params = make_list_virtual_mfa_devices_params(AssignmentStatus, Marker, MaxItems),
     ItemPath = "/ListVirtualMFADevicesResponse/ListVirtualMFADevicesResult/VirtualMFADevices/member",
     iam_query(Config, "ListVirtualMFADevices", Params, ItemPath, data_type("VirtualMFADeviceMetadata")).
 
 
--spec list_virtual_mfa_devices_all() -> {ok, proplist()} | {error, any()}.
+-spec list_virtual_mfa_devices_all() -> {ok, [proplist()]} | {error, any()}.
 list_virtual_mfa_devices_all() ->
     list_virtual_mfa_devices_all(default_config()).
 
--spec list_virtual_mfa_devices_all(string() | aws_config()) -> {ok, proplist()} | {error, any()}.
+-spec list_virtual_mfa_devices_all(string() | aws_config()) -> {ok, [proplist()]} | {error, any()}.
 list_virtual_mfa_devices_all(#aws_config{} = Config) ->
     list_virtual_mfa_devices_all(undefined, Config);
 list_virtual_mfa_devices_all(AssignmentStatus) ->
     list_virtual_mfa_devices_all(AssignmentStatus, default_config()).
 
--spec list_virtual_mfa_devices_all(undefined | string(), aws_config()) -> {ok, proplist()} | {error, any()}.
+-spec list_virtual_mfa_devices_all(undefined | string(), aws_config()) -> {ok, [proplist()]} | {error, any()}.
 list_virtual_mfa_devices_all(AssignmentStatus, #aws_config{} = Config) ->
     Params = make_list_virtual_mfa_devices_params(AssignmentStatus, undefined, undefined),
     ItemPath = "/ListVirtualMFADevicesResponse/ListVirtualMFADevicesResult/VirtualMFADevices/member",

--- a/src/erlcloud_inspector.erl
+++ b/src/erlcloud_inspector.erl
@@ -134,16 +134,16 @@ inspector_result_fun(#aws_request{response_type = error, error_type = aws} = Req
 -type attribute() :: proplists:proplist().
 
 -spec add_attributes_to_findings
-          (Attributes :: [attribute()],
-           FindingArns :: [string()]) ->
+          (Attributes :: attribute(),
+           FindingArns :: [string() | binary()]) ->
           inspector_return_val().
 add_attributes_to_findings(Attributes, FindingArns) ->
     add_attributes_to_findings(Attributes, FindingArns, default_config()).
 
 
 -spec add_attributes_to_findings
-          (Attributes :: [attribute()],
-           FindingArns :: [string()],
+          (Attributes :: attribute(),
+           FindingArns :: [string() | binary()],
            Config :: aws_config()) ->
           inspector_return_val().
 add_attributes_to_findings(Attributes, FindingArns, Config) ->
@@ -159,16 +159,16 @@ add_attributes_to_findings(Attributes, FindingArns, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec attach_assessment_and_rules_package
-          (AssessmentArn :: string(),
-           RulesPackageArn :: string()) ->
+          (AssessmentArn :: string() | binary(),
+           RulesPackageArn :: string() | binary()) ->
           inspector_return_val().
 attach_assessment_and_rules_package(AssessmentArn, RulesPackageArn) ->
     attach_assessment_and_rules_package(AssessmentArn, RulesPackageArn, default_config()).
 
 
 -spec attach_assessment_and_rules_package
-          (AssessmentArn :: string(),
-           RulesPackageArn :: string(),
+          (AssessmentArn :: string() | binary(),
+           RulesPackageArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 attach_assessment_and_rules_package(AssessmentArn, RulesPackageArn, Config) ->
@@ -184,16 +184,16 @@ attach_assessment_and_rules_package(AssessmentArn, RulesPackageArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec create_application
-          (ApplicationName :: string(),
-           ResourceGroupArn :: string()) ->
+          (ApplicationName :: string() | binary(),
+           ResourceGroupArn :: string() | binary()) ->
           inspector_return_val().
 create_application(ApplicationName, ResourceGroupArn) ->
     create_application(ApplicationName, ResourceGroupArn, default_config()).
 
 
 -spec create_application
-          (ApplicationName :: string(),
-           ResourceGroupArn :: string(),
+          (ApplicationName :: string() | binary(),
+           ResourceGroupArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 create_application(ApplicationName, ResourceGroupArn, Config) ->
@@ -209,8 +209,8 @@ create_application(ApplicationName, ResourceGroupArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec create_assessment
-          (ApplicationArn :: string(),
-           AssessmentName :: string(),
+          (ApplicationArn :: string() | binary(),
+           AssessmentName :: string() | binary(),
            DurationInSeconds :: integer()) ->
           inspector_return_val().
 create_assessment(ApplicationArn, AssessmentName, DurationInSeconds) ->
@@ -218,8 +218,8 @@ create_assessment(ApplicationArn, AssessmentName, DurationInSeconds) ->
 
 
 -spec create_assessment
-          (ApplicationArn :: string(),
-           AssessmentName :: string(),
+          (ApplicationArn :: string() | binary(),
+           AssessmentName :: string() | binary(),
            DurationInSeconds :: integer(),
            Options :: inspector_opts()) ->
           inspector_return_val().
@@ -228,8 +228,8 @@ create_assessment(ApplicationArn, AssessmentName, DurationInSeconds, Options) ->
 
 
 -spec create_assessment
-          (ApplicationArn :: string(),
-           AssessmentName :: string(),
+          (ApplicationArn :: string() | binary(),
+           AssessmentName :: string() | binary(),
            DurationInSeconds :: integer(),
            Options :: inspector_opts(),
            Config :: aws_config()) ->
@@ -271,14 +271,14 @@ create_resource_group(ResourceGroupTags, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec delete_application
-          (ApplicationArn :: string()) ->
+          (ApplicationArn :: string() | binary()) ->
           inspector_return_val().
 delete_application(ApplicationArn) ->
     delete_application(ApplicationArn, default_config()).
 
 
 -spec delete_application
-          (ApplicationArn :: string(),
+          (ApplicationArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 delete_application(ApplicationArn, Config) ->
@@ -293,14 +293,14 @@ delete_application(ApplicationArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec delete_assessment
-          (AssessmentArn :: string()) ->
+          (AssessmentArn :: string() | binary()) ->
           inspector_return_val().
 delete_assessment(AssessmentArn) ->
     delete_assessment(AssessmentArn, default_config()).
 
 
 -spec delete_assessment
-          (AssessmentArn :: string(),
+          (AssessmentArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 delete_assessment(AssessmentArn, Config) ->
@@ -315,14 +315,14 @@ delete_assessment(AssessmentArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec delete_run
-          (RunArn :: string()) ->
+          (RunArn :: string() | binary()) ->
           inspector_return_val().
 delete_run(RunArn) ->
     delete_run(RunArn, default_config()).
 
 
 -spec delete_run
-          (RunArn :: string(),
+          (RunArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 delete_run(RunArn, Config) ->
@@ -337,14 +337,14 @@ delete_run(RunArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec describe_application
-          (ApplicationArn :: string()) ->
+          (ApplicationArn :: string() | binary()) ->
           inspector_return_val().
 describe_application(ApplicationArn) ->
     describe_application(ApplicationArn, default_config()).
 
 
 -spec describe_application
-          (ApplicationArn :: string(),
+          (ApplicationArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 describe_application(ApplicationArn, Config) ->
@@ -359,14 +359,14 @@ describe_application(ApplicationArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec describe_assessment
-          (AssessmentArn :: string()) ->
+          (AssessmentArn :: string() | binary()) ->
           inspector_return_val().
 describe_assessment(AssessmentArn) ->
     describe_assessment(AssessmentArn, default_config()).
 
 
 -spec describe_assessment
-          (AssessmentArn :: string(),
+          (AssessmentArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 describe_assessment(AssessmentArn, Config) ->
@@ -401,14 +401,14 @@ describe_cross_account_access_role(Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec describe_finding
-          (FindingArn :: string()) ->
+          (FindingArn :: string() | binary()) ->
           inspector_return_val().
 describe_finding(FindingArn) ->
     describe_finding(FindingArn, default_config()).
 
 
 -spec describe_finding
-          (FindingArn :: string(),
+          (FindingArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 describe_finding(FindingArn, Config) ->
@@ -423,14 +423,14 @@ describe_finding(FindingArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec describe_resource_group
-          (ResourceGroupArn :: string()) ->
+          (ResourceGroupArn :: string() | binary()) ->
           inspector_return_val().
 describe_resource_group(ResourceGroupArn) ->
     describe_resource_group(ResourceGroupArn, default_config()).
 
 
 -spec describe_resource_group
-          (ResourceGroupArn :: string(),
+          (ResourceGroupArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 describe_resource_group(ResourceGroupArn, Config) ->
@@ -445,14 +445,14 @@ describe_resource_group(ResourceGroupArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec describe_rules_package
-          (RulesPackageArn :: string()) ->
+          (RulesPackageArn :: string() | binary()) ->
           inspector_return_val().
 describe_rules_package(RulesPackageArn) ->
     describe_rules_package(RulesPackageArn, default_config()).
 
 
 -spec describe_rules_package
-          (RulesPackageArn :: string(),
+          (RulesPackageArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 describe_rules_package(RulesPackageArn, Config) ->
@@ -467,14 +467,14 @@ describe_rules_package(RulesPackageArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec describe_run
-          (RunArn :: string()) ->
+          (RunArn :: string() | binary()) ->
           inspector_return_val().
 describe_run(RunArn) ->
     describe_run(RunArn, default_config()).
 
 
 -spec describe_run
-          (RunArn :: string(),
+          (RunArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 describe_run(RunArn, Config) ->
@@ -489,16 +489,16 @@ describe_run(RunArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec detach_assessment_and_rules_package
-          (AssessmentArn :: string(),
-           RulesPackageArn :: string()) ->
+          (AssessmentArn :: string() | binary(),
+           RulesPackageArn :: string() | binary()) ->
           inspector_return_val().
 detach_assessment_and_rules_package(AssessmentArn, RulesPackageArn) ->
     detach_assessment_and_rules_package(AssessmentArn, RulesPackageArn, default_config()).
 
 
 -spec detach_assessment_and_rules_package
-          (AssessmentArn :: string(),
-           RulesPackageArn :: string(),
+          (AssessmentArn :: string() | binary(),
+           RulesPackageArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 detach_assessment_and_rules_package(AssessmentArn, RulesPackageArn, Config) ->
@@ -514,14 +514,14 @@ detach_assessment_and_rules_package(AssessmentArn, RulesPackageArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec get_assessment_telemetry
-          (AssessmentArn :: string()) ->
+          (AssessmentArn :: string() | binary()) ->
           inspector_return_val().
 get_assessment_telemetry(AssessmentArn) ->
     get_assessment_telemetry(AssessmentArn, default_config()).
 
 
 -spec get_assessment_telemetry
-          (AssessmentArn :: string(),
+          (AssessmentArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 get_assessment_telemetry(AssessmentArn, Config) ->
@@ -565,14 +565,14 @@ list_applications(Options, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec list_assessment_agents
-          (AssessmentArn :: string()) ->
+          (AssessmentArn :: string() | binary()) ->
           inspector_return_val().
 list_assessment_agents(AssessmentArn) ->
     list_assessment_agents(AssessmentArn, []).
 
 
 -spec list_assessment_agents
-          (AssessmentArn :: string(),
+          (AssessmentArn :: string() | binary(),
            Options :: inspector_opts()) ->
           inspector_return_val().
 list_assessment_agents(AssessmentArn, Options) ->
@@ -580,7 +580,7 @@ list_assessment_agents(AssessmentArn, Options) ->
 
 
 -spec list_assessment_agents
-          (AssessmentArn :: string(),
+          (AssessmentArn :: string() | binary(),
            Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
@@ -626,14 +626,14 @@ list_assessments(Options, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec list_attached_assessments
-          (RulesPackageArn :: string()) ->
+          (RulesPackageArn :: string() | binary()) ->
           inspector_return_val().
 list_attached_assessments(RulesPackageArn) ->
     list_attached_assessments(RulesPackageArn, []).
 
 
 -spec list_attached_assessments
-          (RulesPackageArn :: string(),
+          (RulesPackageArn :: string() | binary(),
            Options :: inspector_opts()) ->
           inspector_return_val().
 list_attached_assessments(RulesPackageArn, Options) ->
@@ -641,7 +641,7 @@ list_attached_assessments(RulesPackageArn, Options) ->
 
 
 -spec list_attached_assessments
-          (RulesPackageArn :: string(),
+          (RulesPackageArn :: string() | binary(),
            Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
@@ -658,14 +658,14 @@ list_attached_assessments(RulesPackageArn, Options, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec list_attached_rules_packages
-          (AssessmentArn :: string()) ->
+          (AssessmentArn :: string() | binary()) ->
           inspector_return_val().
 list_attached_rules_packages(AssessmentArn) ->
     list_attached_rules_packages(AssessmentArn, []).
 
 
 -spec list_attached_rules_packages
-          (AssessmentArn :: string(),
+          (AssessmentArn :: string() | binary(),
            Options :: inspector_opts()) ->
           inspector_return_val().
 list_attached_rules_packages(AssessmentArn, Options) ->
@@ -673,7 +673,7 @@ list_attached_rules_packages(AssessmentArn, Options) ->
 
 
 -spec list_attached_rules_packages
-          (AssessmentArn :: string(),
+          (AssessmentArn :: string() | binary(),
            Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
@@ -704,7 +704,7 @@ list_findings(Options) ->
 
 
 -spec list_findings
-          (Options :: inspector_opts(), 
+          (Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
 list_findings(Options, Config) ->
@@ -733,7 +733,7 @@ list_rules_packages(Options) ->
 
 
 -spec list_rules_packages
-          (Options :: inspector_opts(), 
+          (Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
 list_rules_packages(Options, Config) ->
@@ -762,7 +762,7 @@ list_runs(Options) ->
 
 
 -spec list_runs
-          (Options :: inspector_opts(), 
+          (Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
 list_runs(Options, Config) ->
@@ -777,14 +777,14 @@ list_runs(Options, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec list_tags_for_resource
-          (ResourceArn :: string()) ->
+          (ResourceArn :: string() | binary()) ->
           inspector_return_val().
 list_tags_for_resource(ResourceArn) ->
     list_tags_for_resource(ResourceArn, []).
 
 
 -spec list_tags_for_resource
-          (ResourceArn :: string(),
+          (ResourceArn :: string() | binary(),
            Options :: inspector_opts()) ->
           inspector_return_val().
 list_tags_for_resource(ResourceArn, Options) ->
@@ -792,7 +792,7 @@ list_tags_for_resource(ResourceArn, Options) ->
 
 
 -spec list_tags_for_resource
-          (ResourceArn :: string(),
+          (ResourceArn :: string() | binary(),
            Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
@@ -826,7 +826,7 @@ localize_text(LocalizedTexts) ->
 
 -spec localize_text
           (LocalizedTexts :: [localized_text()],
-           Locale :: string()) ->
+           Locale :: string() | binary()) ->
           inspector_return_val().
 localize_text(LocalizedTexts, Locale) ->
     localize_text(LocalizedTexts, Locale, default_config()).
@@ -834,7 +834,7 @@ localize_text(LocalizedTexts, Locale) ->
 
 -spec localize_text
           (LocalizedTexts :: [localized_text()],
-           Locale :: string(),
+           Locale :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 localize_text(LocalizedTexts, Locale, Config) ->
@@ -850,14 +850,14 @@ localize_text(LocalizedTexts, Locale, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec preview_agents_for_resource_group
-          (ResourceGroupArn :: string()) ->
+          (ResourceGroupArn :: string() | binary()) ->
           inspector_return_val().
 preview_agents_for_resource_group(ResourceGroupArn) ->
     preview_agents_for_resource_group(ResourceGroupArn, []).
 
 
 -spec preview_agents_for_resource_group
-          (ResourceGroupArn :: string(),
+          (ResourceGroupArn :: string() | binary(),
            Options :: inspector_opts()) ->
           inspector_return_val().
 preview_agents_for_resource_group(ResourceGroupArn, Options) ->
@@ -865,7 +865,7 @@ preview_agents_for_resource_group(ResourceGroupArn, Options) ->
 
 
 -spec preview_agents_for_resource_group
-          (ResourceGroupArn :: string(),
+          (ResourceGroupArn :: string() | binary(),
            Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
@@ -882,14 +882,14 @@ preview_agents_for_resource_group(ResourceGroupArn, Options, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec register_cross_account_access_role
-          (RoleArn :: string()) ->
+          (RoleArn :: string() | binary()) ->
           inspector_return_val().
 register_cross_account_access_role(RoleArn) ->
     register_cross_account_access_role(RoleArn, []).
 
 
 -spec register_cross_account_access_role
-          (RoleArn :: string(),
+          (RoleArn :: string() | binary(),
            Options :: inspector_opts()) ->
           inspector_return_val().
 register_cross_account_access_role(RoleArn, Options) ->
@@ -897,7 +897,7 @@ register_cross_account_access_role(RoleArn, Options) ->
 
 
 -spec register_cross_account_access_role
-          (RoleArn :: string(),
+          (RoleArn :: string() | binary(),
            Options :: inspector_opts(),
            Config :: aws_config()) ->
           inspector_return_val().
@@ -914,16 +914,16 @@ register_cross_account_access_role(RoleArn, Options, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec remove_attributes_from_findings
-          (AttributeKeys :: [string()],
-           FindingArns :: [string()]) ->
+          (AttributeKeys :: [string() | binary()],
+           FindingArns :: [string() | binary()]) ->
           inspector_return_val().
 remove_attributes_from_findings(AttributeKeys, FindingArns) ->
     remove_attributes_from_findings(AttributeKeys, FindingArns, default_config()).
 
 
 -spec remove_attributes_from_findings
-          (AttributeKeys :: [string()],
-           FindingArns :: [string()],
+          (AttributeKeys :: [string() | binary()],
+           FindingArns :: [string() | binary()],
            Config :: aws_config()) ->
           inspector_return_val().
 remove_attributes_from_findings(AttributeKeys, FindingArns, Config) ->
@@ -939,16 +939,16 @@ remove_attributes_from_findings(AttributeKeys, FindingArns, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec run_assessment
-          (AssessmentArn :: string(),
-           RunName :: string()) ->
+          (AssessmentArn :: string() | binary(),
+           RunName :: string() | binary()) ->
           inspector_return_val().
 run_assessment(AssessmentArn, RunName) ->
     run_assessment(AssessmentArn, RunName, default_config()).
 
 
 -spec run_assessment
-          (AssessmentArn :: string(),
-           RunName :: string(),
+          (AssessmentArn :: string() | binary(),
+           RunName :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 run_assessment(AssessmentArn, RunName, Config) ->
@@ -964,7 +964,7 @@ run_assessment(AssessmentArn, RunName, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec set_tags_for_resource
-          (ResourceArn :: string(),
+          (ResourceArn :: string() | binary(),
            Tags :: term()) ->
           inspector_return_val().
 set_tags_for_resource(ResourceArn, Tags) ->
@@ -972,8 +972,8 @@ set_tags_for_resource(ResourceArn, Tags) ->
 
 
 -spec set_tags_for_resource
-          (ResourceArn :: string(),
-           Tags :: string(),
+          (ResourceArn :: string() | binary(),
+           Tags :: term(),
            Config :: aws_config()) ->
           inspector_return_val().
 set_tags_for_resource(ResourceArn, Tags, Config) ->
@@ -989,7 +989,7 @@ set_tags_for_resource(ResourceArn, Tags, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec start_data_collection
-          (AssessmentArn :: string()) ->
+          (AssessmentArn :: string() | binary()) ->
           inspector_return_val().
 start_data_collection(RunArn) ->
     start_data_collection(RunArn, default_config()).
@@ -1011,7 +1011,7 @@ start_data_collection(AssessmentArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec stop_data_collection
-          (AssessmentArn :: string()) ->
+          (AssessmentArn :: string() | binary()) ->
           inspector_return_val().
 stop_data_collection(RunArn) ->
     stop_data_collection(RunArn, default_config()).
@@ -1033,18 +1033,18 @@ stop_data_collection(AssessmentArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec update_application
-          (ApplicationArn :: string(),
-           ApplicationName :: string(),
-           ResourceGroupArn :: string()) ->
+          (ApplicationArn :: string() | binary(),
+           ApplicationName :: string() | binary(),
+           ResourceGroupArn :: string() | binary()) ->
           inspector_return_val().
 update_application(ApplicationArn, ApplicationName, ResourceGroupArn) ->
     update_application(ApplicationArn, ApplicationName, ResourceGroupArn, default_config()).
 
 
 -spec update_application
-          (ApplicationArn :: string(),
-           ApplicationName :: string(),
-           ResourceGroupArn :: string(),
+          (ApplicationArn :: string() | binary(),
+           ApplicationName :: string() | binary(),
+           ResourceGroupArn :: string() | binary(),
            Config :: aws_config()) ->
           inspector_return_val().
 update_application(ApplicationArn, ApplicationName, ResourceGroupArn, Config) ->
@@ -1061,8 +1061,8 @@ update_application(ApplicationArn, ApplicationName, ResourceGroupArn, Config) ->
 %%%------------------------------------------------------------------------------
 
 -spec update_assessment
-          (AssessmentArn :: string(),
-           AssessmentName :: string(),
+          (AssessmentArn :: string() | binary(),
+           AssessmentName :: string() | binary(),
            DurationInSeconds :: integer()) ->
           inspector_return_val().
 update_assessment(AssessmentArn, AssessmentName, DurationInSeconds) ->
@@ -1070,8 +1070,8 @@ update_assessment(AssessmentArn, AssessmentName, DurationInSeconds) ->
 
 
 -spec update_assessment
-          (AssessmentArn :: string(),
-           AssessmentName :: string(),
+          (AssessmentArn :: string() | binary(),
+           AssessmentName :: string() | binary(),
            DurationInSeconds :: integer(),
            Config :: aws_config()) ->
           inspector_return_val().

--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -555,12 +555,12 @@ get_shard_iterator_request(Config, Json) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_records(string()) -> erlcloud_kinesis_impl:json_return().
+-spec get_records(binary()) -> erlcloud_kinesis_impl:json_return().
 get_records(ShardIterator) ->
     Json = [{<<"ShardIterator">>, ShardIterator}],
     get_normalized_records(default_config(), Json).
 
--spec get_records(string(), get_records_limit()| aws_config()) -> erlcloud_kinesis_impl:json_return().
+-spec get_records(binary(), get_records_limit()| aws_config()) -> erlcloud_kinesis_impl:json_return().
 get_records(ShardIterator, Config) when is_record(Config, aws_config) ->
     Json = [{<<"ShardIterator">>, ShardIterator}],
     get_normalized_records(Config, Json);
@@ -712,8 +712,8 @@ put_record(StreamName, PartitionKey, Data, ExplicitHashKey, Ordering, Options, C
 %% @end
 %%------------------------------------------------------------------------------
 
--type put_records_item() :: {Data :: string(), PartitionKey :: string()}
-                          | {Data :: string(), ExplicitHashKey :: string(), PartitionKey :: string()}.
+-type put_records_item() :: {Data :: binary(), PartitionKey :: binary()}
+                          | {Data :: binary(), ExplicitHashKey :: binary(), PartitionKey :: binary()}.
 -type put_records_items() :: [put_records_item()].
 
 -spec put_records(binary(), put_records_items()) -> erlcloud_kinesis_impl:json_return().
@@ -771,13 +771,13 @@ prepare_put_records_item({Data, ExplicitHashKey, PartitionKey}, Fun) ->
 %% @end
 %%------------------------------------------------------------------------------
 
--spec merge_shards(binary(), string(), string()) -> erlcloud_kinesis_impl:json_return().
+-spec merge_shards(binary(), binary(), binary()) -> erlcloud_kinesis_impl:json_return().
 
 merge_shards(StreamName, AdjacentShardToMerge, ShardToMerge) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"AdjacentShardToMerge">>, AdjacentShardToMerge}, {<<"ShardToMerge">>, ShardToMerge}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.MergeShards", Json).
 
--spec merge_shards(binary(), string(), string(), aws_config()) -> erlcloud_kinesis_impl:json_return().
+-spec merge_shards(binary(), binary(), binary(), aws_config()) -> erlcloud_kinesis_impl:json_return().
 
 merge_shards(StreamName, AdjacentShardToMerge, ShardToMerge, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"AdjacentShardToMerge">>, AdjacentShardToMerge}, {<<"ShardToMerge">>, ShardToMerge}],
@@ -800,13 +800,13 @@ merge_shards(StreamName, AdjacentShardToMerge, ShardToMerge, Config) when is_rec
 %% @end
 %%------------------------------------------------------------------------------
 
--spec split_shards(binary(), string(), string()) -> erlcloud_kinesis_impl:json_return().
+-spec split_shards(binary(), binary(), binary()) -> erlcloud_kinesis_impl:json_return().
 
 split_shards(StreamName, ShardToSplit, NewStartingHashKey) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"ShardToSplit">>, ShardToSplit}, {<<"NewStartingHashKey">>, NewStartingHashKey}],
   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.SplitShard", Json).
 
--spec split_shards(binary(), string(), string(), aws_config()) -> erlcloud_kinesis_impl:json_return().
+-spec split_shards(binary(), binary(), binary(), aws_config()) -> erlcloud_kinesis_impl:json_return().
 
 split_shards(StreamName, ShardToSplit, NewStartingHashKey, Config) when is_record(Config, aws_config) ->
   Json = [{<<"StreamName">>, StreamName}, {<<"ShardToSplit">>, ShardToSplit}, {<<"NewStartingHashKey">>, NewStartingHashKey}],

--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -164,9 +164,9 @@ create_event_source_mapping(EventSourceArn, FunctionName,
 %%
 %%------------------------------------------------------------------------------
 -spec create_function(Code         :: erlcloud_lambda_code(),
-                            FunctionName :: string(),
-                            Handler      :: string(),
-                            Role         :: string(),
+                            FunctionName :: binary(),
+                            Handler      :: binary(),
+                            Role         :: binary(),
                             Runtime      :: runtime(),
                             Options      :: proplist()) -> return_val().
 create_function(#erlcloud_lambda_code{} = Code,
@@ -175,9 +175,9 @@ create_function(#erlcloud_lambda_code{} = Code,
                     Runtime, Options, default_config()).
 
 -spec create_function(Code         :: erlcloud_lambda_code(),
-                            FunctionName :: string(),
-                            Handler      :: string(),
-                            Role         :: string(),
+                            FunctionName :: binary(),
+                            Handler      :: binary(),
+                            Role         :: binary(),
                             Runtime      :: runtime(),
                             Options      :: proplist(),
                             Config       :: aws_config()) -> return_val().

--- a/src/erlcloud_route53.erl
+++ b/src/erlcloud_route53.erl
@@ -77,7 +77,7 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
 %% @end
 %% --------------------------------------------------------------------
 -spec describe_zone(ZoneId :: string()) ->
-             {ok, list(aws_route53_zone())} |
+             {ok, aws_route53_zone()} |
              {error, term()}.
 describe_zone(ZoneId) ->
     describe_zone(ZoneId, erlcloud_aws:default_config()).
@@ -88,7 +88,7 @@ describe_zone(ZoneId) ->
 %% --------------------------------------------------------------------
 -spec describe_zone(ZoneId :: string(),
                     AwsConfig :: aws_config()) ->
-             {ok, list(aws_route53_zone())} |
+             {ok, aws_route53_zone()} |
              {error, term()}.
 describe_zone(ZoneId, AwsConfig) ->
     describe_zone(ZoneId, [], AwsConfig).
@@ -100,7 +100,7 @@ describe_zone(ZoneId, AwsConfig) ->
 -spec describe_zone(ZoneId :: string(),
                     Options   :: list({string(), string()}),
                     AwsConfig :: aws_config()) ->
-    {ok, list(aws_route53_zone())} |
+    {ok, aws_route53_zone()} |
     {error, term()}.
 describe_zone(ZoneId, Options, Config) when is_list(Options),
                                             is_record(Config, aws_config) ->
@@ -132,7 +132,7 @@ describe_zones(AwsConfig) ->
 %% @doc Describes all zones using provided config + AWS options
 %% @end
 %% --------------------------------------------------------------------
--spec describe_zones(Options   :: list({string(), string()}),
+-spec describe_zones(Options   :: list({string(), string() | integer()}),
                      AwsConfig :: aws_config()) ->
              {ok, list(aws_route53_zone())} |
              {ok, list(aws_route53_zone()), string()} |
@@ -498,7 +498,7 @@ key_replace_or_add(Key, Value, List) ->
     end.
 
 -spec route53_query(get | post, aws_config(), string(), string(),
-                    list({string(), string()}), string()) ->
+                    list({string(), string() | integer()}), string()) ->
     {ok, term()} | {error, term()}.
 route53_query(Method, Config, Action, Path, Params, ApiVersion) ->
     QParams = [{"Action", Action}, {"Version", ApiVersion} | Params],

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -470,11 +470,11 @@ put_bucket_policy(BucketName, Policy, Config)
   when is_list(BucketName), is_binary(Policy), is_record(Config, aws_config) ->
     s3_simple_request(Config, put, BucketName, "/", "policy", [], Policy, []).
 
--spec get_bucket_lifecycle(BucketName::string()) -> ok | {error, Reason::term()}.
+-spec get_bucket_lifecycle(BucketName::string()) -> {ok, list(proplist())} | {error, Reason::term()}.
 get_bucket_lifecycle(BucketName) ->
     get_bucket_lifecycle(BucketName, default_config()).
 
--spec get_bucket_lifecycle(BucketName::string(), Config::aws_config()) -> {ok, Policy::string()} | {error, Reason::term()}.
+-spec get_bucket_lifecycle(BucketName::string(), Config::aws_config()) -> {ok, list(proplist())} | {error, Reason::term()}.
 get_bucket_lifecycle(BucketName, Config)
     when is_record(Config, aws_config) ->
         case s3_request2(Config, get, BucketName, "/", "lifecycle", [], <<>>, []) of
@@ -1701,7 +1701,7 @@ delete_bucket_encryption(BucketName, Config) ->
 %% takes an S3 bucket notification configuration and creates an xmerl simple
 %% form out of it.
 %% for the examples of input / output of this function, see tests.
--spec create_notification_xml(proplist()) -> tuple().
+-spec create_notification_xml(list(proplist())) -> tuple().
 create_notification_xml(Confs) ->
     {'NotificationConfiguration', [create_notification_xml(ConfName, Params)
         || [{ConfName, Params}] <- Confs]}.

--- a/src/erlcloud_waf.erl
+++ b/src/erlcloud_waf.erl
@@ -899,7 +899,7 @@ update_ip_set(ChangeToken, IPSetId, Updates, Config) ->
 %% http://docs.aws.amazon.com/waf/latest/APIReference/API_UpdateRule.html
 %%%------------------------------------------------------------------------------
 -spec update_rule(ChangeToken :: string() | binary(),
-                  RuleId :: string(),
+                  RuleId :: string() | binary(),
                   Updates :: [waf_rule_update()]) ->
     waf_return_val().
 update_rule(ChangeToken, RuleId, Updates) ->
@@ -1034,7 +1034,8 @@ update_xss_match_set(ChangeToken, XssMatchSetId, Updates, Config) ->
                             waf_rule_update() |
                             waf_size_constraint_update() |
                             waf_sql_injection_match_set_update() |
-                            waf_web_acl_update()) ->
+                            waf_web_acl_update() |
+                            waf_xss_match_set_update()) ->
     proplists:proplist().
 transform_to_proplist(#waf_byte_match_set_update{action = Action, byte_match_tuple = ByteMatchTuple}) ->
     [{<<"Action">>, get_update_action(Action)},

--- a/test/erlcloud_autoscaling_tests.erl
+++ b/test/erlcloud_autoscaling_tests.erl
@@ -140,7 +140,7 @@ output_expect_seq(Responses) ->
 
 
 %% output_test converts an output_test specifier into an eunit test generator
--type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string(), term()}}.
+-type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string() | [string()], term()}}.
 -spec output_test(fun(), output_test_spec(), fun()) -> tuple().
 output_test(Fun, {Line, {Description, Response, Result}}, OutputFun) ->
     {Description,

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -16,7 +16,7 @@ request_test_() ->
 
 start() ->
     meck:new(erlcloud_httpc),
-    meck:expect(erlcloud_httpc, request, fun(_,_,_,_,_,_) -> {ok, {{200, "OK"}, [], ok}} end),
+    meck:expect(erlcloud_httpc, request, fun(_,_,_,_,_,_) -> {ok, {{200, "OK"}, [], <<"OkBody">>}} end),
     ok.
 
 stop(_) ->
@@ -29,7 +29,7 @@ config() ->
                 retry_num = 3}.
 
 test_request_default(_) ->
-    _Body = erlcloud_aws:aws_request(get, "host", "/", [], "id", "key"),
+    <<"OkBody">> = erlcloud_aws:aws_request(get, "host", "/", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(https, "host", 443, "/", Url).
 
@@ -66,7 +66,7 @@ test_request_retry(_) ->
               erlcloud_aws:aws_request_xml4(get, "host", "/", [], "any", config());
           (ResponseSeq) ->
               meck:sequence(erlcloud_httpc, request, 6, ResponseSeq),
-              erlcloud_aws:aws_request(get, "host", "/", [], config())
+              <<"OkBody">> = erlcloud_aws:aws_request(get, "host", "/", [], config())
         end,
     [?_assertMatch(<<"OkBody">>, MeckAndRequest([Response400, Response200])),
      ?_assertMatch(<<"OkBody">>, MeckAndRequest([Response400, Response500, Response200])),
@@ -77,12 +77,12 @@ test_request_retry(_) ->
 
 
 test_request_prot_host_port_str(_) ->
-    _Body = erlcloud_aws:aws_request(get, "http", "host1", "9999", "/path1", [], "id", "key"),
+    <<"OkBody">> = erlcloud_aws:aws_request(get, "http", "host1", "9999", "/path1", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(http, "host1", 9999, "/path1", Url).
 
 test_request_prot_host_port_int(_) ->
-    _Body = erlcloud_aws:aws_request(get, "http", "host1", 9999, "/path1", [], "id", "key"),
+    <<"OkBody">> = erlcloud_aws:aws_request(get, "http", "host1", 9999, "/path1", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(http, "host1", 9999, "/path1", Url).
 

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -29,7 +29,7 @@ config() ->
                 retry_num = 3}.
 
 request_default_test(_) ->
-    ok = erlcloud_aws:aws_request(get, "host", "/", [], "id", "key"),
+    _Body = erlcloud_aws:aws_request(get, "host", "/", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(https, "host", 443, "/", Url).
 
@@ -77,12 +77,12 @@ request_retry_test(_) ->
 
 
 request_prot_host_port_str_test(_) ->
-    ok = erlcloud_aws:aws_request(get, "http", "host1", "9999", "/path1", [], "id", "key"),
+    _Body = erlcloud_aws:aws_request(get, "http", "host1", "9999", "/path1", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(http, "host1", 9999, "/path1", Url).
 
 request_prot_host_port_int_test(_) ->
-    ok = erlcloud_aws:aws_request(get, "http", "host1", 9999, "/path1", [], "id", "key"),
+    _Body = erlcloud_aws:aws_request(get, "http", "host1", 9999, "/path1", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(http, "host1", 9999, "/path1", Url).
 

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -7,12 +7,12 @@ request_test_() ->
     {foreach,
      fun start/0,
      fun stop/1,
-     [fun request_default_test/1,
-      fun request_retry_test/1,
-      fun request_prot_host_port_str_test/1,
-      fun request_prot_host_port_int_test/1,
-      fun get_service_status_test/1,
-      fun auto_config_with_env/1]}.
+     [fun test_request_default/1,
+      fun test_request_retry/1,
+      fun test_request_prot_host_port_str/1,
+      fun test_request_prot_host_port_int/1,
+      fun test_get_service_status/1,
+      fun test_auto_config_with_env/1]}.
 
 start() ->
     meck:new(erlcloud_httpc),
@@ -28,12 +28,12 @@ config() ->
                 retry = fun erlcloud_retry:default_retry/1,
                 retry_num = 3}.
 
-request_default_test(_) ->
+test_request_default(_) ->
     _Body = erlcloud_aws:aws_request(get, "host", "/", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(https, "host", 443, "/", Url).
 
-request_retry_test(_) ->
+test_request_retry(_) ->
     Response400 = {ok, {{400, "Bad Request"}, [],
         <<"<ErrorResponse xmlns=\"http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/\">\n"
           "  <Error>\n"
@@ -76,17 +76,17 @@ request_retry_test(_) ->
      ].
 
 
-request_prot_host_port_str_test(_) ->
+test_request_prot_host_port_str(_) ->
     _Body = erlcloud_aws:aws_request(get, "http", "host1", "9999", "/path1", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(http, "host1", 9999, "/path1", Url).
 
-request_prot_host_port_int_test(_) ->
+test_request_prot_host_port_int(_) ->
     _Body = erlcloud_aws:aws_request(get, "http", "host1", 9999, "/path1", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(http, "host1", 9999, "/path1", Url).
 
-get_service_status_test(_) ->
+test_get_service_status(_) ->
     StatusJsonS3 = jsx:encode(
         [{<<"archive">>,
             [[{<<"service_name">>,
@@ -157,7 +157,7 @@ get_service_status_test(_) ->
      ].
 
 
-auto_config_with_env(_) ->
+test_auto_config_with_env(_) ->
     % Note: meck do not support os module
     X_AWS_ACCESS  = os:getenv("AWS_ACCESS_KEY_ID"),
     X_AWS_SECRET  = os:getenv("AWS_SECRET_ACCESS_KEY"),

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -68,9 +68,9 @@ request_retry_test(_) ->
               meck:sequence(erlcloud_httpc, request, 6, ResponseSeq),
               erlcloud_aws:aws_request(get, "host", "/", [], config())
         end,
-    [?_assertNotException(_, _, <<"OkBody">> = MeckAndRequest([Response400, Response200])),
-     ?_assertNotException(_, _, <<"OkBody">> = MeckAndRequest([Response400, Response500, Response200])),
-     ?_assertNotException(_, _, <<"OkBody">> = MeckAndRequest([Response429, Response200])),
+    [?_assertMatch(<<"OkBody">>, MeckAndRequest([Response400, Response200])),
+     ?_assertMatch(<<"OkBody">>, MeckAndRequest([Response400, Response500, Response200])),
+     ?_assertMatch(<<"OkBody">>, MeckAndRequest([Response429, Response200])),
      ?_assertMatch({error, {http_error, 400, "Bad Request", _ErrorMsg}},
                    MeckAndRequest({[Response400, Response500, Response400, Response200], xml4}))
      ].

--- a/test/erlcloud_cloudtrail_tests.erl
+++ b/test/erlcloud_cloudtrail_tests.erl
@@ -125,7 +125,7 @@ output_expect(Response) ->
     end.
 
 %% output_test converts an output_test specifier into an eunit test generator
--type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string(), term()}}.
+-type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string() | binary(), term()}}.
 -spec output_test(fun(), output_test_spec()) -> tuple().
 output_test(Fun, {Line, {Description, Response, Result}}) ->
     {Description,

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -2010,8 +2010,8 @@ create_table_output_tests(_) ->
         ],
         \"ProvisionedThroughput\": {
             \"NumberOfDecreasesToday\": 0,
-            \"ReadCapacityUnits\": 0,
-            \"WriteCapacityUnits\": 0
+            \"ReadCapacityUnits\": 1,
+            \"WriteCapacityUnits\": 1
         },
         \"TableName\": \"Thread\",
         \"TableSizeBytes\": 0,
@@ -2033,8 +2033,8 @@ create_table_output_tests(_) ->
                       last_decrease_date_time = undefined,
                       last_increase_date_time = undefined,
                       number_of_decreases_today = 0,
-                      read_capacity_units = 0,
-                      write_capacity_units = 0},
+                      read_capacity_units = 1,
+                      write_capacity_units = 1},
                table_name = <<"Thread">>,
                table_size_bytes = 0,
                table_status = creating}}})

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -19,7 +19,7 @@
 -define(_f(F), fun() -> F end).
 
 -export([validate_body/2]).
-                            
+
 %%%===================================================================
 %%% Test entry points
 %%%===================================================================
@@ -149,7 +149,7 @@ validate_body(Body, Expected) ->
 %% Validates the request body and responds with the provided response.
 -spec input_expect(string(), expected_body()) -> fun().
 input_expect(Response, Expected) ->
-    fun(_Url, post, _Headers, Body, _Timeout, _Config) -> 
+    fun(_Url, post, _Headers, Body, _Timeout, _Config) ->
             validate_body(Body, Expected),
             {ok, {{200, "OK"}, [], list_to_binary(Response)}}
     end.
@@ -159,7 +159,7 @@ input_expect(Response, Expected) ->
 -spec input_test(string(), input_test_spec()) -> tuple().
 input_test(Response, {Line, {Description, Fun, Expected}}) when
       is_list(Description) ->
-    {Description, 
+    {Description,
      {Line,
       fun() ->
               meck:expect(erlcloud_httpc, request, input_expect(Response, Expected)),
@@ -181,8 +181,8 @@ input_tests(Response, Tests) ->
 %% returns the mock of the erlcloud_httpc function output tests expect to be called.
 -spec output_expect(string()) -> fun().
 output_expect(Response) ->
-    fun(_Url, post, _Headers, _Body, _Timeout, _Config) -> 
-            {ok, {{200, "OK"}, [], list_to_binary(Response)}} 
+    fun(_Url, post, _Headers, _Body, _Timeout, _Config) ->
+            {ok, {{200, "OK"}, [], list_to_binary(Response)}}
     end.
 
 %% output_test converts an output_test specifier into an eunit test generator
@@ -204,9 +204,9 @@ output_test(Fun, {Line, {Description, Response, Result}}) ->
       end}}.
 %% output_test(Fun, {Line, {Response, Result}}) ->
 %%     output_test(Fun, {Line, {"", Response, Result}}).
-      
+
 %% output_tests converts a list of output_test specifiers into an eunit test generator
--spec output_tests(fun(), [output_test_spec()]) -> [term()].       
+-spec output_tests(fun(), [output_test_spec()]) -> [term()].
 output_tests(Fun, Tests) ->
     [output_test(Fun, Test) || Test <- Tests].
 
@@ -218,7 +218,7 @@ output_tests(Fun, Tests) ->
 -spec httpc_response(pos_integer(), string()) -> tuple().
 httpc_response(Code, Body) ->
     {ok, {{Code, ""}, [], list_to_binary(Body)}}.
-    
+
 -type error_test_spec() :: {pos_integer(), {string(), list(), term()}}.
 -spec error_test(fun(), error_test_spec()) -> tuple().
 error_test(Fun, {Line, {Description, Responses, Result}}) ->
@@ -232,7 +232,7 @@ error_test(Fun, {Line, {Description, Responses, Result}}) ->
               Actual = Fun(),
               ?assertEqual(Result, Actual)
       end}}.
-      
+
 -spec error_tests(fun(), [error_test_spec()]) -> [term()].
 error_tests(Fun, Tests) ->
     [error_test(Fun, Test) || Test <- Tests].
@@ -243,13 +243,16 @@ error_tests(Fun, Tests) ->
 
 input_exception_test_() ->
     [?_assertError({erlcloud_ddb, {invalid_attr_value, {n, "string"}}},
-                   erlcloud_ddb2:get_item(<<"Table">>, {<<"K">>, {n, "string"}})),
+                   erlcloud_ddb2:get_item(<<"Table">>, {<<"K">>, {n, "string"}}))]
+    ++ input_exception_failures_test_().
+
+-dialyzer({nowarn_function, input_exception_failures_test_/0}).
+input_exception_failures_test_() ->
      %% This test causes an expected dialyzer error
-     ?_assertError({erlcloud_ddb, {invalid_item, <<"Attr">>}},
+    [?_assertError({erlcloud_ddb, {invalid_item, <<"Attr">>}},
                    erlcloud_ddb2:put_item(<<"Table">>, <<"Attr">>)),
      ?_assertError({erlcloud_ddb, {invalid_opt, {myopt, myval}}},
-                   erlcloud_ddb2:list_tables([{myopt, myval}]))
-    ].
+                   erlcloud_ddb2:list_tables([{myopt, myval}]))].
 
 %% Error handling tests based on:
 %% http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html
@@ -260,12 +263,12 @@ error_handling_tests(_) ->
      \"status\":{\"S\":\"online\"}
     },
 \"ConsumedCapacityUnits\": 1
-}"                                   
+}"
                                   ),
     OkResult = {ok, [{<<"friends">>, [<<"Lynda">>, <<"Aaron">>]},
                      {<<"status">>, <<"online">>}]},
 
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"Test retry after ProvisionedThroughputExceededException",
              [httpc_response(400, "
@@ -287,7 +290,7 @@ error_handling_tests(_) ->
               OkResponse],
              OkResult})
         ],
-    
+
     error_tests(?_f(erlcloud_ddb2:get_item(<<"table">>, {<<"k">>, <<"v">>})), Tests),
 
     TransactionErrorResult = {error, {<<"TransactionCanceledException">>,
@@ -351,13 +354,13 @@ batch_get_item_input_tests(_) ->
         [?_ddb_test(
             {"BatchGetItem example request",
              ?_f(erlcloud_ddb2:batch_get_item(
-                   [{<<"Forum">>, 
+                   [{<<"Forum">>,
                      [{<<"Name">>, {s, <<"Amazon DynamoDB">>}},
-                      {<<"Name">>, {s, <<"Amazon RDS">>}}, 
+                      {<<"Name">>, {s, <<"Amazon RDS">>}},
                       {<<"Name">>, {s, <<"Amazon Redshift">>}}],
                      [{attributes_to_get, [<<"Name">>, <<"Threads">>, <<"Messages">>, <<"Views">>]}]},
-                    {<<"Thread">>, 
-                     [[{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}}, 
+                    {<<"Thread">>,
+                     [[{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},
                        {<<"Subject">>, {s, <<"Concurrent reads">>}}]],
                      [{attributes_to_get, [<<"Tags">>, <<"Message">>]}]}],
                    [{return_consumed_capacity, total}])), "
@@ -512,7 +515,7 @@ batch_get_item_input_tests(_) ->
     input_tests(Response, Tests).
 
 batch_get_item_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"BatchGetItem example response", "
 {
@@ -586,10 +589,10 @@ batch_get_item_output_tests(_) ->
     ]
 }",
              {ok, #ddb2_batch_get_item
-              {consumed_capacity = 
+              {consumed_capacity =
                    [#ddb2_consumed_capacity{table_name = <<"Forum">>, capacity_units = 3},
                     #ddb2_consumed_capacity{table_name = <<"Thread">>, capacity_units = 1}],
-               responses = 
+               responses =
                    [#ddb2_batch_get_item_response
                     {table = <<"Forum">>,
                      items = [[{<<"Name">>, <<"Amazon DynamoDB">>},
@@ -644,19 +647,19 @@ batch_get_item_output_tests(_) ->
     }
 }",
              {ok, #ddb2_batch_get_item
-              {responses = [], 
-               unprocessed_keys = 
-                   [{<<"Forum">>, 
+              {responses = [],
+               unprocessed_keys =
+                   [{<<"Forum">>,
                      [[{<<"Name">>, {s, <<"Amazon DynamoDB">>}}],
-                      [{<<"Name">>, {s, <<"Amazon RDS">>}}], 
+                      [{<<"Name">>, {s, <<"Amazon RDS">>}}],
                       [{<<"Name">>, {s, <<"Amazon Redshift">>}}]],
                      [{attributes_to_get, [<<"Name">>, <<"Threads">>, <<"Messages">>, <<"Views">>]}]},
-                    {<<"Thread">>, 
-                     [[{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}}, 
+                    {<<"Thread">>,
+                     [[{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},
                        {<<"Subject">>, {s, <<"Concurrent reads">>}}]],
                      [{attributes_to_get, [<<"Tags">>, <<"Message">>]}]}]}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:batch_get_item([{<<"table">>, [{<<"k">>, <<"v">>}]}], [{out, record}])), Tests).
 
 %% BatchWriteItem test based on the API examples:
@@ -799,7 +802,7 @@ batch_write_item_input_tests(_) ->
     input_tests(Response, Tests).
 
 batch_write_item_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"BatchWriteItem example response", "
 {
@@ -829,7 +832,7 @@ batch_write_item_output_tests(_) ->
              {ok, #ddb2_batch_write_item
               {consumed_capacity = [#ddb2_consumed_capacity{table_name = <<"Forum">>, capacity_units = 3}],
                item_collection_metrics = undefined,
-               unprocessed_items = [{<<"Forum">>, 
+               unprocessed_items = [{<<"Forum">>,
                                      [{put, [{<<"Name">>, {s, <<"Amazon ElastiCache">>}},
                                              {<<"Category">>, {s, <<"Amazon Web Services">>}}]}]}]}}}),
          ?_ddb_test(
@@ -862,7 +865,7 @@ batch_write_item_output_tests(_) ->
     }
 }",
              {ok, #ddb2_batch_write_item
-              {consumed_capacity = undefined, 
+              {consumed_capacity = undefined,
                item_collection_metrics = undefined,
                unprocessed_items =
                    [{<<"Forum">>, [{put, [{<<"Name">>, {s, <<"Amazon DynamoDB">>}},
@@ -913,8 +916,8 @@ batch_write_item_output_tests(_) ->
     }
 }",
              {ok, #ddb2_batch_write_item
-              {consumed_capacity = undefined, 
-               item_collection_metrics = 
+              {consumed_capacity = undefined,
+               item_collection_metrics =
                    [{<<"Table1">>,
                      [#ddb2_item_collection_metrics
                       {item_collection_key = <<"value1">>,
@@ -930,7 +933,7 @@ batch_write_item_output_tests(_) ->
                      ]}],
                unprocessed_items = []}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:batch_write_item([], [{out, record}])), Tests).
 
 %% CreateBackup test based on the API examples:
@@ -991,10 +994,10 @@ create_global_table_input_tests(_) ->
                                                                     {region_name, <<"us-west-2">>}])), "
 {
    \"GlobalTableName\": \"Thread\",
-   \"ReplicationGroup\": [ 
-      { 
+   \"ReplicationGroup\": [
+      {
          \"RegionName\": \"us-east-1\"
-      },{ 
+      },{
          \"RegionName\": \"us-west-2\"
       }
    ]
@@ -1002,11 +1005,11 @@ create_global_table_input_tests(_) ->
               }),
            ?_ddb_test(
               {"CreateGlobalTable example request (1 region)",
-               ?_f(erlcloud_ddb2:create_global_table(<<"Thread">>, #ddb2_replica{region_name = <<"us-west-2">>})), "
+               ?_f(erlcloud_ddb2:create_global_table(<<"Thread">>, [#ddb2_replica{region_name = <<"us-west-2">>}])), "
 {
    \"GlobalTableName\": \"Thread\",
-   \"ReplicationGroup\": [ 
-      { 
+   \"ReplicationGroup\": [
+      {
          \"RegionName\": \"us-west-2\"
       }
    ]
@@ -1014,15 +1017,15 @@ create_global_table_input_tests(_) ->
               })],
       Response = "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"CREATING\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"us-east-1\"
-          },{ 
+          },{
              \"RegionName\": \"us-west-2\"
           }
       ]
@@ -1032,17 +1035,17 @@ create_global_table_input_tests(_) ->
 
 %% CreateGlobalTable output test:
 create_global_table_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"CreateGlobalTable example response with CREATING status ", "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"CREATING\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"us-east-1\"
           }
       ]
@@ -1058,15 +1061,15 @@ create_global_table_output_tests(_) ->
          ?_ddb_test(
             {"CreateGlobalTable example response with ACTIVE status ", "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"ACTIVE\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"us-east-1\"
-          },{ 
+          },{
              \"RegionName\": \"eu-west-1\"
           }
       ]
@@ -1079,7 +1082,7 @@ create_global_table_output_tests(_) ->
                 global_table_status = active,
                 replication_group = [#ddb2_replica_description{region_name = <<"us-east-1">>},
                                      #ddb2_replica_description{region_name = <<"eu-west-1">>}]}}})],
-    output_tests(?_f(erlcloud_ddb2:create_global_table(<<"Thread">>, {region_name, <<"us-east-1">>})), Tests).
+    output_tests(?_f(erlcloud_ddb2:create_global_table(<<"Thread">>, [{region_name, <<"us-east-1">>}])), Tests).
 
 %% CreateTable test based on the API examples:
 %% http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html
@@ -1093,7 +1096,7 @@ create_table_input_tests(_) ->
                     {<<"Subject">>, s},
                     {<<"LastPostDateTime">>, s}],
                    {<<"ForumName">>, <<"Subject">>},
-                   5, 
+                   5,
                    5,
                    [{local_secondary_indexes,
                      [{<<"LastPostIndex">>, <<"LastPostDateTime">>, keys_only}]},
@@ -1136,7 +1139,7 @@ create_table_input_tests(_) ->
                 \"WriteCapacityUnits\": 5
             }
         }
-    ],    
+    ],
     \"TableName\": \"Thread\",
     \"KeySchema\": [
         {
@@ -1180,12 +1183,12 @@ create_table_input_tests(_) ->
                     {<<"Subject">>, s},
                     {<<"LastPostDateTime">>, s}],
                    {<<"ForumName">>, <<"Subject">>},
-                   5, 
+                   5,
                    5,
                    [{local_secondary_indexes,
                      [{<<"LastPostIndex">>, <<"LastPostDateTime">>, {include, [<<"Author">>, <<"Body">>]}}]},
                     {global_secondary_indexes,
-                     [{<<"SubjectIndex">>, {<<"Subject">>, <<"LastPostDateTime">>}, {include, [<<"Author">>]}, 10, 5}]}]  
+                     [{<<"SubjectIndex">>, {<<"Subject">>, <<"LastPostDateTime">>}, {include, [<<"Author">>]}, 10, 5}]}]
                   )), "
 {
     \"AttributeDefinitions\": [
@@ -1226,7 +1229,7 @@ create_table_input_tests(_) ->
                 \"WriteCapacityUnits\": 5
             }
         }
-    ],  
+    ],
     \"TableName\": \"Thread\",
     \"KeySchema\": [
         {
@@ -1269,7 +1272,7 @@ create_table_input_tests(_) ->
                    <<"Thread">>,
                    {<<"ForumName">>, s},
                    <<"ForumName">>,
-                   1, 
+                   1,
                    1
                   )), "
 {
@@ -1656,7 +1659,7 @@ delete_backup_output_tests(_) ->
  output_tests(?_f(erlcloud_ddb2:delete_backup(<<"arn:aws:dynamodb:">>)), Tests).
 
 create_table_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"CreateTable example response", "
 {
@@ -1767,7 +1770,7 @@ create_table_output_tests(_) ->
                        item_count = 0,
                        key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
                        projection = keys_only}],
-               global_secondary_indexes = 
+               global_secondary_indexes =
                    [#ddb2_global_secondary_index_description{
                        index_name = <<"SubjectIndex">>,
                        index_size_bytes = 2048,
@@ -1782,7 +1785,7 @@ create_table_output_tests(_) ->
                           read_capacity_units = 3,
                           write_capacity_units = 4}
                     }],
-               provisioned_throughput = 
+               provisioned_throughput =
                    #ddb2_provisioned_throughput_description{
                       last_decrease_date_time = undefined,
                       last_increase_date_time = undefined,
@@ -1844,7 +1847,7 @@ create_table_output_tests(_) ->
                     \"WriteCapacityUnits\": 4
                 }
             }
-        ],        
+        ],
         \"CreationDateTime\": 1.36372808007E9,
         \"ItemCount\": 0,
         \"KeySchema\": [
@@ -1906,7 +1909,7 @@ create_table_output_tests(_) ->
                        item_count = 0,
                        key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
                        projection = {include, [<<"Author">>, <<"Body">>]}}],
-               global_secondary_indexes = 
+               global_secondary_indexes =
                    [#ddb2_global_secondary_index_description{
                        index_name = <<"SubjectIndex">>,
                        index_size_bytes = 2048,
@@ -1921,7 +1924,7 @@ create_table_output_tests(_) ->
                           read_capacity_units = 3,
                           write_capacity_units = 4}
                     }],
-               provisioned_throughput = 
+               provisioned_throughput =
                    #ddb2_provisioned_throughput_description{
                       last_decrease_date_time = undefined,
                       last_increase_date_time = undefined,
@@ -1973,7 +1976,7 @@ create_table_output_tests(_) ->
                item_count = 0,
                key_schema = <<"ForumName">>,
                local_secondary_indexes = undefined,
-               provisioned_throughput = 
+               provisioned_throughput =
                    #ddb2_provisioned_throughput_description{
                       last_decrease_date_time = undefined,
                       last_increase_date_time = undefined,
@@ -2036,7 +2039,7 @@ create_table_output_tests(_) ->
                table_size_bytes = 0,
                table_status = creating}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:create_table(<<"name">>, [{<<"key">>, s}], <<"key">>, 5, 10)), Tests).
 
 %% DeleteItem test based on the API examples:
@@ -2045,7 +2048,7 @@ delete_item_input_tests(_) ->
     Tests =
         [?_ddb_test(
             {"DeleteItem example request",
-             ?_f(erlcloud_ddb2:delete_item(<<"Thread">>, 
+             ?_f(erlcloud_ddb2:delete_item(<<"Thread">>,
                                           [{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},
                                            {<<"Subject">>, {s, <<"How do I update multiple items?">>}}],
                                           [{return_values, all_old},
@@ -2091,7 +2094,7 @@ delete_item_input_tests(_) ->
             }),
          ?_ddb_test(
             {"DeleteItem return metrics",
-             ?_f(erlcloud_ddb2:delete_item(<<"Thread">>, 
+             ?_f(erlcloud_ddb2:delete_item(<<"Thread">>,
                                           {<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},
                                           [{return_consumed_capacity, total},
                                            {return_item_collection_metrics, size}])), "
@@ -2134,7 +2137,7 @@ delete_item_input_tests(_) ->
     input_tests(Response, Tests).
 
 delete_item_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"DeleteItem example response", "
 {
@@ -2194,7 +2197,7 @@ delete_item_output_tests(_) ->
                             size_estimate_range_gb = {1,2}}
                      }}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:delete_item(<<"table">>, {<<"k">>, <<"v">>}, [{out, record}])), Tests).
 
 %% DeleteTable test based on the API examples:
@@ -2227,7 +2230,7 @@ delete_table_input_tests(_) ->
     input_tests(Response, Tests).
 
 delete_table_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"DeleteTable example response", "
 {
@@ -2253,7 +2256,7 @@ delete_table_output_tests(_) ->
                table_size_bytes = 0,
                table_status = deleting}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:delete_table(<<"name">>)), Tests).
 
 %% DescribeBackup test based on the API examples:
@@ -2582,15 +2585,15 @@ describe_global_table_input_tests(_) ->
               })],
       Response = "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"ACTIVE\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"us-east-1\"
-          },{ 
+          },{
              \"RegionName\": \"us-west-2\"
           }
       ]
@@ -2600,17 +2603,17 @@ describe_global_table_input_tests(_) ->
 
 %% DescribeGlobalTable output test:
 describe_global_table_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"DescribeGlobalTable example response with CREATING status ", "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"CREATING\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"us-east-1\"
           }
       ]
@@ -2626,15 +2629,15 @@ describe_global_table_output_tests(_) ->
          ?_ddb_test(
             {"DescribeGlobalTable example response with ACTIVE status ", "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"ACTIVE\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"us-east-1\"
-          },{ 
+          },{
              \"RegionName\": \"eu-west-1\"
           }
       ]
@@ -2983,7 +2986,7 @@ describe_table_input_tests(_) ->
     input_tests(Response, Tests).
 
 describe_table_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"DescribeTable example response", "
 {
@@ -3032,7 +3035,7 @@ describe_table_output_tests(_) ->
                     \"WriteCapacityUnits\": 4
                 }
             }
-        ],          
+        ],
         \"CreationDateTime\": 1.363729002358E9,
         \"GlobalTableVersion\": \"2019.11.21\",
         \"ItemCount\": 0,
@@ -3101,7 +3104,7 @@ describe_table_output_tests(_) ->
                        item_count = 0,
                        key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
                        projection = keys_only}],
-               global_secondary_indexes = 
+               global_secondary_indexes =
                    [#ddb2_global_secondary_index_description{
                        index_name = <<"SubjectIndex">>,
                        index_size_bytes = 2048,
@@ -3115,8 +3118,8 @@ describe_table_output_tests(_) ->
                           number_of_decreases_today = 2,
                           read_capacity_units = 3,
                           write_capacity_units = 4}
-                    }],                       
-               provisioned_throughput = 
+                    }],
+               provisioned_throughput =
                    #ddb2_provisioned_throughput_description{
                       last_decrease_date_time = undefined,
                       last_increase_date_time = undefined,
@@ -3131,7 +3134,7 @@ describe_table_output_tests(_) ->
                table_size_bytes = 0,
                table_status = active}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:describe_table(<<"name">>)), Tests).
 
 
@@ -3356,7 +3359,7 @@ describe_time_to_live_input_tests(_) ->
 }"
               })],
       Response = "
-{          
+{
     \"TimeToLiveDescription\": {
         \"AttributeName\": \"ExpirationTime\",
         \"TimeToLiveStatus\": \"ENABLED\"
@@ -3366,7 +3369,7 @@ describe_time_to_live_input_tests(_) ->
 
 %% DescribeTimeToLive test:
 describe_time_to_live_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"DescribeTimeToLive example response with enabled TTL", "
 {
@@ -3441,7 +3444,7 @@ get_item_input_tests(_) ->
         [?_ddb_test(
             {"GetItem example request, with fully specified keys",
              ?_f(erlcloud_ddb2:get_item(<<"Thread">>,
-                                       [{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}}, 
+                                       [{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},
                                         {<<"Subject">>, {s, <<"How do I update multiple items?">>}}],
                                        [{attributes_to_get, [<<"LastPostDateTime">>, <<"Message">>, <<"Tags">>]},
                                         consistent_read,
@@ -3452,7 +3455,7 @@ get_item_input_tests(_) ->
              Example1Response}),
          ?_ddb_test(
             {"GetItem example request, with inferred key types",
-             ?_f(erlcloud_ddb2:get_item(<<"Thread">>, 
+             ?_f(erlcloud_ddb2:get_item(<<"Thread">>,
                                        [{<<"ForumName">>, "Amazon DynamoDB"},
                                         {<<"Subject">>, <<"How do I update multiple items?">>}],
                                        [{attributes_to_get, [<<"LastPostDateTime">>, <<"Message">>, <<"Tags">>]},
@@ -3514,7 +3517,7 @@ get_item_input_tests(_) ->
     input_tests(Response, Tests).
 
 get_item_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"GetItem example response", "
 {
@@ -3573,19 +3576,19 @@ get_item_output_tests(_) ->
                              {<<"empty_map">>, []}],
                     consumed_capacity = undefined}}}),
          ?_ddb_test(
-            {"GetItem item not found", 
+            {"GetItem item not found",
              "{}",
              {ok, #ddb2_get_item{item = undefined}}}),
          ?_ddb_test(
-            {"GetItem no attributes returned", 
+            {"GetItem no attributes returned",
              "{\"Item\":{}}",
              {ok, #ddb2_get_item{item = []}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:get_item(<<"table">>, {<<"k">>, <<"v">>}, [{out, record}])), Tests).
 
 get_item_output_typed_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"GetItem typed test all attribute types", "
 {\"Item\":
@@ -3618,7 +3621,7 @@ get_item_output_typed_tests(_) ->
                              {<<"empty_map">>, {m, []}}],
                     consumed_capacity = undefined}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:get_item(
                        <<"table">>, {<<"k">>, <<"v">>}, [{out, typed_record}])), Tests).
 
@@ -3705,7 +3708,7 @@ list_global_tables_input_tests(_) ->
             }),
          ?_ddb_test(
             {"ListGlobalTables empty request",
-             ?_f(erlcloud_ddb2:list_global_tables()), 
+             ?_f(erlcloud_ddb2:list_global_tables()),
              "{}"
             })
 
@@ -3713,22 +3716,22 @@ list_global_tables_input_tests(_) ->
 
     Response = "
 {
-   \"GlobalTables\": [ 
-      { 
+   \"GlobalTables\": [
+      {
          \"GlobalTableName\": \"Forum\",
-         \"ReplicationGroup\": [ 
-            { 
+         \"ReplicationGroup\": [
+            {
                \"RegionName\": \"us-west-2\"
-            },{ 
+            },{
                \"RegionName\": \"us-east-1\"
             }
          ]
-      },{ 
+      },{
          \"GlobalTableName\": \"Thread\",
-         \"ReplicationGroup\": [ 
-            { 
+         \"ReplicationGroup\": [
+            {
                \"RegionName\": \"us-east-1\"
-            },{ 
+            },{
                \"RegionName\": \"eu-west-1\"
             }
          ]
@@ -3740,26 +3743,26 @@ list_global_tables_input_tests(_) ->
 
 %% ListGlobalTables output test:
 list_global_tables_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"ListGlobalTables example response", "
 {
-   \"GlobalTables\": [ 
-      { 
+   \"GlobalTables\": [
+      {
          \"GlobalTableName\": \"Forum\",
-         \"ReplicationGroup\": [ 
-            { 
+         \"ReplicationGroup\": [
+            {
                \"RegionName\": \"us-west-2\"
-            },{ 
+            },{
                \"RegionName\": \"us-east-1\"
             }
          ]
-      },{ 
+      },{
          \"GlobalTableName\": \"Thread\",
-         \"ReplicationGroup\": [ 
-            { 
+         \"ReplicationGroup\": [
+            {
                \"RegionName\": \"us-east-1\"
-            },{ 
+            },{
                \"RegionName\": \"eu-west-1\"
             }
          ]
@@ -3778,7 +3781,7 @@ list_global_tables_output_tests(_) ->
                                   replication_group = [#ddb2_replica{region_name = <<"us-east-1">>},
                                                        #ddb2_replica{region_name = <<"eu-west-1">>}]}]}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:list_global_tables([{out, record}])), Tests).
 
 %% ListTables test based on the API examples:
@@ -3795,7 +3798,7 @@ list_tables_input_tests(_) ->
             }),
          ?_ddb_test(
             {"ListTables empty request",
-             ?_f(erlcloud_ddb2:list_tables()), 
+             ?_f(erlcloud_ddb2:list_tables()),
              "{}"
             })
 
@@ -3809,7 +3812,7 @@ list_tables_input_tests(_) ->
     input_tests(Response, Tests).
 
 list_tables_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"ListTables example response", "
 {
@@ -3820,7 +3823,7 @@ list_tables_output_tests(_) ->
               {last_evaluated_table_name = <<"Thread">>,
                table_names = [<<"Forum">>, <<"Reply">>, <<"Thread">>]}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:list_tables([{out, record}])), Tests).
 
 %% ListTagsOfResource test based on the API:
@@ -3853,7 +3856,7 @@ list_tags_of_resource_input_tests(_) ->
     input_tests(Response, Tests).
 
 list_tags_of_resource_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"ListTagsOfResource example response", "
 {
@@ -3874,7 +3877,7 @@ list_tags_of_resource_output_tests(_) ->
                tags = [{<<"example_key1">>, <<"example_value1">>},
                        {<<"example_key2">>, <<"example_value2">>}]}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:list_tags_of_resource(<<"arn:aws:dynamodb:us-east-1:111122223333:table/Forum">>,
                                                          [{out, record}])),
                      Tests).
@@ -3885,7 +3888,7 @@ put_item_input_tests(_) ->
     Tests =
         [?_ddb_test(
             {"PutItem example request",
-             ?_f(erlcloud_ddb2:put_item(<<"Thread">>, 
+             ?_f(erlcloud_ddb2:put_item(<<"Thread">>,
                                        [{<<"LastPostedBy">>, <<"fred@example.com">>},
                                         {<<"ForumName">>, <<"Amazon DynamoDB">>},
                                         {<<"LastPostDateTime">>, <<"201303190422">>},
@@ -3927,7 +3930,7 @@ put_item_input_tests(_) ->
             }),
          ?_ddb_test(
             {"PutItem float inputs",
-             ?_f(erlcloud_ddb2:put_item(<<"Thread">>, 
+             ?_f(erlcloud_ddb2:put_item(<<"Thread">>,
                                        [{<<"typed float">>, {n, 1.2}},
                                         {<<"untyped float">>, 3.456},
                                         {<<"mixed set">>, {ns, [7.8, 9.0, 10]}}],
@@ -4038,7 +4041,7 @@ put_item_input_tests(_) ->
     input_tests(Response, Tests).
 
 put_item_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"PutItem example response", "
 {
@@ -4135,7 +4138,7 @@ put_item_output_tests(_) ->
                                   ]
                      }}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:put_item(<<"table">>, [], [{out, record}])), Tests).
 
 %% Query test based on the API examples:
@@ -4275,7 +4278,7 @@ q_input_tests(_) ->
     input_tests(Response, Tests).
 
 q_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"Query example 1 response", "
 {
@@ -4371,12 +4374,12 @@ q_output_tests(_) ->
     }
 }",
              {ok, #ddb2_q{count = 17,
-                         last_evaluated_key = 
+                         last_evaluated_key =
                              [{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},
                               {<<"Subject">>, {s, <<"Exclusive key can have 3 parts">>}},                                                        {<<"LastPostDateTime">>, {s, <<"20130102054211">>}}]
                          }}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:q(<<"table">>, [{<<"k">>, <<"v">>, eq}], [{out, record}])), Tests).
 
 %% RestoreTableFromBackup test based on the API examples:
@@ -4900,7 +4903,7 @@ scan_input_tests(_) ->
             }),
          ?_ddb_test(
             {"Scan example 2 request",
-             ?_f(erlcloud_ddb2:scan(<<"Reply">>, 
+             ?_f(erlcloud_ddb2:scan(<<"Reply">>,
                                    [{scan_filter, [{<<"PostedBy">>, <<"joe@example.com">>, eq}]},
                                     {return_consumed_capacity, total}])), "
 {
@@ -4929,7 +4932,7 @@ scan_input_tests(_) ->
             }),
          ?_ddb_test(
             {"Scan exclusive start key",
-             ?_f(erlcloud_ddb2:scan(<<"Reply">>, 
+             ?_f(erlcloud_ddb2:scan(<<"Reply">>,
                                    [{exclusive_start_key, [{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},
                                                            {<<"LastPostDateTime">>, {n, 20130102054211}}]}])), "
 {
@@ -5073,7 +5076,7 @@ scan_input_tests(_) ->
     input_tests(Response, Tests).
 
 scan_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"Scan example 1 response", "
 {
@@ -5277,7 +5280,7 @@ scan_output_tests(_) ->
                                      {<<"LastPostDateTime">>, {n, 20130102054211}}],
                scanned_count = 4}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:scan(<<"name">>, [{out, record}])), Tests).
 
 %% TagResource test based on the API:
@@ -5308,7 +5311,7 @@ tag_resource_input_tests(_) ->
     input_tests(Response, Tests).
 
 tag_resource_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"ListTagsOfResource example response", "",
              ok})
@@ -5749,7 +5752,7 @@ untag_resource_input_tests(_) ->
     input_tests(Response, Tests).
 
 untag_resource_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"ListTagsOfResource example response", "",
              ok})
@@ -5816,7 +5819,7 @@ update_item_input_tests(_) ->
     Tests =
         [?_ddb_test(
             {"UpdateItem example request",
-             ?_f(erlcloud_ddb2:update_item(<<"Thread">>, 
+             ?_f(erlcloud_ddb2:update_item(<<"Thread">>,
                                           [{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},
                                            {<<"Subject">>, {s, <<"How do I update multiple items?">>}}],
                                           [{<<"LastPostedBy">>, {s, <<"alice@example.com">>}, put}],
@@ -5933,7 +5936,7 @@ update_item_input_tests(_) ->
     input_tests(Response, Tests).
 
 update_item_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"UpdateItem example response", "
 {
@@ -5974,7 +5977,7 @@ update_item_output_tests(_) ->
 }",
              {ok, []}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:update_item(<<"table">>, {<<"k">>, <<"v">>}, [])), Tests).
 
 %% UpdateGlobalTable input test:
@@ -5985,9 +5988,9 @@ update_global_table_input_tests(_) ->
                ?_f(erlcloud_ddb2:update_global_table(<<"Thread">>, [{create, {region_name, <<"us-east-1">>}}])), "
 {
    \"GlobalTableName\": \"Thread\",
-   \"ReplicaUpdates\": [ 
-      { 
-         \"Create\": { 
+   \"ReplicaUpdates\": [
+      {
+         \"Create\": {
             \"RegionName\": \"us-east-1\"
          }
       }
@@ -5996,12 +5999,12 @@ update_global_table_input_tests(_) ->
               }),
            ?_ddb_test(
               {"UpdateGlobalTable example request (delete)",
-               ?_f(erlcloud_ddb2:update_global_table(<<"Thread">>, {delete, #ddb2_replica{region_name = <<"us-west-2">>}})), "
+               ?_f(erlcloud_ddb2:update_global_table(<<"Thread">>, [{delete, #ddb2_replica{region_name = <<"us-west-2">>}}])), "
 {
    \"GlobalTableName\": \"Thread\",
-   \"ReplicaUpdates\": [ 
-      { 
-         \"Delete\": { 
+   \"ReplicaUpdates\": [
+      {
+         \"Delete\": {
             \"RegionName\": \"us-west-2\"
          }
       }
@@ -6014,13 +6017,13 @@ update_global_table_input_tests(_) ->
                                                                     {delete, {region_name, <<"eu-west-1">>}}])), "
 {
    \"GlobalTableName\": \"Thread\",
-   \"ReplicaUpdates\": [ 
-      { 
-         \"Create\": { 
+   \"ReplicaUpdates\": [
+      {
+         \"Create\": {
             \"RegionName\": \"us-east-1\"
          }
-      },{ 
-         \"Delete\": { 
+      },{
+         \"Delete\": {
             \"RegionName\": \"eu-west-1\"
          }
       }
@@ -6029,13 +6032,13 @@ update_global_table_input_tests(_) ->
               })],
       Response = "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"UPDATING\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"us-east-1\"
           }
       ]
@@ -6045,17 +6048,17 @@ update_global_table_input_tests(_) ->
 
 %% UpdateGlobalTable output test:
 update_global_table_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"UpdateGlobalTable example response with UPDATING status", "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"UPDATING\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"us-east-1\"
           }
       ]
@@ -6071,13 +6074,13 @@ update_global_table_output_tests(_) ->
          ?_ddb_test(
             {"UpdateGlobalTable example response with DELETING status", "
 {
-   \"GlobalTableDescription\": { 
+   \"GlobalTableDescription\": {
       \"CreationDateTime\": 1519161181.107,
       \"GlobalTableArn\": \"arn:aws:dynamodb::111122223333:global-table/Thread\",
       \"GlobalTableName\": \"Thread\",
       \"GlobalTableStatus\": \"DELETING\",
-      \"ReplicationGroup\": [ 
-          { 
+      \"ReplicationGroup\": [
+          {
              \"RegionName\": \"eu-west-1\"
           }
       ]
@@ -6089,7 +6092,7 @@ update_global_table_output_tests(_) ->
                 global_table_name = <<"Thread">>,
                 global_table_status = deleting,
                 replication_group = [#ddb2_replica_description{region_name = <<"eu-west-1">>}]}}})],
-    output_tests(?_f(erlcloud_ddb2:update_global_table(<<"Thread">>, {create, {region_name, <<"us-east-1">>}})), Tests).
+    output_tests(?_f(erlcloud_ddb2:update_global_table(<<"Thread">>, [{create, {region_name, <<"us-east-1">>}}])), Tests).
 
 update_global_table_settings_input_tests(_) ->
     ReadUnits = 10,
@@ -6690,7 +6693,7 @@ update_table_input_tests(_) ->
         ],
 
     Response = "
-{          
+{
     \"TableDescription\": {
         \"AttributeDefinitions\": [
             {
@@ -6752,10 +6755,10 @@ update_table_input_tests(_) ->
     input_tests(Response, Tests).
 
 update_table_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"UpdateTable example response", "
-{          
+{
     \"TableDescription\": {
         \"AttributeDefinitions\": [
             {
@@ -6801,7 +6804,7 @@ update_table_output_tests(_) ->
                     \"WriteCapacityUnits\": 4
                 }
             }
-        ],          
+        ],
         \"CreationDateTime\": 1.363801528686E9,
         \"ItemCount\": 0,
         \"KeySchema\": [
@@ -6859,7 +6862,7 @@ update_table_output_tests(_) ->
                        item_count = 0,
                        key_schema = {<<"ForumName">>, <<"LastPostDateTime">>},
                        projection = keys_only}],
-               global_secondary_indexes = 
+               global_secondary_indexes =
                    [#ddb2_global_secondary_index_description{
                        index_name = <<"SubjectIndex">>,
                        index_size_bytes = 2048,
@@ -6873,8 +6876,8 @@ update_table_output_tests(_) ->
                           number_of_decreases_today = 2,
                           read_capacity_units = 3,
                           write_capacity_units = 4}
-                    }],                        
-               provisioned_throughput = 
+                    }],
+               provisioned_throughput =
                    #ddb2_provisioned_throughput_description{
                       last_decrease_date_time = undefined,
                       last_increase_date_time = 1363801701.282,
@@ -6885,7 +6888,7 @@ update_table_output_tests(_) ->
                table_size_bytes = 0,
                table_status = updating}}})
         ],
-    
+
     output_tests(?_f(erlcloud_ddb2:update_table(<<"name">>, 5, 15)), Tests).
 
 update_table_replica_auto_scaling_input_tests(_) ->
@@ -7214,10 +7217,10 @@ update_time_to_live_input_tests(_) ->
         \"AttributeName\": \"ExpirationTime\",
         \"Enabled\": false
     }
-}" 
+}"
             })],
       Response = "
-{          
+{
     \"TimeToLiveSpecification\": {
         \"AttributeName\": \"ExpirationTime\",
         \"Enabled\": true
@@ -7227,7 +7230,7 @@ update_time_to_live_input_tests(_) ->
 
 %% UpdateTimeToLive test:
 update_time_to_live_output_tests(_) ->
-    Tests = 
+    Tests =
         [?_ddb_test(
             {"UpdateTimeToLive example response", "
 {
@@ -7239,5 +7242,5 @@ update_time_to_live_output_tests(_) ->
               {ok, #ddb2_time_to_live_specification{
                 attribute_name = <<"ExpirationTime">>,
                 enabled = true}}})],
-    output_tests(?_f(erlcloud_ddb2:update_time_to_live(<<"SessionData">>, 
+    output_tests(?_f(erlcloud_ddb2:update_time_to_live(<<"SessionData">>,
       [{attribute_name, <<"ExpirationTime">>}, {enabled, true}])), Tests).

--- a/test/erlcloud_ddb_tests.erl
+++ b/test/erlcloud_ddb_tests.erl
@@ -180,9 +180,13 @@ error_tests(Fun, Tests) ->
 
 input_exception_test_() ->
     [?_assertError({erlcloud_ddb, {invalid_attr_value, {n, "string"}}},
-                   erlcloud_ddb:get_item(<<"Table">>, {n, "string"})),
-     %% This test causes an expected dialyzer error
-     ?_assertError({erlcloud_ddb, {invalid_item, <<"Attr">>}},
+                   erlcloud_ddb:get_item(<<"Table">>, {n, "string"}))]
+    ++ input_exception_failures_test_().
+
+-dialyzer({nowarn_function, input_exception_failures_test_/0}).
+input_exception_failures_test_() ->
+    %% This test causes an expected dialyzer error
+    [?_assertError({erlcloud_ddb, {invalid_item, <<"Attr">>}},
                    erlcloud_ddb:put_item(<<"Table">>, <<"Attr">>)),
      ?_assertError({erlcloud_ddb, {invalid_opt, {myopt, myval}}},
                    erlcloud_ddb:list_tables([{myopt, myval}]))

--- a/test/erlcloud_ddb_util_tests.erl
+++ b/test/erlcloud_ddb_util_tests.erl
@@ -652,8 +652,8 @@ q_all_tests(_) ->
     multi_call_tests(Tests).
 
 q_all_attributes() ->
-    Item1 = <<"item_1">>,
-    Item2 = <<"item_2">>,
+    Item1 = [{<<"key">>, <<"item_1">>}],
+    Item2 = [{<<"key">>, <<"item_2">>}],
     meck:new(EDDB = erlcloud_ddb2),
     meck:sequence(EDDB, q, 4, [
         {ok, #ddb2_q{last_evaluated_key = <<"key">>,
@@ -799,8 +799,8 @@ scan_all_tests(_) ->
     multi_call_tests(Tests).
 
 scan_all_attributes() ->
-    Item1 = <<"item_1">>,
-    Item2 = <<"item_2">>,
+    Item1 = [{<<"key">>, <<"item_1">>}],
+    Item2 = [{<<"key">>, <<"item_2">>}],
     meck:new(EDDB = erlcloud_ddb2),
     meck:sequence(EDDB, scan, 3, [
         {ok, #ddb2_scan{last_evaluated_key = <<"key">>,

--- a/test/erlcloud_ddb_util_tests.erl
+++ b/test/erlcloud_ddb_util_tests.erl
@@ -656,7 +656,7 @@ q_all_attributes() ->
     Item2 = [{<<"key">>, <<"item_2">>}],
     meck:new(EDDB = erlcloud_ddb2),
     meck:sequence(EDDB, q, 4, [
-        {ok, #ddb2_q{last_evaluated_key = <<"key">>,
+        {ok, #ddb2_q{last_evaluated_key = {<<"key">>, <<"last1">>},
                      items              = [Item1]}},
         {ok, #ddb2_q{last_evaluated_key = undefined,
                      items              = [Item2]}}
@@ -668,7 +668,7 @@ q_all_attributes() ->
 q_all_count() ->
     meck:new(EDDB = erlcloud_ddb2),
     meck:sequence(EDDB, q, 4, [
-        {ok, #ddb2_q{last_evaluated_key = <<"key">>,
+        {ok, #ddb2_q{last_evaluated_key = {<<"key">>, <<"last1">>},
                      items              = undefined,
                      count              = 2}},
         {ok, #ddb2_q{last_evaluated_key = undefined,
@@ -803,7 +803,7 @@ scan_all_attributes() ->
     Item2 = [{<<"key">>, <<"item_2">>}],
     meck:new(EDDB = erlcloud_ddb2),
     meck:sequence(EDDB, scan, 3, [
-        {ok, #ddb2_scan{last_evaluated_key = <<"key">>,
+        {ok, #ddb2_scan{last_evaluated_key = {<<"key">>, <<"last1">>},
                         items              = [Item1]}},
         {ok, #ddb2_scan{last_evaluated_key = undefined,
                         items              = [Item2]}}
@@ -815,7 +815,7 @@ scan_all_attributes() ->
 scan_all_count() ->
     meck:new(EDDB = erlcloud_ddb2),
     meck:sequence(EDDB, scan, 3, [
-        {ok, #ddb2_scan{last_evaluated_key = <<"key">>,
+        {ok, #ddb2_scan{last_evaluated_key = {<<"key">>, <<"last1">>},
                         items              = undefined,
                         count              = 2}},
         {ok, #ddb2_scan{last_evaluated_key = undefined,

--- a/test/erlcloud_ddb_util_tests.erl
+++ b/test/erlcloud_ddb_util_tests.erl
@@ -1516,8 +1516,13 @@ set_out_opt_test_() ->
                     erlcloud_ddb_util:set_out_opt([{typed_out, true}]))},
      {"set_out_opt typed_out=false sets out=record",
       ?_assertEqual([{out, record}],
-                    erlcloud_ddb_util:set_out_opt([{typed_out, false}]))},
-     {"set_out_opt preserves location of out opt",
+                    erlcloud_ddb_util:set_out_opt([{typed_out, false}]))}]
+    ++ set_out_opt_failures_test_().
+
+% these will generate dialyzer warnings, so we isolate them
+-dialyzer({nowarn_function, set_out_opt_failures_test_/0}).
+set_out_opt_failures_test_() ->
+    [{"set_out_opt preserves location of out opt",
       ?_assertEqual([{foo, bar}, {out, record}],
                     erlcloud_ddb_util:set_out_opt([{typed_out, false}, {foo, bar}, {out, record}]))},
      {"set_out_opt overrides out opt with valid value",

--- a/test/erlcloud_ec2_tests.erl
+++ b/test/erlcloud_ec2_tests.erl
@@ -1223,6 +1223,7 @@ describe_spot_price_history_test_() ->
     {timeout, 60, fun () -> test_pagination(Tests, generate_spot_price_history_response, describe_spot_price_history, [], ["", "", [], ""]) end}
 .
 
+-dialyzer({nowarn_function, describe_spot_price_history_boundaries_test_/0}).
 describe_spot_price_history_boundaries_test_() ->
     [
         ?_assertException(error, function_clause, erlcloud_ec2:describe_spot_price_history(["", "", [], ""], 4, undefined)),

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -174,14 +174,14 @@ create_service_input_tests(_) ->
         },
         \"deployments\": [
           {
-            \"createdAt\": 1430326887.362,
+            \"createdAt\": 1430326887362,
             \"desiredCount\": 10,
             \"id\": \"ecs-svc/9223370606527888445\",
             \"pendingCount\": 0,
             \"runningCount\": 0,
             \"status\": \"PRIMARY\",
             \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1\",
-            \"updatedAt\": 1430326887.362
+            \"updatedAt\": 1430326887362
           }
         ],
         \"desiredCount\": 10,
@@ -210,14 +210,14 @@ create_service_output_tests(_) ->
         },
         \"deployments\": [
           {
-            \"createdAt\": 1430326887.362,
+            \"createdAt\": 1430326887362,
             \"desiredCount\": 10,
             \"id\": \"ecs-svc/9223370606527888445\",
             \"pendingCount\": 0,
             \"runningCount\": 0,
             \"status\": \"PRIMARY\",
             \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1\",
-            \"updatedAt\": 1430326887.362
+            \"updatedAt\": 1430326887362
           }
         ],
         \"desiredCount\": 10,
@@ -238,14 +238,14 @@ create_service_output_tests(_) ->
                         minimum_healthy_percent = 100
                      },
                      deployments = [#ecs_deployment{
-                        created_at = 1430326887.362,
+                        created_at = 1430326887362,
                         desired_count = 10,
                         id = <<"ecs-svc/9223370606527888445">>,
                         pending_count = 0,
                         running_count = 0,
                         status = <<"PRIMARY">>,
                         task_definition = <<"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1">>,
-                        updated_at = 1430326887.362
+                        updated_at = 1430326887362
                      }],
                      desired_count = 10,
                      events = [],
@@ -338,14 +338,14 @@ delete_service_input_tests(_) ->
         },
         \"deployments\": [
           {
-            \"createdAt\": 1430326887.362,
+            \"createdAt\": 1430326887362,
             \"desiredCount\": 10,
             \"id\": \"ecs-svc/9223370606527888445\",
             \"pendingCount\": 0,
             \"runningCount\": 0,
             \"status\": \"PRIMARY\",
             \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1\",
-            \"updatedAt\": 1430326887.362
+            \"updatedAt\": 1430326887362
           }
         ],
         \"desiredCount\": 10,
@@ -374,14 +374,14 @@ delete_service_output_tests(_) ->
         },
         \"deployments\": [
           {
-            \"createdAt\": 1430326887.362,
+            \"createdAt\": 1430326887362,
             \"desiredCount\": 10,
             \"id\": \"ecs-svc/9223370606527888445\",
             \"pendingCount\": 0,
             \"runningCount\": 0,
             \"status\": \"PRIMARY\",
             \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1\",
-            \"updatedAt\": 1430326887.362
+            \"updatedAt\": 1430326887362
           }
         ],
         \"desiredCount\": 10,
@@ -402,14 +402,14 @@ delete_service_output_tests(_) ->
                         minimum_healthy_percent = 100
                      },
                      deployments = [#ecs_deployment{
-                        created_at = 1430326887.362,
+                        created_at = 1430326887362,
                         desired_count = 10,
                         id = <<"ecs-svc/9223370606527888445">>,
                         pending_count = 0,
                         running_count = 0,
                         status = <<"PRIMARY">>,
                         task_definition = <<"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1">>,
-                        updated_at = 1430326887.362
+                        updated_at = 1430326887362
                      }],
                      desired_count = 10,
                      events = [],
@@ -1349,14 +1349,14 @@ describe_services_input_tests(_) ->
       },
       \"deployments\": [
         {
-          \"createdAt\": 1432829320.611,
+          \"createdAt\": 1432829320611,
           \"desiredCount\": 4,
           \"id\": \"ecs-svc/9223370604025455196\",
           \"pendingCount\": 0,
           \"runningCount\": 4,
           \"status\": \"PRIMARY\",
           \"taskDefinition\": \"arn:aws:ecs:us-west-2:012345678910:task-definition/hpcc-t2-medium:1\",
-          \"updatedAt\": 1432829320.611
+          \"updatedAt\": 1432829320611
         }
       ],
       \"desiredCount\": 4,
@@ -1390,14 +1390,14 @@ describe_services_output_tests(_) ->
       },
       \"deployments\": [
         {
-          \"createdAt\": 1432829320.611,
+          \"createdAt\": 1432829320611,
           \"desiredCount\": 4,
           \"id\": \"ecs-svc/9223370604025455196\",
           \"pendingCount\": 0,
           \"runningCount\": 4,
           \"status\": \"PRIMARY\",
           \"taskDefinition\": \"arn:aws:ecs:us-west-2:012345678910:task-definition/hpcc-t2-medium:1\",
-          \"updatedAt\": 1432829320.611
+          \"updatedAt\": 1432829320611
         }
       ],
       \"desiredCount\": 4,
@@ -1423,14 +1423,14 @@ describe_services_output_tests(_) ->
                         },
                         deployments = [
                             #ecs_deployment{
-                                created_at = 1432829320.611,
+                                created_at = 1432829320611,
                                 desired_count = 4,
                                 id = <<"ecs-svc/9223370604025455196">>,
                                 pending_count = 0,
                                 running_count = 4,
                                 status = <<"PRIMARY">>,
                                 task_definition = <<"arn:aws:ecs:us-west-2:012345678910:task-definition/hpcc-t2-medium:1">>,
-                                updated_at = 1432829320.611
+                                updated_at = 1432829320611
                             }
                         ],
                         desired_count = 4,
@@ -3130,14 +3130,14 @@ update_service_input_tests(_) ->
     },
     \"deployments\": [
       {
-        \"createdAt\": 1430333711.033,
+        \"createdAt\": 1430333711033,
         \"desiredCount\": 3,
         \"id\": \"ecs-svc/9223370606521064774\",
         \"pendingCount\": 0,
         \"runningCount\": 0,
         \"status\": \"PRIMARY\",
         \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10\",
-        \"updatedAt\": 1430336267.173
+        \"updatedAt\": 1430336267173
       }
     ],
     \"desiredCount\": 3,
@@ -3167,14 +3167,14 @@ update_service_output_tests(_) ->
     },
     \"deployments\": [
       {
-        \"createdAt\": 1430333711.033,
+        \"createdAt\": 1430333711033,
         \"desiredCount\": 3,
         \"id\": \"ecs-svc/9223370606521064774\",
         \"pendingCount\": 0,
         \"runningCount\": 0,
         \"status\": \"PRIMARY\",
         \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10\",
-        \"updatedAt\": 1430336267.173
+        \"updatedAt\": 1430336267173
       }
     ],
     \"desiredCount\": 3,
@@ -3197,14 +3197,14 @@ update_service_output_tests(_) ->
                     },
                     deployments = [
                         #ecs_deployment{
-                            created_at = 1430333711.033,
+                            created_at = 1430333711033,
                             desired_count = 3,
                             id = <<"ecs-svc/9223370606521064774">>,
                             pending_count = 0,
                             running_count = 0,
                             status = <<"PRIMARY">>,
                             task_definition = <<"arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10">>,
-                            updated_at = 1430336267.173
+                            updated_at = 1430336267173
                         }
                     ],
                     desired_count = 3,

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -174,14 +174,14 @@ create_service_input_tests(_) ->
         },
         \"deployments\": [
           {
-            \"createdAt\": 1430326887362,
+            \"createdAt\": 1430326887.362,
             \"desiredCount\": 10,
             \"id\": \"ecs-svc/9223370606527888445\",
             \"pendingCount\": 0,
             \"runningCount\": 0,
             \"status\": \"PRIMARY\",
             \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1\",
-            \"updatedAt\": 1430326887362
+            \"updatedAt\": 1430326887.362
           }
         ],
         \"desiredCount\": 10,
@@ -210,14 +210,14 @@ create_service_output_tests(_) ->
         },
         \"deployments\": [
           {
-            \"createdAt\": 1430326887362,
+            \"createdAt\": 1430326887.362,
             \"desiredCount\": 10,
             \"id\": \"ecs-svc/9223370606527888445\",
             \"pendingCount\": 0,
             \"runningCount\": 0,
             \"status\": \"PRIMARY\",
             \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1\",
-            \"updatedAt\": 1430326887362
+            \"updatedAt\": 1430326887.362
           }
         ],
         \"desiredCount\": 10,
@@ -238,14 +238,14 @@ create_service_output_tests(_) ->
                         minimum_healthy_percent = 100
                      },
                      deployments = [#ecs_deployment{
-                        created_at = 1430326887362,
+                        created_at = 1430326887.362,
                         desired_count = 10,
                         id = <<"ecs-svc/9223370606527888445">>,
                         pending_count = 0,
                         running_count = 0,
                         status = <<"PRIMARY">>,
                         task_definition = <<"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1">>,
-                        updated_at = 1430326887362
+                        updated_at = 1430326887.362
                      }],
                      desired_count = 10,
                      events = [],
@@ -338,14 +338,14 @@ delete_service_input_tests(_) ->
         },
         \"deployments\": [
           {
-            \"createdAt\": 1430326887362,
+            \"createdAt\": 1430326887.362,
             \"desiredCount\": 10,
             \"id\": \"ecs-svc/9223370606527888445\",
             \"pendingCount\": 0,
             \"runningCount\": 0,
             \"status\": \"PRIMARY\",
             \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1\",
-            \"updatedAt\": 1430326887362
+            \"updatedAt\": 1430326887.362
           }
         ],
         \"desiredCount\": 10,
@@ -374,14 +374,14 @@ delete_service_output_tests(_) ->
         },
         \"deployments\": [
           {
-            \"createdAt\": 1430326887362,
+            \"createdAt\": 1430326887.362,
             \"desiredCount\": 10,
             \"id\": \"ecs-svc/9223370606527888445\",
             \"pendingCount\": 0,
             \"runningCount\": 0,
             \"status\": \"PRIMARY\",
             \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1\",
-            \"updatedAt\": 1430326887362
+            \"updatedAt\": 1430326887.362
           }
         ],
         \"desiredCount\": 10,
@@ -402,14 +402,14 @@ delete_service_output_tests(_) ->
                         minimum_healthy_percent = 100
                      },
                      deployments = [#ecs_deployment{
-                        created_at = 1430326887362,
+                        created_at = 1430326887.362,
                         desired_count = 10,
                         id = <<"ecs-svc/9223370606527888445">>,
                         pending_count = 0,
                         running_count = 0,
                         status = <<"PRIMARY">>,
                         task_definition = <<"arn:aws:ecs:us-east-1:012345678910:task-definition/ecs-demo:1">>,
-                        updated_at = 1430326887362
+                        updated_at = 1430326887.362
                      }],
                      desired_count = 10,
                      events = [],
@@ -1349,14 +1349,14 @@ describe_services_input_tests(_) ->
       },
       \"deployments\": [
         {
-          \"createdAt\": 1432829320611,
+          \"createdAt\": 1432829320.611,
           \"desiredCount\": 4,
           \"id\": \"ecs-svc/9223370604025455196\",
           \"pendingCount\": 0,
           \"runningCount\": 4,
           \"status\": \"PRIMARY\",
           \"taskDefinition\": \"arn:aws:ecs:us-west-2:012345678910:task-definition/hpcc-t2-medium:1\",
-          \"updatedAt\": 1432829320611
+          \"updatedAt\": 1432829320.611
         }
       ],
       \"desiredCount\": 4,
@@ -1390,14 +1390,14 @@ describe_services_output_tests(_) ->
       },
       \"deployments\": [
         {
-          \"createdAt\": 1432829320611,
+          \"createdAt\": 1432829320.611,
           \"desiredCount\": 4,
           \"id\": \"ecs-svc/9223370604025455196\",
           \"pendingCount\": 0,
           \"runningCount\": 4,
           \"status\": \"PRIMARY\",
           \"taskDefinition\": \"arn:aws:ecs:us-west-2:012345678910:task-definition/hpcc-t2-medium:1\",
-          \"updatedAt\": 1432829320611
+          \"updatedAt\": 1432829320.611
         }
       ],
       \"desiredCount\": 4,
@@ -1423,14 +1423,14 @@ describe_services_output_tests(_) ->
                         },
                         deployments = [
                             #ecs_deployment{
-                                created_at = 1432829320611,
+                                created_at = 1432829320.611,
                                 desired_count = 4,
                                 id = <<"ecs-svc/9223370604025455196">>,
                                 pending_count = 0,
                                 running_count = 4,
                                 status = <<"PRIMARY">>,
                                 task_definition = <<"arn:aws:ecs:us-west-2:012345678910:task-definition/hpcc-t2-medium:1">>,
-                                updated_at = 1432829320611
+                                updated_at = 1432829320.611
                             }
                         ],
                         desired_count = 4,
@@ -3130,14 +3130,14 @@ update_service_input_tests(_) ->
     },
     \"deployments\": [
       {
-        \"createdAt\": 1430333711033,
+        \"createdAt\": 1430333711.033,
         \"desiredCount\": 3,
         \"id\": \"ecs-svc/9223370606521064774\",
         \"pendingCount\": 0,
         \"runningCount\": 0,
         \"status\": \"PRIMARY\",
         \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10\",
-        \"updatedAt\": 1430336267173
+        \"updatedAt\": 1430336267.173
       }
     ],
     \"desiredCount\": 3,
@@ -3167,14 +3167,14 @@ update_service_output_tests(_) ->
     },
     \"deployments\": [
       {
-        \"createdAt\": 1430333711033,
+        \"createdAt\": 1430333711.033,
         \"desiredCount\": 3,
         \"id\": \"ecs-svc/9223370606521064774\",
         \"pendingCount\": 0,
         \"runningCount\": 0,
         \"status\": \"PRIMARY\",
         \"taskDefinition\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10\",
-        \"updatedAt\": 1430336267173
+        \"updatedAt\": 1430336267.173
       }
     ],
     \"desiredCount\": 3,
@@ -3197,14 +3197,14 @@ update_service_output_tests(_) ->
                     },
                     deployments = [
                         #ecs_deployment{
-                            created_at = 1430333711033,
+                            created_at = 1430333711.033,
                             desired_count = 3,
                             id = <<"ecs-svc/9223370606521064774">>,
                             pending_count = 0,
                             running_count = 0,
                             status = <<"PRIMARY">>,
                             task_definition = <<"arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10">>,
-                            updated_at = 1430336267173
+                            updated_at = 1430336267.173
                         }
                     ],
                     desired_count = 3,

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -1319,7 +1319,7 @@ describe_container_instances_output_tests(_) ->
                 failures = []
             }}})
         ],
-    output_tests(?_f(erlcloud_ecs:describe_container_instances("f9cc75bb-0c94-46b9-bf6d-49d320bc1551", [{out, record}])), Tests).
+    output_tests(?_f(erlcloud_ecs:describe_container_instances(["f9cc75bb-0c94-46b9-bf6d-49d320bc1551"], [{out, record}])), Tests).
 
 %% DescribeServices test based on the API examples:
 %% http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeServices.html
@@ -3284,7 +3284,7 @@ input_tests(Response, Tests) ->
 %%%===================================================================
 
 %% returns the mock of the erlcloud_httpc function output tests expect to be called.
--spec output_expect(string()) -> fun().
+-spec output_expect(binary()) -> fun().
 output_expect(Response) ->
     fun(_Url, post, _Headers, _Body, _Timeout, _Config) ->
             {ok, {{200, "OK"}, [], Response}}

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -198,7 +198,7 @@ input_tests(Response, Tests) ->
 %%%===================================================================
 
 %% returns the mock of the erlcloud_httpc function output tests expect to be called.
--spec output_expect(string()) -> fun().
+-spec output_expect(string()) -> meck:ret_spec().
 output_expect(Response) ->
     meck:val({ok, {{200, "OK"}, [], list_to_binary(Response)}}).
 

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -207,7 +207,7 @@ output_expect_seq(Responses) ->
     meck:seq([{ok, {{200, "OK"}, [], list_to_binary(Response)}} || Response <- Responses]).
 
 %% output_test converts an output_test specifier into an eunit test generator
--type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string(), term()}}.
+-type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string() | [string()], term()}}.
 -spec output_test(fun(), output_test_spec(), fun()) -> tuple().
 output_test(Fun, {Line, {Description, Response, Result}}, OutputFun) ->
     {Description,
@@ -923,7 +923,7 @@ get_access_key_last_used_output_tests() ->
                         {access_key_last_used_service_name, "s3"}]
                  }})
             ],
-    output_tests(?_f(erlcloud_iam:get_access_key_last_used_output("KEYID")), Tests).
+    output_tests(?_f(erlcloud_iam:get_access_key_last_used("KEYID")), Tests).
 
 %% ListUsers test based on the API examples:
 %% http://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUsers.html

--- a/test/erlcloud_inspector_tests.erl
+++ b/test/erlcloud_inspector_tests.erl
@@ -499,7 +499,7 @@ update_assessment_tests(_) ->
 %%% Input test helpers
 %%%===================================================================
 
--type expected_body() :: string().
+-type expected_body() :: binary().
 
 sort_json([{_, _} | _] = Json) ->
     %% Value is an object
@@ -526,7 +526,7 @@ validate_body(Body, Expected) ->
 
 %% returns the mock of the erlcloud_httpc function input tests expect to be called.
 %% Validates the request body and responds with the provided response.
--spec input_expect(string(), expected_body()) -> fun().
+-spec input_expect(binary(), expected_body()) -> fun().
 input_expect(Response, Expected) ->
     fun(_Url, post, _Headers, Body, _Timeout, _Config) ->
             validate_body(Body, Expected),
@@ -536,7 +536,7 @@ input_expect(Response, Expected) ->
 
 %% input_test converts an input_test specifier into an eunit test generator
 -type input_test_spec() :: {pos_integer(), {fun(), expected_body()} | {string(), fun(), expected_body()}}.
--spec input_test(string(), input_test_spec()) -> tuple().
+-spec input_test(binary(), input_test_spec()) -> tuple().
 input_test(Response, {Line, {Description, Fun, Expected}})
   when is_list(Description) ->
     {Description,
@@ -549,7 +549,7 @@ input_test(Response, {Line, {Description, Fun, Expected}})
 
 
 %% input_tests converts a list of input_test specifiers into an eunit test generator
--spec input_tests(string(), [input_test_spec()]) -> [tuple()].
+-spec input_tests(binary(), [input_test_spec()]) -> [tuple()].
 input_tests(Response, Tests) ->
     [input_test(Response, Test) || Test <- Tests].
 
@@ -565,7 +565,7 @@ output_expect(Response) ->
     end.
 
 %% output_test converts an output_test specifier into an eunit test generator
--type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string(), term()}}.
+-type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), binary(), term()}}.
 -spec output_test(fun(), output_test_spec()) -> tuple().
 output_test(Fun, {Line, {Description, Response, Result}}) ->
     {Description,

--- a/test/erlcloud_kms_tests.erl
+++ b/test/erlcloud_kms_tests.erl
@@ -101,7 +101,7 @@ stop(_) ->
 %%% Input test helpers
 %%%===================================================================
 
--type expected_body() :: string().
+-type expected_body() :: binary().
 
 sort_json([{_, _} | _] = Json) ->
     %% Value is an object
@@ -128,7 +128,7 @@ validate_body(Body, Expected) ->
 
 %% returns the mock of the erlcloud_httpc function input tests expect to be called.
 %% Validates the request body and responds with the provided response.
--spec input_expect(string(), expected_body()) -> fun().
+-spec input_expect(binary(), expected_body()) -> fun().
 input_expect(Response, Expected) ->
     fun(_Url, post, _Headers, Body, _Timeout, _Config) ->
             validate_body(Body, Expected),
@@ -138,7 +138,7 @@ input_expect(Response, Expected) ->
 
 %% input_test converts an input_test specifier into an eunit test generator
 -type input_test_spec() :: {pos_integer(), {fun(), expected_body()} | {string(), fun(), expected_body()}}.
--spec input_test(string(), input_test_spec()) -> tuple().
+-spec input_test(binary(), input_test_spec()) -> tuple().
 input_test(Response, {Line, {Description, Fun, Expected}})
   when is_list(Description) ->
     {Description,
@@ -151,7 +151,7 @@ input_test(Response, {Line, {Description, Fun, Expected}})
 
 
 %% input_tests converts a list of input_test specifiers into an eunit test generator
--spec input_tests(string(), [input_test_spec()]) -> [tuple()].
+-spec input_tests(binary(), [input_test_spec()]) -> [tuple()].
 input_tests(Response, Tests) ->
     [input_test(Response, Test) || Test <- Tests].
 
@@ -167,7 +167,7 @@ output_expect(Response) ->
     end.
 
 %% output_test converts an output_test specifier into an eunit test generator
--type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string(), term()}}.
+-type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), binary(), term()}}.
 -spec output_test(fun(), output_test_spec()) -> tuple().
 output_test(Fun, {Line, {Description, Response, Result}}) ->
     {Description,

--- a/test/erlcloud_s3_tests.erl
+++ b/test/erlcloud_s3_tests.erl
@@ -73,8 +73,8 @@ httpc_expect(Method, Response) ->
               hackney ->
                 Method = Method2,
                 Insecure = false,
-                Proxy = "10.10.10.10",
-                Proxy_auth = {"AAAA", "BBBB"};
+                Proxy = <<"10.10.10.10">>,
+                Proxy_auth = {<<"AAAA">>, <<"BBBB">>};
 
               _else ->
                 Method = Method2,
@@ -815,8 +815,8 @@ delete_bucket_encryption_test(_) ->
 hackney_proxy_put_validation_test(_) ->
     Response = {ok, {{200, "OK"}, [{"x-amz-version-id", "version_id"}], <<>>}},
     Config2 = #aws_config{hackney_client_options = #hackney_client_options{insecure = false,
-			   proxy = "10.10.10.10",
-			   proxy_auth = {"AAAA", "BBBB"}},
+			   proxy = <<"10.10.10.10">>,
+			   proxy_auth = {<<"AAAA">>, <<"BBBB">>}},
 			  http_client = hackney},
     meck:expect(erlcloud_httpc, request, httpc_expect(put, Response)),
     Result = erlcloud_s3:put_object("BucketName", "Key", "Data", config(Config2)),

--- a/test/erlcloud_sdb_tests.erl
+++ b/test/erlcloud_sdb_tests.erl
@@ -1,9 +1,17 @@
 -module(erlcloud_sdb_tests).
 
--ifdef(TEST).
--compile(export_all).
-
 -include_lib("eunit/include/eunit.hrl").
+
+-export([setup/0]).
+-export([cleanup/1]).
+-export([select_single_response/0]).
+-export([select_next_token/0]).
+-export([select_all_single_response/0]).
+-export([select_all_failure/0]).
+-export([select_all_503/0]).
+-export([select_all_next_token/0]).
+-export([select_all_next_and_failure/0]).
+-export([select_all_two_results/0]).
 
 setup() ->
     erlcloud_sdb:configure("fake", "fake-secret"),
@@ -153,5 +161,3 @@ extract_token_test() ->
     ?assertEqual(next_token(), erlcloud_sdb:extract_token(parse_document(only_token_response_body()))),
     ?assertEqual(next_token(), erlcloud_sdb:extract_token(parse_document(single_result_and_token_response_body()))),
     ?assertEqual(done, erlcloud_sdb:extract_token(parse_document(single_result_response_body("item0")))).
-
--endif.

--- a/test/erlcloud_sns_tests.erl
+++ b/test/erlcloud_sns_tests.erl
@@ -285,7 +285,7 @@ set_topic_attributes_input_tests(_) ->
     Tests =
         [?_sns_test(
             {"Test sets topic's attribute.",
-             ?_f(erlcloud_sns:set_topic_attributes("DisplayName", "MyTopicName", "arn:aws:sns:us-west-2:123456789012:MyTopic")),
+             ?_f(erlcloud_sns:set_topic_attributes('DisplayName', "MyTopicName", "arn:aws:sns:us-west-2:123456789012:MyTopic")),
              [
               {"Action", "SetTopicAttributes"},
               {"AttributeName", "DisplayName"},
@@ -313,7 +313,7 @@ set_topic_attributes_output_tests(_) ->
                     </SetTopicAttributesResponse>",
                 ok})
             ],
-    output_tests(?_f(erlcloud_sns:set_topic_attributes("DisplayName", "MyTopicName", "arn:aws:sns:us-west-2:123456789012:MyTopic")), Tests).
+    output_tests(?_f(erlcloud_sns:set_topic_attributes('DisplayName', "MyTopicName", "arn:aws:sns:us-west-2:123456789012:MyTopic")), Tests).
 
 
 %% Set subscription attributes test based on the API examples:
@@ -322,7 +322,7 @@ set_subscription_attributes_input_tests(_) ->
     Tests =
     [?_sns_test(
         {"Test sets subscriptions's attribute.",
-         ?_f(erlcloud_sns:set_subscription_attributes("FilterPolicy", "{\"a\": [\"b\"]}", "arn:aws:sns:us-east-1:123456789012:My-Topic:80289ba6-0fd4-4079-afb4-ce8c8260f0ca")),
+         ?_f(erlcloud_sns:set_subscription_attributes('FilterPolicy', "{\"a\": [\"b\"]}", "arn:aws:sns:us-east-1:123456789012:My-Topic:80289ba6-0fd4-4079-afb4-ce8c8260f0ca")),
          [
              {"Action", "SetSubscriptionAttributes"},
              {"AttributeName", "FilterPolicy"},
@@ -350,7 +350,7 @@ set_subscription_attributes_output_tests(_) ->
         </SetSubscriptionAttributesResponse>",
          ok})
     ],
-    output_tests(?_f(erlcloud_sns:set_subscription_attributes("FilterPolicy", "{\"a\": [\"b\"]}", "arn:aws:sns:us-east-1:123456789012:My-Topic:80289ba6-0fd4-4079-afb4-ce8c8260f0ca")), Tests).
+    output_tests(?_f(erlcloud_sns:set_subscription_attributes('FilterPolicy', "{\"a\": [\"b\"]}", "arn:aws:sns:us-east-1:123456789012:My-Topic:80289ba6-0fd4-4079-afb4-ce8c8260f0ca")), Tests).
 
 
 %% List topics test based on the API example:
@@ -762,6 +762,7 @@ doesnt_support_gopher(_) ->
     ?_assertError({sns_error, {unsupported_scheme,"gopher://"}},
                   erlcloud_sns:publish_to_topic("topicarn", "message", "subject", Config)).
 
+-dialyzer({nowarn_function, doesnt_accept_non_strings/1}).
 doesnt_accept_non_strings(_) ->
     Config = (erlcloud_aws:default_config())#aws_config{sns_scheme=https},
     ?_assertError({sns_error, badarg},

--- a/test/erlcloud_waf_tests.erl
+++ b/test/erlcloud_waf_tests.erl
@@ -41,7 +41,7 @@
         byte_match_tuple = #waf_byte_match_tuple{
                                 field_to_match = #waf_field_to_match{type = query_string},
                                 positional_constraint = contains,
-                                target_string = "foobar",
+                                target_string = <<"foobar">>,
                                 text_transformation = none}}). 
 
 -define(UPDATE_IP_SET,
@@ -593,7 +593,7 @@ update_xss_match_set_tests(_) ->
 %%% Input test helpers
 %%%===================================================================
 
--type expected_body() :: string().
+-type expected_body() :: binary().
 
 sort_json([{_, _} | _] = Json) ->
     %% Value is an object
@@ -620,7 +620,7 @@ validate_body(Body, Expected) ->
 
 %% returns the mock of the erlcloud_httpc function input tests expect to be called.
 %% Validates the request body and responds with the provided response.
--spec input_expect(string(), expected_body()) -> fun().
+-spec input_expect(binary(), expected_body()) -> fun().
 input_expect(Response, Expected) ->
     fun(_Url, post, _Headers, Body, _Timeout, _Config) ->
             validate_body(Body, Expected),
@@ -630,7 +630,7 @@ input_expect(Response, Expected) ->
 
 %% input_test converts an input_test specifier into an eunit test generator
 -type input_test_spec() :: {pos_integer(), {fun(), expected_body()} | {string(), fun(), expected_body()}}.
--spec input_test(string(), input_test_spec()) -> tuple().
+-spec input_test(binary(), input_test_spec()) -> tuple().
 input_test(Response, {Line, {Description, Fun, Expected}})
   when is_list(Description) ->
     {Description,
@@ -643,7 +643,7 @@ input_test(Response, {Line, {Description, Fun, Expected}})
 
 
 %% input_tests converts a list of input_test specifiers into an eunit test generator
--spec input_tests(string(), [input_test_spec()]) -> [tuple()].
+-spec input_tests(binary(), [input_test_spec()]) -> [tuple()].
 input_tests(Response, Tests) ->
     [input_test(Response, Test) || Test <- Tests].
 
@@ -659,7 +659,7 @@ output_expect(Response) ->
     end.
 
 %% output_test converts an output_test specifier into an eunit test generator
--type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), string(), term()}}.
+-type output_test_spec() :: {pos_integer(), {string(), term()} | {string(), binary(), term()}}.
 -spec output_test(fun(), output_test_spec()) -> tuple().
 output_test(Fun, {Line, {Description, Response, Result}}) ->
     {Description,


### PR DESCRIPTION
We stop compilation with error the same we would for normal code (`warnings_as_errors`).

We apply this to the Travis checks.

We fix the issues surfaced by this increased strictness.