### PR TITLE
Fix ECS to_binary conversion

### DIFF
--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -2591,6 +2591,7 @@ to_binary(undefined) -> undefined;
 to_binary(true) -> true;
 to_binary(false) -> false;
 to_binary(L) when is_list(L), is_list(hd(L)) -> [to_binary(V) || V <- L];
+to_binary(L) when is_list(L), is_binary(hd(L)) -> [to_binary(V) || V <- L];
 to_binary(L) when is_list(L) -> list_to_binary(L);
 to_binary(B) when is_binary(B) -> B;
 to_binary(A) when is_atom(A) -> atom_to_binary(A, latin1).

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -1620,6 +1620,16 @@ describe_tasks_input_tests(_) ->
   ]
 }
 "
+            }),
+         ?_ecs_test(
+            {"DescribeTasks binary input example request",
+             ?_f(erlcloud_ecs:describe_tasks([<<"c09f0188-7f87-4b0f-bfc3-16296622b6fe">>])), "
+{
+  \"tasks\": [
+    \"c09f0188-7f87-4b0f-bfc3-16296622b6fe\"
+  ]
+}
+"
             })
         ],
     Response = "


### PR DESCRIPTION
If I pass a list of binary task IDs into `erlcloud_ecs:describe_tasks()` I get the following error due to improper binary conversion:
```
rp(erlcloud_ecs:describe_tasks([<<"test-task-id">>], [{cluster, <<"test-cluster-arn">>}])).
{error,{http_error,400,[],
                   <<"{\"__type\":\"SerializationException\",\"Message\":\"Expected list or null\"}">>,
                   [{"connection","close"},
                    {"date","Mon, 07 Dec 2020 15:50:36 GMT"},
                    {"content-length","69"},
                    {"content-type","application/x-amz-json-1.1"},
                    {"x-amzn-requestid",
                     "b23958b9-6fd8-415d-9492-f50f4daa1a8e"}]}}

```