### PR TITLE
Add RoleLastUsed field to erlcloud_iam:get_role response

### DIFF
--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -989,9 +989,6 @@ data_type("Role") ->
      {"RoleName", role_name, "String"},
      {"Path", path, "String"},
      {"RoleLastUsed", role_last_used, data_type("RoleLastUsed")}];
-data_type("RoleLastUsed") ->
-    [{"LastUsedDate", last_used_date, "DateTime"},
-     {"Region", region, "String"}];
 data_type("RoleDetail") ->
     [{"RolePolicyList/member", role_policy_list, data_type("PolicyDetail")},
      {"RoleName", role_name, "String"},
@@ -1001,6 +998,9 @@ data_type("RoleDetail") ->
      {"CreateDate", create_date, "DateTime"},
      {"AssumeRolePolicyDocument", assume_role_policy_document, "Uri"},
      {"Arn", arn, "String"}];
+data_type("RoleLastUsed") ->
+    [{"LastUsedDate", last_used_date, "DateTime"},
+     {"Region", region, "String"}];
 data_type("RolePolicyList") ->
     [{"PolicyDocument", policy_document, "Uri"},
      {"RoleName", role_name, "String"},

--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -436,7 +436,7 @@ list_roles(PathPrefix) ->
 list_roles(PathPrefix, #aws_config{} = Config)
   when is_list(PathPrefix) ->
     ItemPath = "/ListRolesResponse/ListRolesResult/Roles/member",
-    iam_query(Config, "ListRoles", [{"PathPrefix", PathPrefix}], ItemPath, data_type("Role")).
+    iam_query(Config, "ListRoles", [{"PathPrefix", PathPrefix}], ItemPath, data_type("RoleList")).
 
 -spec list_roles_all() -> {ok, proplist()} |  {error, any()}.
 list_roles_all() -> list_roles([]).
@@ -450,7 +450,7 @@ list_roles_all(PathPrefix) ->
 list_roles_all(PathPrefix, #aws_config{} = Config)
   when is_list(PathPrefix) ->
     ItemPath = "/ListRolesResponse/ListRolesResult/Roles/member",
-    iam_query_all(Config, "ListRoles", [{"PathPrefix", PathPrefix}], ItemPath, data_type("Role")).
+    iam_query_all(Config, "ListRoles", [{"PathPrefix", PathPrefix}], ItemPath, data_type("RoleList")).
 
 -spec list_role_policies(string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}.
 list_role_policies(RoleName) ->
@@ -938,7 +938,7 @@ data_type("InstanceProfile") ->
      {"Arn", arn, "String"},
      {"Path", path, "String"},
      {"InstanceProfileName", instance_profile_name, "String"},
-     {"Roles/member", roles, data_type("Role")},
+     {"Roles/member", roles, data_type("RoleList")},
      {"InstanceProfileId", instance_profile_id, "String"}];
 data_type("Group") ->
     [{"Path", path, "String"},
@@ -974,7 +974,7 @@ data_type("PasswordPolicy") ->
 data_type("PolicyDetail") ->
     [{"PolicyName", policy_name, "String"},
      {"PolicyDocument", policy_document, "Uri"}];
-data_type("Role") ->
+data_type("RoleList") ->
     [{"Arn", arn, "String"},
      {"CreateDate", create_date, "DateTime"},
      {"AssumeRolePolicyDocument", assume_role_policy_doc, "Uri"},

--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -419,7 +419,7 @@ get_role(RoleName, Config) ->
 
 get_role_impl(RoleNameParam, #aws_config{} = Config) ->
     ItemPath = "/GetRoleResponse/GetRoleResult/Role",
-    case iam_query(Config, "GetRole", RoleNameParam, ItemPath, data_type("RoleGetDetail")) of
+    case iam_query(Config, "GetRole", RoleNameParam, ItemPath, data_type("Role")) of
         {ok, [Role]} -> {ok, Role};
         {error, _} = Error -> Error
     end.
@@ -981,7 +981,7 @@ data_type("RoleList") ->
      {"RoleId", role_id, "String"},
      {"RoleName", role_name, "String"},
      {"Path", path, "String"}];
-data_type("RoleGetDetail") ->
+data_type("Role") ->
     [{"Arn", arn, "String"},
      {"CreateDate", create_date, "DateTime"},
      {"AssumeRolePolicyDocument", assume_role_policy_doc, "Uri"},

--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -416,10 +416,10 @@ get_role(RoleName) when is_list(RoleName) ->
 -spec get_role(string(), aws_config()) -> {ok, proplist()} |  {error, any()}.
 get_role(RoleName, Config) ->
     get_role_impl([{"RoleName", RoleName}], Config).
-    
+
 get_role_impl(RoleNameParam, #aws_config{} = Config) ->
     ItemPath = "/GetRoleResponse/GetRoleResult/Role",
-    case iam_query(Config, "GetRole", RoleNameParam, ItemPath, data_type("Role")) of
+    case iam_query(Config, "GetRole", RoleNameParam, ItemPath, data_type("RoleGetDetail")) of
         {ok, [Role]} -> {ok, Role};
         {error, _} = Error -> Error
     end.
@@ -981,6 +981,17 @@ data_type("Role") ->
      {"RoleId", role_id, "String"},
      {"RoleName", role_name, "String"},
      {"Path", path, "String"}];
+data_type("RoleGetDetail") ->
+    [{"Arn", arn, "String"},
+     {"CreateDate", create_date, "DateTime"},
+     {"AssumeRolePolicyDocument", assume_role_policy_doc, "Uri"},
+     {"RoleId", role_id, "String"},
+     {"RoleName", role_name, "String"},
+     {"Path", path, "String"},
+     {"RoleLastUsed", role_last_used, data_type("RoleLastUsed")}];
+data_type("RoleLastUsed") ->
+    [{"LastUsedDate", last_used_date, "DateTime"},
+     {"Region", region, "String"}];
 data_type("RoleDetail") ->
     [{"RolePolicyList/member", role_policy_list, data_type("PolicyDetail")},
      {"RoleName", role_name, "String"},

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -38,6 +38,8 @@ iam_api_test_() ->
       fun get_group_policy_output_tests/1,
       fun get_login_profile_input_tests/1,
       fun get_login_profile_output_tests/1,
+      fun get_role_input_tests/1,
+      fun get_role_output_tests/1,
       fun get_role_policy_input_tests/1,
       fun get_role_policy_output_tests/1,
       fun get_user_policy_input_tests/1,
@@ -681,6 +683,55 @@ get_login_profile_output_tests(_) ->
              })
             ],
     output_tests(?_f(erlcloud_iam:get_login_profile("Bob")), Tests).
+
+-define(GET_ROLE_RESP,
+        "<GetRoleResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+        <GetRoleResult>
+          <Role>
+            <Path>/application_abc/component_xyz/</Path>
+            <Arn>arn:aws:iam::123456789012:role/application_abc/component_xyz/S3Access</Arn>
+            <RoleName>S3Access</RoleName>
+            <AssumeRolePolicyDocument>{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}</AssumeRolePolicyDocument>
+            <CreateDate>2012-05-08T23:34:01Z</CreateDate>
+            <RoleId>AROADBQP57FF2AEXAMPLE</RoleId>
+            <RoleLastUsed>
+              <LastUsedDate>2013-05-08T23:34:01Z</LastUsedDate>
+              <Region>us-east-1</Region>
+            </RoleLastUsed>
+          </Role>
+        </GetRoleResult>
+        </GetRoleResponse>").
+
+get_role_input_tests(_) ->
+    Tests =
+        [?_iam_test(
+            {"Test returning role.",
+                ?_f(erlcloud_iam:get_role("test")),
+                [
+                    {"Action", "GetRole"},
+                    {"RoleName", "test"}
+                ]})
+        ],
+
+    input_tests(?GET_ROLE_RESP, Tests).
+
+get_role_output_tests(_) ->
+    Tests = [?_iam_test(
+        {"This returns the role",
+            ?GET_ROLE_RESP,
+            {ok, [{role_last_used,
+                [[{region,"us-east-1"},
+                    {last_used_date,{{2013,5,8},{23,34,1}}}]]},
+                {path,"/application_abc/component_xyz/"},
+                {role_name,"S3Access"},
+                {role_id,"AROADBQP57FF2AEXAMPLE"},
+                {assume_role_policy_doc,
+                    "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"},
+                {create_date,{{2012,5,8},{23,34,1}}},
+                {arn, "arn:aws:iam::123456789012:role/application_abc/component_xyz/S3Access"}]}
+        })
+    ],
+    output_tests(?_f(erlcloud_iam:get_role("test")), Tests).
 
 -define(GET_ROLE_POLICY_RESP,
         "<GetRolePolicyResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -708,28 +708,28 @@ get_role_input_tests(_) ->
             {"Test returning role.",
                 ?_f(erlcloud_iam:get_role("test")),
                 [
-                    {"Action", "GetRole"},
-                    {"RoleName", "test"}
-                ]})
+                 {"Action", "GetRole"},
+                 {"RoleName", "test"}
+                 ]})
         ],
 
     input_tests(?GET_ROLE_RESP, Tests).
 
 get_role_output_tests(_) ->
     Tests = [?_iam_test(
-        {"This returns the role",
-            ?GET_ROLE_RESP,
-            {ok, [{role_last_used,
-                [[{region,"us-east-1"},
-                    {last_used_date,{{2013,5,8},{23,34,1}}}]]},
-                {path,"/application_abc/component_xyz/"},
-                {role_name,"S3Access"},
-                {role_id,"AROADBQP57FF2AEXAMPLE"},
-                {assume_role_policy_doc,
-                    "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"},
-                {create_date,{{2012,5,8},{23,34,1}}},
-                {arn, "arn:aws:iam::123456789012:role/application_abc/component_xyz/S3Access"}]}
-        })
+             {"This returns the role",
+              ?GET_ROLE_RESP,
+              {ok, [{role_last_used,
+                    [[{region,"us-east-1"},
+                      {last_used_date,{{2013,5,8},{23,34,1}}}]]},
+                    {path,"/application_abc/component_xyz/"},
+                    {role_name,"S3Access"},
+                    {role_id,"AROADBQP57FF2AEXAMPLE"},
+                    {assume_role_policy_doc,
+                     "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"},
+                    {create_date,{{2012,5,8},{23,34,1}}},
+                    {arn, "arn:aws:iam::123456789012:role/application_abc/component_xyz/S3Access"}]}
+             })
     ],
     output_tests(?_f(erlcloud_iam:get_role("test")), Tests).
 


### PR DESCRIPTION
**Summary**
This PR adds the RoleLastUsed field from the GetRole AWS API endpoint to the erlcloud_iam:get_role response

**Issue**
fixes #670

**References**
AWS API docs reference for GetRole Endpoint:

https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRole.html#API_GetRole_Examples