### PR TITLE
Update how VPC endpoints are calculated

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -824,11 +824,14 @@ get_host_vpc_endpoint(Service, Default) when is_binary(Service) ->
         {env, EnvVarName} when is_list(EnvVarName) ->
             % ignore "" env var or ",," cases
             % also handle "zoneID:zoneName" form when it comes from CFN
-            Es = string_split(string_split(os:getenv(EnvVarName, ""), ","), ":"),
+            Es = string_split(os:getenv(EnvVarName, ""), ","),
             lists:filtermap(
-                fun ([""]) -> false;
-                    ([Name]) -> {true, list_to_binary(Name)};
-                    ([_Id, Name]) -> {true, list_to_binary(Name)}
+                fun ("") -> false;
+                    (Value) ->
+                        case string_split(Value, ":") of
+                            [_Id, Name] -> {true, list_to_binary(Name)};
+                            [Name] ->{true, list_to_binary(Name)}
+                        end
                 end,
                 Es
             );

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -830,7 +830,7 @@ get_host_vpc_endpoint(Service, Default) when is_binary(Service) ->
                     (Value) ->
                         case string_split(Value, ":") of
                             [_Id, Name] -> {true, list_to_binary(Name)};
-                            [Name] ->{true, list_to_binary(Name)}
+                            [Name] -> {true, list_to_binary(Name)}
                         end
                 end,
                 Es


### PR DESCRIPTION
current approach was based of manual setting of env var. 
while working on CFN via `{"Fn::GetAtt": ["CWLogsEndpoint", "DnsEntries"]` gets both "ID:Name"

support that ^.

example CFN:
`Z1xxx:vpce-xxxx-427maydd.logs.us-west-2.vpce.amazonaws.com,Z1xxx:vpce-xxxxx-427maydd-us-west-2b.logs.us-west-2.vpce.amazonaws.com,Z1xxx:vpce-xxxx-427maydd-us-west-2a.logs.us-west-2.vpce.amazonaws.com,Z1xxxx:vpce-xxxx-427maydd-us-west-2c.logs.us-west-2.vpce.amazonaws.com,Z0xxxx:logs.us-west-2.amazonaws.com`