### PR TITLE
Expose erlcloud_cloudwatch_logs:start_query/stop_query/get_query_results

### DIFF
--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -123,6 +123,7 @@
     start_query/4,
     start_query/5,
     start_query/6,
+
     stop_query/1,
     stop_query/2,
 
@@ -511,8 +512,8 @@ get_query_results(QueryId, Config) ->
                       value := string() }].
 results_from_get_query_results(In) ->
     lists:map(fun (Result) ->
-                  #{ field => proplists:get_value(<<"field">>, Result),
-                     value => proplists:get_value(<<"value">>, Result) }
+                  #{ field => binary_to_list(proplists:get_value(<<"field">>, Result)),
+                     value => binary_to_list(proplists:get_value(<<"value">>, Result)) }
               end,
               In).
 
@@ -750,7 +751,7 @@ list_tags_log_group(LogGroup, Config) ->
            QueryString :: string(),
            StartTime :: non_neg_integer(),
            EndTime :: non_neg_integer(),
-           Result :: {ok, QueryId :: string()} | {error, erlcloud_aws:httpc_result_error()}.
+           Result :: {ok, #{ query_id => string() }} | {error, erlcloud_aws:httpc_result_error()}.
 start_query(LogGroupNames0, QueryString, StartTime, EndTime) ->
     start_query(LogGroupNames0, QueryString, StartTime, EndTime, _Limit = 1000).
 
@@ -760,7 +761,7 @@ start_query(LogGroupNames0, QueryString, StartTime, EndTime) ->
            StartTime :: non_neg_integer(),
            EndTime :: non_neg_integer(),
            Limit :: 1..10000,
-           Result :: {ok, QueryId :: string()} | {error, erlcloud_aws:httpc_result_error()}.
+           Result :: {ok, #{ query_id => string() }} | {error, erlcloud_aws:httpc_result_error()}.
 start_query(LogGroupNames0, QueryString, StartTime, EndTime, Limit) ->
     start_query(LogGroupNames0, QueryString, StartTime, EndTime, Limit, default_config()).
 

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -820,7 +820,7 @@ stop_query(QueryId) ->
 -spec stop_query(QueryId, Config) -> Result
       when QueryId :: string(),
            Config :: aws_config(),
-           Result :: ok.
+           Result :: ok | {error, erlcloud_aws:httpc_result_error()}.
 stop_query(QueryId, Config) ->
     Result = cw_request(Config, "StopQuery", [{<<"queryId">>, QueryId}]),
     case Result of

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -30,6 +30,7 @@
 -type metric_namespace() :: string() | binary() | undefined.
 -type log_stream_order() :: log_stream_name | last_event_time | undefined.
 -type events() :: [#{message => binary(), timestamp => pos_integer()}].
+-export_type([events/0]).
 -type kms_key_id() :: string() | binary() | undefined.
 
 

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -508,10 +508,12 @@ get_query_results(QueryId, Config) ->
     end.
 
 -spec results_from_get_query_results(In) -> Out
-      when In :: [[{binary(), binary()}]],
+      when In :: [[[{binary(), binary()}]]],
            Out :: [#{ field := string(),
                       value := string() }].
-results_from_get_query_results(In) ->
+results_from_get_query_results([]) ->
+    [];
+results_from_get_query_results([In]) ->
     lists:map(fun (Result) ->
                   #{ field => binary_to_list(proplists:get_value(<<"field">>, Result)),
                      value => binary_to_list(proplists:get_value(<<"value">>, Result)) }

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -486,7 +486,8 @@ log_stream_order_by(last_event_time) -> <<"LastEventTime">>.
 -spec get_query_results(QueryId, Options) -> Results
       when QueryId :: string(),
            Options :: [{out, map}],
-           Results :: {ok, query_results()} | {error, erlcloud_aws:httpc_result_error()}.
+           Results :: {ok, query_results() | AWSAPIReturn} | {error, erlcloud_aws:httpc_result_error()},
+           AWSAPIReturn :: [{binary(), term()}]. % as per #API_GetQueryResults_ResponseSyntax
 get_query_results(QueryId, Options) ->
     get_query_results(QueryId, Options, default_config()).
 
@@ -494,7 +495,8 @@ get_query_results(QueryId, Options) ->
       when QueryId :: string(),
            Options :: [{out, map}],
            Config :: aws_config(),
-           Results :: {ok, query_results()} | {error, erlcloud_aws:httpc_result_error()}.
+           Results :: {ok, query_results() | AWSAPIReturn} | {error, erlcloud_aws:httpc_result_error()},
+           AWSAPIReturn :: [{binary(), term()}]. % as per #API_GetQueryResults_ResponseSyntax
 get_query_results(QueryId, Options, Config) ->
     Result0 = cw_request(Config, "GetQueryResults", [{<<"queryId">>, QueryId}]),
     Out = proplists:get_value(out, Options, undefined),

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -477,7 +477,7 @@ log_stream_order_by(last_event_time) -> <<"LastEventTime">>.
 %% `
 %%   application:ensure_all_started(erlcloud).
 %%   {ok, Config} = erlcloud_aws:auto_config().
-%%   {ok, Results} = erlcloud_cloudwatch_logs:get_query_results("12ab3456-12ab-123a-789e-1234567890ab").
+%%   {ok, Results} = erlcloud_cloudwatch_logs:get_query_results("12ab3456-12ab-123a-789e-1234567890ab", Config).
 %% `
 %%
 %% @end

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -499,12 +499,12 @@ get_query_results(QueryId, Config) ->
         {error, _} = E -> E;
         {ok, Result} ->
             Statistics = proplists:get_value(<<"statistics">>, Result),
-            #{ results => results_from_get_query_results(proplists:get_value(<<"results">>, Result)),
-               statistics => #{ bytes_scanned => proplists:get_value(<<"bytesScanned">>, Statistics),
-                                records_matched => proplists:get_value(<<"recordsMatched">>, Statistics),
-                                records_scanned => proplists:get_value(<<"recordsScanned">>, Statistics)
-               },
-               status => status_from_get_query_results(proplists:get_value(<<"status">>, Result))}
+            {ok, #{ results => results_from_get_query_results(proplists:get_value(<<"results">>, Result)),
+                    statistics => #{ bytes_scanned => proplists:get_value(<<"bytesScanned">>, Statistics),
+                                     records_matched => proplists:get_value(<<"recordsMatched">>, Statistics),
+                                     records_scanned => proplists:get_value(<<"recordsScanned">>, Statistics)
+                    },
+                    status => status_from_get_query_results(proplists:get_value(<<"status">>, Result)) }}
     end.
 
 -spec results_from_get_query_results(In) -> Out

--- a/test/erlcloud_cloudwatch_logs_tests.erl
+++ b/test/erlcloud_cloudwatch_logs_tests.erl
@@ -606,10 +606,10 @@ get_query_results_output_tests(_) ->
     output_tests(?_f(erlcloud_cloudwatch_logs:get_query_results("12ab3456-12ab-123a-789e-1234567890ab")), [
         ?_cloudwatch_test(
             {"Tests output format for get_query_results",
-             jsx:encode([{<<"results">>, [[{<<"field">>, <<"LogEvent1-field1-name">>},
-                                           {<<"value">>, <<"LogEvent1-field1-value">>}],
-                                          [{<<"field">>, <<"LogEvent1-field2-name">>},
-                                           {<<"value">>, <<"LogEvent1-field2-value">>}]]},
+             jsx:encode([{<<"results">>, [[[{<<"field">>, <<"LogEvent1-field1-name">>},
+                                            {<<"value">>, <<"LogEvent1-field1-value">>}],
+                                           [{<<"field">>, <<"LogEvent1-field2-name">>},
+                                            {<<"value">>, <<"LogEvent1-field2-value">>}]]]},
                          {<<"statistics">>, [{<<"bytesScanned">>, 81349723.0},
                                              {<<"recordsMatched">>, 360851.0},
                                              {<<"recordsScanned">>, 610956.0}]},

--- a/test/erlcloud_cloudwatch_logs_tests.erl
+++ b/test/erlcloud_cloudwatch_logs_tests.erl
@@ -614,14 +614,14 @@ get_query_results_output_tests(_) ->
                                              {<<"recordsMatched">>, 360851.0},
                                              {<<"recordsScanned">>, 610956.0}]},
                          {<<"status">>, <<"Complete">>}]),
-             #{ results => [#{ field => "LogEvent1-field1-name",
-                               value => "LogEvent1-field1-value" },
-                            #{ field => "LogEvent1-field2-name",
-                               value => "LogEvent1-field2-value" }],
-                statistics => #{ bytes_scanned => 81349723.0,
-                                 records_matched => 360851.0,
-                                 records_scanned => 610956.0 },
-                status => complete }}
+             {ok, #{ results => [#{ field => "LogEvent1-field1-name",
+                                    value => "LogEvent1-field1-value" },
+                                 #{ field => "LogEvent1-field2-name",
+                                    value => "LogEvent1-field2-value" }],
+                     statistics => #{ bytes_scanned => 81349723.0,
+                                      records_matched => 360851.0,
+                                      records_scanned => 610956.0 },
+                     status => complete }}}
         )
     ]).
 

--- a/test/erlcloud_cloudwatch_logs_tests.erl
+++ b/test/erlcloud_cloudwatch_logs_tests.erl
@@ -603,7 +603,7 @@ stop_query_output_tests(_) ->
     ]).
 
 get_query_results_output_tests(_) ->
-    output_tests(?_f(erlcloud_cloudwatch_logs:get_query_results("12ab3456-12ab-123a-789e-1234567890ab")), [
+    output_tests(?_f(erlcloud_cloudwatch_logs:get_query_results("12ab3456-12ab-123a-789e-1234567890ab", [{out, map}])), [
         ?_cloudwatch_test(
             {"Tests output format for get_query_results",
              jsx:encode([{<<"results">>, [[[{<<"field">>, <<"LogEvent1-field1-name">>},


### PR DESCRIPTION
~~I'm pushing this as a draft first (it's missing tests) to try and get early feedback.~~

~~Stuff I did:~~ This pull request:
- exposes functions `erlcloud_cloudwatch_logs:get_query_results/2,3`
- exposes functions `erlcloud_cloudwatch_logs:start_query/4,5,6`
- exposes functions `erlcloud_cloudwatch_logs:stop_query/1,2`
- exposes type `erlcloud_cloudwatch_logs:query_status/0`
- exposes type `erlcloud_cloudwatch_logs:query_results/0`
- has input/output as `string()` always, for consistency
- has output as `map()`-based (optional for `:get_query_results`), and transformed in a way that keeps a reference to the original (check doc.) but is more "native" to Erlang consumers (e.g. `atom()` and `map()`)