### PR TITLE
Implement GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+---
+name: build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  ci:
+    name: Run checks and tests over ${{matrix.otp_vsn}} and ${{matrix.os}} (rebar2? ${{matrix.force_rebar2}})
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        otp_vsn: [19.3, 20.3, 21.3, 22.3, 23.0]
+        os: [ubuntu-latest]
+        force_rebar2: [true, false]
+    steps:
+      - uses: actions/checkout@v2
+      - run: export FORCE_REBAR2=${{matrix.force_rebar2}}
+      - run: make travis-install
+      - run: make warnings
+      - run: make check
+      - run: make eunit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+---
+name: publish
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  pub:
+    name: Publish to Hex.pm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make travis-publish

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # erlcloud: AWS APIs library for Erlang #
 
-[![Build Status](https://secure.travis-ci.org/erlcloud/erlcloud.png?branch=master)](http://travis-ci.org/erlcloud/erlcloud)
+[![Build Status](https://github.com/erlcloud/erlcloud/workflows/build/badge.svg)](https://github.com/erlcloud/erlcloud)
 
 This library is not developed or maintained by AWS thus lots of functionality is still missing comparing to [aws-cli](https://aws.amazon.com/cli/) or [boto](https://github.com/boto/boto).
 Required functionality is being added upon request.


### PR DESCRIPTION
This is currently a _best-effort_ implementation. Since there's no GitHub Action in place yet, it won't run until merged to `master` (unless you want to initialize GitHub Actions for this repo, in `master`, after which I can rebase this).

I'm **mostly** sure that `ci.yml` will work as-is.

`publish.yml`... I'm not so sure of, but it's not fancy code, so I'm _confident_ 😄.

Closes #675.