### PR TITLE
erlcloud_application_autoscaler: return error tuple when '#aws_request.response_type' is not 'ok'

### DIFF
--- a/src/erlcloud_application_autoscaler.erl
+++ b/src/erlcloud_application_autoscaler.erl
@@ -702,7 +702,12 @@ request_with_action(Configuration, BodyConfiguration, Action) ->
             Headers = [{"content-type", "application/x-amz-json-1.1"} | HeadersPrev],
             Request = prepare_record(Config, post, Headers, Body),
             Response = erlcloud_retry:request(Config, Request, fun aas_result_fun/1),
-            {ok, jsx:decode(Response#aws_request.response_body, [{return_maps, false}])};
+            case Response#aws_request.response_type of
+                ok ->
+                    {ok, jsx:decode(Response#aws_request.response_body, [{return_maps, false}])};
+                _ ->
+                    {error, jsx:decode(Response#aws_request.response_body, [{return_maps, false}])}
+            end;
         {error, Reason} ->
             {error, Reason}
     end.

--- a/src/erlcloud_application_autoscaler.erl
+++ b/src/erlcloud_application_autoscaler.erl
@@ -706,7 +706,7 @@ request_with_action(Configuration, BodyConfiguration, Action) ->
                 ok ->
                     {ok, jsx:decode(Response#aws_request.response_body, [{return_maps, false}])};
                 _ ->
-                    {error, jsx:decode(Response#aws_request.response_body, [{return_maps, false}])}
+                    {error, decode_error(Response)}
             end;
         {error, Reason} ->
             {error, Reason}
@@ -723,18 +723,26 @@ prepare_record(Config, Method, Headers, Body) ->
     ]),
 
     #aws_request{service = application_autoscaling,
-                           method = Method,
-                           request_headers = Headers,
-                           request_body = Body,
-                           uri = RequestURI}.
+                 method = Method,
+                 request_headers = Headers,
+                 request_body = Body,
+                 uri = RequestURI}.
 
 port_spec(#aws_config{application_autoscaling_port=80}) ->
     "";
 port_spec(#aws_config{application_autoscaling_port=Port}) ->
     [":", erlang:integer_to_list(Port)].
 
-
 headers(Config, Operation, Body) ->
     Headers = [{"host", Config#aws_config.application_autoscaling_host},
                {"x-amz-target", Operation}],
     erlcloud_aws:sign_v4_headers(Config, Headers, Body, erlcloud_aws:aws_region_from_host(Config#aws_config.application_autoscaling_host), "application-autoscaling").
+
+%% Extracts and decodes the error from the response returning
+%% in the format of `{error, {ErrorType, Message}}' (matching to how errors are returned in `ercloud_ddb2' module)
+%% Example: {error, {<<"ConcurrentUpdateException">>, <<"You already have a pending update to an Auto Scaling resource.">>}}
+decode_error(Response) ->
+    DecodedError = jsx:decode(Response#aws_request.response_body, [{return_maps, false}]),
+    ErrorType = proplists:get_value(<<"__type">>, DecodedError, <<>>),
+    ErrorMessage = proplists:get_value(<<"Message">>, DecodedError, <<>>),
+    {error, {ErrorType, ErrorMessage}}.


### PR DESCRIPTION
Internal function `erlcloud_application_autoscaler:request_with_action/3` currently ignores any error response from AWS other than config update failures. It currently returns `{ok, {error, _}}` and throws function clause error in some actions like [here](https://github.com/erlcloud/erlcloud/blob/master/src/erlcloud_application_autoscaler.erl#L531-L533). This change updates the code to check `#aws_request.response_type` and return `{ok, _}`/`{error, _}` appropriately.

Update (10-08-2020):
Updated the branch to decode auto scaling application errors and return them in the format of `{error, {Type, Message}}`

**Note**: `erlcloud_application_autoscaler` module does not have any test coverage hence why I did not update the tests for this change.