### PR TITLE
Add Ecs:ListTagsForResources support

### DIFF
--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -1992,6 +1992,20 @@ list_services(Opts, Config) ->
         EcsOpts).
 
 %%%------------------------------------------------------------------------------
+%% ListTagsForResource
+%%%------------------------------------------------------------------------------
+-spec list_tags_for_resource(
+        Arn :: string_param()) -> ecs_return([#ecs_tag{}]).
+list_tags_for_resource(Arn) ->
+    list_tags_for_resource(Arn, [], default_config()).
+
+-spec list_tags_for_resource(
+        Arn :: string_param(),
+        Config :: aws_config()) -> ecs_return([#ecs_tag{}]).
+list_tags_for_resource(Arn, Config) when is_record(Config, aws_config) ->
+    list_tags_for_resource(Arn, [], default_config()).
+
+%%%------------------------------------------------------------------------------
 %% @doc 
 %% ECS API
 %% [https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListTagsForResource.html]
@@ -2005,17 +2019,6 @@ list_services(Opts, Config) ->
 %% '
 %% @end
 %%%------------------------------------------------------------------------------
--spec list_tags_for_resource(
-        Arn :: string_param()) -> ecs_return([#ecs_tag{}]).
-list_tags_for_resource(Arn) ->
-    list_tags_for_resource(Arn, [], default_config()).
-
--spec list_tags_for_resource(
-        Arn :: string_param(),
-        Config :: aws_config()) -> ecs_return([#ecs_tag{}]).
-list_tags_for_resource(Arn, Config) when is_record(Config, aws_config) ->
-    list_tags_for_resource(Arn, [], default_config()).
-
 -spec list_tags_for_resource(
         Arn :: string_param(),
         Opts :: proplist(),

--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -1992,6 +1992,48 @@ list_services(Opts, Config) ->
         EcsOpts).
 
 %%%------------------------------------------------------------------------------
+%% @doc 
+%% ECS API
+%% [https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListTagsForResource.html]
+%%
+%% ===Example===
+%%
+%% List tags for a given resource
+%%
+%% `
+%% {ok, Result} = erlcloud_ecs:list_tags_for_resource("resource-arn"),
+%% '
+%% @end
+%%%------------------------------------------------------------------------------
+-spec list_tags_for_resource(
+        Arn :: string_param()) -> ecs_return([#ecs_tag{}]).
+list_tags_for_resource(Arn) ->
+    list_tags_for_resource(Arn, [], default_config()).
+
+-spec list_tags_for_resource(
+        Arn :: string_param(),
+        Config :: aws_config()) -> ecs_return([#ecs_tag{}]).
+list_tags_for_resource(Arn, Config) when is_record(Config, aws_config) ->
+    list_tags_for_resource(Arn, [], default_config()).
+
+-spec list_tags_for_resource(
+        Arn :: string_param(),
+        Opts :: proplist(),
+        Config :: aws_config()) -> ecs_return([#ecs_tag{}]).
+list_tags_for_resource(Arn, Opts, #aws_config{} = Config) ->
+    {AwsOpts, EcsOpts} = opts([], Opts),
+    Return = ecs_request(
+                Config,
+                "ListTagsForResource",
+                [{<<"resourceArn">>, to_binary(Arn)}] ++ AwsOpts),
+    out(Return, fun(Json, UOpts) -> 
+                        TagsList = proplists:get_value(<<"tags">>, Json),
+                        decode_tags_list(TagsList, UOpts)
+                end,
+        EcsOpts).
+
+
+%%%------------------------------------------------------------------------------
 %% ListTaskDefinitionFamilies
 %%%------------------------------------------------------------------------------
 -type list_task_definition_families_opt() :: {family_prefix, string_param()} |
@@ -2532,47 +2574,6 @@ update_service(Service, Opts, #aws_config{} = Config) ->
                 "UpdateService",
                 [{<<"service">>, to_binary(Service)}] ++ AwsOpts),
     out(Return, fun(Json, UOpts) -> decode_single_record(service_record(), <<"service">>, Json, UOpts) end,
-        EcsOpts).
-
-%%%------------------------------------------------------------------------------
-%% @doc 
-%% ECS API
-%% [https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListTagsForResource.html]
-%%
-%% ===Example===
-%%
-%% List tags for a given resource
-%%
-%% `
-%% {ok, Result} = erlcloud_ecs:list_tags_for_resource("resource-arn"),
-%% '
-%% @end
-%%%------------------------------------------------------------------------------
--spec list_tags_for_resource(
-        Arn :: string_param()) -> ecs_return([#ecs_tag{}]).
-list_tags_for_resource(Arn) ->
-    list_tags_for_resource(Arn, [], default_config()).
-
--spec list_tags_for_resource(
-        Arn :: string_param(),
-        Config :: aws_config()) -> ecs_return([#ecs_tag{}]).
-list_tags_for_resource(Arn, Config) when is_record(Config, aws_config) ->
-    list_tags_for_resource(Arn, [], default_config()).
-
--spec list_tags_for_resource(
-        Arn :: string_param(),
-        Opts :: proplist(),
-        Config :: aws_config()) -> ecs_return([#ecs_tag{}]).
-list_tags_for_resource(Arn, Opts, #aws_config{} = Config) ->
-    {AwsOpts, EcsOpts} = opts([], Opts),
-    Return = ecs_request(
-                Config,
-                "ListTagsForResource",
-                [{<<"resourceArn">>, to_binary(Arn)}] ++ AwsOpts),
-    out(Return, fun(Json, UOpts) -> 
-                        TagsList = proplists:get_value(<<"tags">>, Json),
-                        decode_tags_list(TagsList, UOpts)
-                end,
         EcsOpts).
 
 %%%------------------------------------------------------------------------------

--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -2549,20 +2549,20 @@ update_service(Service, Opts, #aws_config{} = Config) ->
 %% @end
 %%%------------------------------------------------------------------------------
 -spec list_tags_for_resource(
-        Arn :: string_param()) -> ecs_return(#ecs_service{}).
+        Arn :: string_param()) -> ecs_return([#ecs_tag{}]).
 list_tags_for_resource(Arn) ->
     list_tags_for_resource(Arn, [], default_config()).
 
 -spec list_tags_for_resource(
         Arn :: string_param(),
-        Config :: aws_config()) -> ecs_return(#ecs_service{}).
+        Config :: aws_config()) -> ecs_return([#ecs_tag{}]).
 list_tags_for_resource(Arn, Config) when is_record(Config, aws_config) ->
     list_tags_for_resource(Arn, [], default_config()).
 
 -spec list_tags_for_resource(
         Arn :: string_param(),
         Opts :: proplist(),
-        Config :: aws_config()) -> ecs_return(#ecs_service{}).
+        Config :: aws_config()) -> ecs_return([#ecs_tag{}]).
 list_tags_for_resource(Arn, Opts, #aws_config{} = Config) ->
     {AwsOpts, EcsOpts} = opts([], Opts),
     Return = ecs_request(

--- a/src/erlcloud_ecs.erl
+++ b/src/erlcloud_ecs.erl
@@ -62,6 +62,7 @@
          list_clusters/0, list_clusters/1, list_clusters/2,
          list_container_instances/0, list_container_instances/1, list_container_instances/2,
          list_services/0, list_services/1, list_services/2,
+         list_tags_for_resource/1, list_tags_for_resource/2, list_tags_for_resource/3,
          list_task_definition_families/0, list_task_definition_families/1, list_task_definition_families/2,
          list_task_definitions/0, list_task_definitions/1, list_task_definitions/2,
          list_tasks/0, list_tasks/1, list_tasks/2,
@@ -2531,6 +2532,47 @@ update_service(Service, Opts, #aws_config{} = Config) ->
                 "UpdateService",
                 [{<<"service">>, to_binary(Service)}] ++ AwsOpts),
     out(Return, fun(Json, UOpts) -> decode_single_record(service_record(), <<"service">>, Json, UOpts) end,
+        EcsOpts).
+
+%%%------------------------------------------------------------------------------
+%% @doc 
+%% ECS API
+%% [https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListTagsForResource.html]
+%%
+%% ===Example===
+%%
+%% List tags for a given resource
+%%
+%% `
+%% {ok, Result} = erlcloud_ecs:list_tags_for_resource("resource-arn"),
+%% '
+%% @end
+%%%------------------------------------------------------------------------------
+-spec list_tags_for_resource(
+        Arn :: string_param()) -> ecs_return(#ecs_service{}).
+list_tags_for_resource(Arn) ->
+    list_tags_for_resource(Arn, [], default_config()).
+
+-spec list_tags_for_resource(
+        Arn :: string_param(),
+        Config :: aws_config()) -> ecs_return(#ecs_service{}).
+list_tags_for_resource(Arn, Config) when is_record(Config, aws_config) ->
+    list_tags_for_resource(Arn, [], default_config()).
+
+-spec list_tags_for_resource(
+        Arn :: string_param(),
+        Opts :: proplist(),
+        Config :: aws_config()) -> ecs_return(#ecs_service{}).
+list_tags_for_resource(Arn, Opts, #aws_config{} = Config) ->
+    {AwsOpts, EcsOpts} = opts([], Opts),
+    Return = ecs_request(
+                Config,
+                "ListTagsForResource",
+                [{<<"resourceArn">>, to_binary(Arn)}] ++ AwsOpts),
+    out(Return, fun(Json, UOpts) -> 
+                        TagsList = proplists:get_value(<<"tags">>, Json),
+                        decode_tags_list(TagsList, UOpts)
+                end,
         EcsOpts).
 
 %%%------------------------------------------------------------------------------

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -65,7 +65,7 @@ operation_test_() ->
       fun list_services_input_tests/1,
       fun list_services_output_tests/1,
       fun list_tags_for_resource_input_tests/1,
-      fun list_tags_for_resource_output_tests/1
+      fun list_tags_for_resource_output_tests/1,
       fun list_task_definition_families_input_tests/1,
       fun list_task_definition_families_output_tests/1,
       fun list_task_definitions_input_tests/1,

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -64,6 +64,8 @@ operation_test_() ->
       fun list_container_instances_output_tests/1,
       fun list_services_input_tests/1,
       fun list_services_output_tests/1,
+      fun list_tags_for_resource_input_tests/1,
+      fun list_tags_for_resource_output_tests/1
       fun list_task_definition_families_input_tests/1,
       fun list_task_definition_families_output_tests/1,
       fun list_task_definitions_input_tests/1,
@@ -81,9 +83,7 @@ operation_test_() ->
       fun update_container_agent_input_tests/1,
       fun update_container_agent_output_tests/1,
       fun update_service_input_tests/1,
-      fun update_service_output_tests/1,
-      fun list_tags_for_resource_input_tests/1,
-      fun list_tags_for_resource_output_tests/1
+      fun update_service_output_tests/1
      ]
     }.
 

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -2007,6 +2007,64 @@ list_services_output_tests(_) ->
         ],
     output_tests(?_f(erlcloud_ecs:list_services([{out, record}])), Tests).
 
+%% ListTagsForResource test based on the API examples:
+%% https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ListTagsForResource.html
+list_tags_for_resource_input_tests(_) ->
+    Tests = 
+        [?_ecs_test(
+            {"ListTagsForResource example request",
+             ?_f(erlcloud_ecs:list_tags_for_resource("testArn")), "
+{
+    \"resourceArn\": \"testArn\"
+}
+"
+            })
+        ],
+    Response = "
+{
+    \"tags\": [
+      {
+        \"key\": \"test-key1\",
+        \"value\": \"test-value1\"
+      },
+      {
+        \"key\": \"test-key2\",
+        \"value\": \"test-value2\"
+      }
+    ]
+}
+",
+    input_tests(Response, Tests).
+
+list_tags_for_resource_output_tests(_) ->
+    Tests =
+        [?_ecs_test(
+            {"ListTagsForResources example response", "
+{
+    \"tags\": [
+      {
+        \"key\": \"test-key1\",
+        \"value\": \"test-value1\"
+      },
+      {
+        \"key\": \"test-key2\",
+        \"value\": \"test-value2\"
+      }
+    ]
+}
+",
+            {ok, [#ecs_tag{
+                    key = <<"test-key1">>,
+                    value = <<"test-value1">>
+                  },
+                  #ecs_tag{
+                    key = <<"test-key2">>,
+                    value = <<"test-value2">>
+                  }
+             ]}})
+        ],
+    output_tests(?_f(erlcloud_ecs:list_tags_for_resource("testArn")), Tests).
+
 %% ListTaskDefinitionFamilies test based on the API examples:
 %% http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListTaskDefinitionFamilies.html
 list_task_definition_families_input_tests(_) ->
@@ -3336,64 +3394,6 @@ update_service_output_tests(_) ->
             }})
         ],
     output_tests(?_f(erlcloud_ecs:update_service("hello_world", [{desired_count, 3}, {out, record}])), Tests).
-
-%% ListTagsForResource test based on the API examples:
-%% https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ListTagsForResource.html
-list_tags_for_resource_input_tests(_) ->
-    Tests = 
-        [?_ecs_test(
-            {"ListTagsForResource example request",
-             ?_f(erlcloud_ecs:list_tags_for_resource("testArn")), "
-{
-    \"resourceArn\": \"testArn\"
-}
-"
-            })
-        ],
-    Response = "
-{
-    \"tags\": [
-      {
-        \"key\": \"test-key1\",
-        \"value\": \"test-value1\"
-      },
-      {
-        \"key\": \"test-key2\",
-        \"value\": \"test-value2\"
-      }
-    ]
-}
-",
-    input_tests(Response, Tests).
-
-list_tags_for_resource_output_tests(_) ->
-    Tests =
-        [?_ecs_test(
-            {"ListTagsForResources example response", "
-{
-    \"tags\": [
-      {
-        \"key\": \"test-key1\",
-        \"value\": \"test-value1\"
-      },
-      {
-        \"key\": \"test-key2\",
-        \"value\": \"test-value2\"
-      }
-    ]
-}
-",
-            {ok, [#ecs_tag{
-                    key = <<"test-key1">>,
-                    value = <<"test-value1">>
-                  },
-                  #ecs_tag{
-                    key = <<"test-key2">>,
-                    value = <<"test-value2">>
-                  }
-             ]}})
-        ],
-    output_tests(?_f(erlcloud_ecs:list_tags_for_resource("testArn")), Tests).
 
 %%%===================================================================
 %%% Input test helpers

--- a/test/erlcloud_ecs_tests.erl
+++ b/test/erlcloud_ecs_tests.erl
@@ -81,7 +81,9 @@ operation_test_() ->
       fun update_container_agent_input_tests/1,
       fun update_container_agent_output_tests/1,
       fun update_service_input_tests/1,
-      fun update_service_output_tests/1
+      fun update_service_output_tests/1,
+      fun list_tags_for_resource_input_tests/1,
+      fun list_tags_for_resource_output_tests/1
      ]
     }.
 
@@ -3334,6 +3336,64 @@ update_service_output_tests(_) ->
             }})
         ],
     output_tests(?_f(erlcloud_ecs:update_service("hello_world", [{desired_count, 3}, {out, record}])), Tests).
+
+%% ListTagsForResource test based on the API examples:
+%% https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ListTagsForResource.html
+list_tags_for_resource_input_tests(_) ->
+    Tests = 
+        [?_ecs_test(
+            {"ListTagsForResource example request",
+             ?_f(erlcloud_ecs:list_tags_for_resource("testArn")), "
+{
+    \"resourceArn\": \"testArn\"
+}
+"
+            })
+        ],
+    Response = "
+{
+    \"tags\": [
+      {
+        \"key\": \"test-key1\",
+        \"value\": \"test-value1\"
+      },
+      {
+        \"key\": \"test-key2\",
+        \"value\": \"test-value2\"
+      }
+    ]
+}
+",
+    input_tests(Response, Tests).
+
+list_tags_for_resource_output_tests(_) ->
+    Tests =
+        [?_ecs_test(
+            {"ListTagsForResources example response", "
+{
+    \"tags\": [
+      {
+        \"key\": \"test-key1\",
+        \"value\": \"test-value1\"
+      },
+      {
+        \"key\": \"test-key2\",
+        \"value\": \"test-value2\"
+      }
+    ]
+}
+",
+            {ok, [#ecs_tag{
+                    key = <<"test-key1">>,
+                    value = <<"test-value1">>
+                  },
+                  #ecs_tag{
+                    key = <<"test-key2">>,
+                    value = <<"test-value2">>
+                  }
+             ]}})
+        ],
+    output_tests(?_f(erlcloud_ecs:list_tags_for_resource("testArn")), Tests).
 
 %%%===================================================================
 %%% Input test helpers


### PR DESCRIPTION
https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ListTagsForResource.html

I haven't found any specific reason for having `#ecs_tags{}` record with the only `tags` list field in it. The new `list_tags_for_resource()` method simply returns the list of `#ecs_tag{}` records 
```
{ok, [
    #ecs_tag{},
    #ecs_tag{},
    ...
  ]
}
```

instead of 
```
{ok, #ecs_tags{
  tags = [
    #ecs_tag{},
    #ecs_tag{},
    ...
  ]
}}
```