### PR TITLE
Export DDB Streams record undynamizer

### DIFF
--- a/src/erlcloud_ddb_streams.erl
+++ b/src/erlcloud_ddb_streams.erl
@@ -65,6 +65,9 @@
          list_streams/0, list_streams/1, list_streams/2
         ]).
 
+%%% Exported DynamoDB Streams Undynamizers
+-export([undynamize_ddb_streams_record/1, undynamize_ddb_streams_record/2]).
+
 -export_type(
    [aws_region/0,
     event_id/0,
@@ -794,6 +797,32 @@ list_streams(Opts, Config) ->
     out(Return,
         fun(Json, UOpts) -> undynamize_record(list_streams_record(), Json, UOpts) end,
         DdbStreamsOpts, #ddb_streams_list_streams.streams).
+
+
+%%%------------------------------------------------------------------------------
+%%% Exported Undynamizers
+%%%------------------------------------------------------------------------------
+-type undynamize_ddb_streams_record_return() :: ddb_streams_return(#ddb_streams_record{}, #ddb_streams_stream_record{}).
+
+-spec undynamize_ddb_streams_record(json_term()) -> undynamize_ddb_streams_record_return().
+undynamize_ddb_streams_record(Return) ->
+    undynamize_ddb_streams_record(Return, []).
+
+%%------------------------------------------------------------------------------
+%% @doc Undynamizes a DynamoDB streams record.
+%% This function can be used to undynamize the jsx-decoded Data field of a
+%% record retrieved from Kinesis, after enabling Kinesis Data Streaming for
+%% a DynamoDB table.
+%%
+%% Change Data Capture for Kinesis Data Streams with DynamoDB:
+%% [http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds.html]
+%%------------------------------------------------------------------------------
+-spec undynamize_ddb_streams_record(json_term(), ddb_streams_opts()) -> undynamize_ddb_streams_record_return().
+undynamize_ddb_streams_record(Return, Opts) ->
+    out({ok, Return},
+        fun(Json, UOpts) -> undynamize_record(record_record(), Json, UOpts) end,
+        Opts, #ddb_streams_record.dynamodb).
+
 
 %%%------------------------------------------------------------------------------
 %%% Request


### PR DESCRIPTION
* Export DDB Streams record undynamizer to use with Kinesis Data Streaming for DynamoDB

After enabling  [Kinesis Data Streaming for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds.html), DynamoDB will asynchronously export item changes to a Kinesis stream destination. The record format is a light wrapper around the existing DynamoDB Streams record, so exporting this undynamizer means that a client can do the following to make existing code compatible with Kinesis sourced records with minimal changes:

Get records from Kinesis, for each record:
1. Decode the `Data` field in the record using jsx
2. Call the exported `erlcloud_ddb_streams:undynamize_ddb_streams_record` function (1 or 2 arity, I use 2 arity with option {out, record} in the list of options)
3. Unwrap `Result` from the `{ok, Result}` tuple
4. 
Since DynamoDB sends records to the Kinesis streaming destination asynchronously, the records are not guaranteed to be in order and a record may appear more than once in the stream. The list of decoded records can be sorted using `lists:sort/2` to utilize a custom compare function and sort using the ApproximateCreationDateTime timestamp. The list should also be de-duplicated if your application does not handle repeated records.