### PR TITLE
erlcloud_sm: fix use of jsx

### DIFF
--- a/src/erlcloud_sm.erl
+++ b/src/erlcloud_sm.erl
@@ -100,7 +100,7 @@ sm_request_no_update(Config, Operation, Body) ->
         request_body = Payload},
     case erlcloud_aws:request_to_return(erlcloud_retry:request(Config, Request, fun sm_result_fun/1)) of
         {ok, {_RespHeaders, <<>>}} -> {ok, []};
-        {ok, {_RespHeaders, RespBody}} -> {ok, jsx:decode(RespBody)};
+        {ok, {_RespHeaders, RespBody}} -> {ok, jsx:decode(RespBody, [{return_maps, false}])};
         {error, _} = Error -> Error
     end.
 


### PR DESCRIPTION
Follow up to https://github.com/erlcloud/erlcloud/pull/645. I missed that I didn't catch this regression when `erlcloud_sm` was introduced in https://github.com/erlcloud/erlcloud/pull/654.

This change just adds the eplicit `[{return_maps, false}]` option to the `jsx:decode(...)` call to ensure that it comes back in the expected format, regardless of which jsx version the client uses.

cc @paulo-ferraz-oliveira.