### PR TITLE
Allow for configurable metadata host and port

### DIFF
--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -21,7 +21,8 @@
   {env, [
       % Example    [{<<"kinesis">>, [<<"myAZ1.amazonaws.com">>, <<"myAZ2.amazonaws.com">>]}]
       % or via ENV [{<<"kinesis">>, {env, "KINESIS_VPC_ENDPOINTS"}]
-      {services_vpc_endpoints, []}
+      {services_vpc_endpoints, []},
+      {ec2_meta_host_port, "169.254.169.254:80"} % allows for an alternative instance metadata service
   ]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/erlcloud/erlcloud"}]}

--- a/src/erlcloud_ec2_meta.erl
+++ b/src/erlcloud_ec2_meta.erl
@@ -25,12 +25,13 @@ get_instance_metadata(Config) ->
 %% @doc Retrieve the instance meta data for the instance this code is running on. Will fail if not an EC2 instance.
 %%
 %% This convenience function will retrieve the instance id from the AWS metadata available at 
-%% http://169.254.169.254/latest/meta-data/*
+%% http://<host:port>/latest/meta-data/*
 %% ItemPath allows fetching specific pieces of metadata.
+%% <host:port> defaults to 169.254.169.254
 %%
 %%
 get_instance_metadata(ItemPath, Config) ->
-    MetaDataPath = "http://169.254.169.254/latest/meta-data/" ++ ItemPath,
+    MetaDataPath = "http://" ++ ec2_meta_host_port() ++ "/latest/meta-data/" ++ ItemPath,
     erlcloud_aws:http_body(erlcloud_httpc:request(MetaDataPath, get, [], <<>>, erlcloud_aws:get_timeout(Config), Config)).
 
 
@@ -44,11 +45,12 @@ get_instance_user_data() ->
 %% @doc Retrieve the user data for the instance this code is running on. Will fail if not an EC2 instance.
 %%
 %% This convenience function will retrieve the user data the instance was started with, i.e. what's available at 
-%% http://169.254.169.254/latest/user-data
+%% http://<host:port>/latest/user-data
+%% <host:port> defaults to 169.254.169.254
 %%
 %%
 get_instance_user_data(Config) ->
-    UserDataPath = "http://169.254.169.254/latest/user-data/",
+    UserDataPath = "http://" ++ ec2_meta_host_port() ++ "/latest/user-data/",
     erlcloud_aws:http_body(erlcloud_httpc:request(UserDataPath, get, [], <<>>, erlcloud_aws:get_timeout(Config), Config)).
 
 
@@ -66,6 +68,13 @@ get_instance_dynamic_data(Config) ->
 %%%---------------------------------------------------------------------------
 
 get_instance_dynamic_data(ItemPath, Config) ->
-    DynamicDataPath = "http://169.254.169.254/latest/dynamic/" ++ ItemPath,
+    DynamicDataPath = "http://" ++ ec2_meta_host_port() ++ "/latest/dynamic/" ++ ItemPath,
     erlcloud_aws:http_body(erlcloud_httpc:request(DynamicDataPath, get, [], <<>>, erlcloud_aws:get_timeout(Config), Config)).
 
+%%%------------------------------------------------------------------------------
+%%% Internal functions.
+%%%------------------------------------------------------------------------------
+
+ec2_meta_host_port() ->
+    {ok, EC2MetaHostPort} = application:get_env(erlcloud, ec2_meta_host_port),
+    EC2MetaHostPort.


### PR DESCRIPTION
I want `erlcloud_aws:auto_config()` to work locally without much hassle. I also want to not have to develop in an EC2 instance and then compare the result with the local env.

Let's say I use https://github.com/aws/amazon-ec2-metadata-mock to emulate EC2 metadata locally. With the content of this PR I can with a simple `application:set_env(erlcloud, metadata_host_port, "127.0.0.1:1338")`.

All previous behaviour remains the same. Would you like this option to be exposed somewhere (e.g. doc.)?