### PR TITLE
erlcloud_aws: support explicit querystring in writes

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -8,8 +8,8 @@
          aws_request_xml4/6, aws_request_xml4/8,
          aws_region_from_host/1,
          aws_request_form/8,
-         aws_request_form_raw/9,
-         do_aws_request_form_raw/10,
+         aws_request_form_raw/8, aws_request_form_raw/9,
+         do_aws_request_form_raw/9, do_aws_request_form_raw/10,
          param_list/2, default_config/0, auto_config/0, auto_config/1,
          default_config_region/2, default_config_override/1,
          update_config/1,clear_config/1, clear_expired_configs/0,
@@ -224,12 +224,23 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
     end,
     aws_request_form_raw(Method, Scheme, Host, Port, Path, list_to_binary(Form), RequestHeaders, [], Config).
 
+
+-spec aws_request_form_raw(Method :: atom(), Scheme :: string() | [string()],
+                           Host :: string(), Port :: undefined | integer() | string(),
+                           Path :: string(), Form :: iodata(), Headers :: list(),
+                           Config :: aws_config()) -> {ok, Body :: binary()} | {error, httpc_result_error()}.
+aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, Config) ->
+    do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, [], Config, false).
+
 -spec aws_request_form_raw(Method :: atom(), Scheme :: string() | [string()],
                            Host :: string(), Port :: undefined | integer() | string(),
                            Path :: string(), Form :: iodata(), Headers :: list(), QueryString :: string(),
                            Config :: aws_config()) -> {ok, Body :: binary()} | {error, httpc_result_error()}.
 aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, QueryString, Config) ->
     do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, QueryString, Config, false).
+
+do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, Config, ShowRespHeaders) ->
+    do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, [], Config, ShowRespHeaders).
 
 do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, QueryString, Config, ShowRespHeaders) ->
     URL = case Port of

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -8,8 +8,8 @@
          aws_request_xml4/6, aws_request_xml4/8,
          aws_region_from_host/1,
          aws_request_form/8,
-         aws_request_form_raw/8,
-         do_aws_request_form_raw/9,
+         aws_request_form_raw/9,
+         do_aws_request_form_raw/10,
          param_list/2, default_config/0, auto_config/0, auto_config/1,
          default_config_region/2, default_config_override/1,
          update_config/1,clear_config/1, clear_expired_configs/0,
@@ -211,8 +211,8 @@ aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service,
 
 
 -spec aws_request_form(Method :: atom(), Protocol :: undefined | string(), Host :: string(),
-                        Port :: undefined | integer() | string(), Path :: string(), Form :: [string()],
-                        Headers :: list(), Config :: aws_config()) -> {ok, Body :: binary()} | {error, httpc_result_error()}.
+                       Port :: undefined | integer() | string(), Path :: string(), Form :: [string()],
+                       Headers :: list(), Config :: aws_config()) -> {ok, Body :: binary()} | {error, httpc_result_error()}.
 aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
     RequestHeaders = case proplists:is_defined("content-type", Headers) of
       false -> [{"content-type", ?DEFAULT_CONTENT_TYPE} | Headers];
@@ -222,16 +222,16 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
         undefined -> "https://";
         _ -> [Protocol, "://"]
     end,
-    aws_request_form_raw(Method, Scheme, Host, Port, Path, list_to_binary(Form), RequestHeaders, Config).
+    aws_request_form_raw(Method, Scheme, Host, Port, Path, list_to_binary(Form), RequestHeaders, [], Config).
 
 -spec aws_request_form_raw(Method :: atom(), Scheme :: string() | [string()],
-                        Host :: string(), Port :: undefined | integer() | string(),
-                        Path :: string(), Form :: iodata(), Headers :: list(),
-                        Config :: aws_config()) -> {ok, Body :: binary()} | {error, httpc_result_error()}.
-aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, Config) ->
-    do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, Config, false).
+                           Host :: string(), Port :: undefined | integer() | string(),
+                           Path :: string(), Form :: iodata(), Headers :: list(), QueryString :: string(),
+                           Config :: aws_config()) -> {ok, Body :: binary()} | {error, httpc_result_error()}.
+aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, QueryString, Config) ->
+    do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, QueryString, Config, false).
 
-do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, Config, ShowRespHeaders) ->
+do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, QueryString, Config, ShowRespHeaders) ->
     URL = case Port of
         undefined -> [Scheme, Host, Path];
         _ -> [Scheme, Host, $:, port_to_str(Port), Path]
@@ -258,25 +258,16 @@ do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, Config,
                 Request#aws_request{should_retry = false}
         end,
 
+    {URI, Body} = aws_request_form_uri_and_body(Method, URL, Form, QueryString),
+    AwsRequest = #aws_request{uri = URI,
+                              method = Method,
+                              request_headers = Headers,
+                              request_body = Body},
+
     %% Note: httpc MUST be used with {timeout, timeout()} option
     %%       Many timeout related failures is observed at prod env
     %%       when library is used in 24/7 manner
-    Response =
-        case Method of
-            M when M =:= get orelse M =:= head orelse M =:= delete ->
-                Req = lists:flatten([URL, $?, Form]),
-                AwsRequest = #aws_request{uri = Req,
-                                          method = M,
-                                          request_headers = Headers,
-                                          request_body = <<>>},
-                erlcloud_retry:request(Config, AwsRequest, ResultFun);
-            _ ->
-                AwsRequest = #aws_request{uri = lists:flatten(URL),
-                                          method = Method,
-                                          request_headers = Headers,
-                                          request_body = Form},
-                erlcloud_retry:request(Config, AwsRequest, ResultFun)
-        end,
+    Response = erlcloud_retry:request(Config, AwsRequest, ResultFun),
 
     show_headers(ShowRespHeaders, request_to_return(Response)).
 
@@ -1040,6 +1031,33 @@ get_timeout(#aws_config{timeout = undefined}) ->
     ?ERLCLOUD_RETRY_TIMEOUT;
 get_timeout(#aws_config{timeout = Timeout}) ->
     Timeout.
+
+%% Construct the URI and body for an AWS request based on the Method, Form, and
+%% QueryString: if the request is a read/delete, join Form and QueryString in
+%% the URI and give an empty body; otherwise, pass the Form in the Body and
+%% the QueryString in the URI.
+aws_request_form_uri_and_body(Method, URL, Form, QueryString) when Method =:= delete;
+                                                                   Method =:= get;
+                                                                   Method =:= head ->
+    URI = make_uri(URL, join_query_strings([Form, QueryString])),
+    {URI, <<>>};
+aws_request_form_uri_and_body(_M, URL, Form, QueryString) ->
+    URI = make_uri(URL, QueryString),
+    {URI, Form}.
+
+
+%% Given a URL and a QueryString, combine them together appropriately (drop the
+%% QueryString if empty).
+make_uri(URL, QueryString) when QueryString =:= <<>>; QueryString == [] ->
+    lists:flatten(URL);
+make_uri(URL, QueryString) ->
+    lists:flatten([URL, $?, QueryString]).
+
+
+%% Join a list of query strings together with `&', filtering out empty ones.
+join_query_strings(QueryStrings) ->
+    lists:join($&, [QS || QS <- QueryStrings, QS /= <<>>, QS /= []]).
+
 
 %% Convert an aws_request record to return value as returned by http_headers_body
 request_to_return(#aws_request{response_type = ok,

--- a/src/erlcloud_cloudsearch.erl
+++ b/src/erlcloud_cloudsearch.erl
@@ -734,7 +734,7 @@ cloudsearch_post_json(Host, Path, Body,
     case erlcloud_aws:aws_request_form_raw(
             post, Scheme, Host, Port, Path, Body,
             [{"content-type", "application/json"} | Headers],
-            Config) of
+            [], Config) of
        {ok, RespBody} ->
             {ok, jsx:decode(RespBody, [{return_maps, false}])};
        {error, Reason} ->

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -201,7 +201,7 @@ request_impl(Method, Scheme, Host, Port, Path, Operation, Params, Body, #aws_con
     case erlcloud_aws:aws_request_form_raw(
         Method, Scheme, Host, Port, Path, Body, 
         [{"content-type", "application/x-amz-json-1.1"} | Headers], 
-        Config) of
+        [], Config) of
        {ok, RespBody} ->
             case Config#aws_config.cloudtrail_raw_result of
                 true -> {ok, RespBody};

--- a/src/erlcloud_cloudwatch_logs.erl
+++ b/src/erlcloud_cloudwatch_logs.erl
@@ -891,6 +891,7 @@ maybe_cw_request({ok, Config}, Action, Params) ->
             "/",
             Request,
             make_request_headers(Config, Action, Request),
+            [],
             Config
         )
     );

--- a/src/erlcloud_emr.erl
+++ b/src/erlcloud_emr.erl
@@ -202,7 +202,7 @@ request_no_update(Action, Json, Scheme, Host, Port, Service, Opts, Cfg) ->
     Region = erlcloud_aws:aws_region_from_host(Host),
     Headers = erlcloud_aws:sign_v4_headers(Cfg, H1, ReqBody, Region, Service) ++ H2,
     case erlcloud_aws:aws_request_form_raw(post, Scheme, Host, Port,
-                                           "/", ReqBody, Headers, Cfg) of
+                                           "/", ReqBody, Headers, [], Cfg) of
         {ok, Body} -> case proplists:get_value(out, Opts, json) of
                           raw -> {ok, Body};
                           _   -> case Body of

--- a/src/erlcloud_guardduty.erl
+++ b/src/erlcloud_guardduty.erl
@@ -115,7 +115,7 @@ guardduty_request_no_update(Config, Method, Path, Body, QParam) ->
     Headers = headers(Method, Path, Config, encode_body(Body), QParam),
     case erlcloud_aws:aws_request_form_raw(
            Method, Config#aws_config.guardduty_scheme, Config#aws_config.guardduty_host,
-           Config#aws_config.guardduty_port, Path, Form, Headers, Config) of
+           Config#aws_config.guardduty_port, Path, Form, Headers, [], Config) of
         {ok, Data} ->
             {ok, jsx:decode(Data, [{return_maps, false}])};
         E ->

--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -377,7 +377,8 @@ invoke(FunctionName, Payload, Options, Qualifier) when is_binary(Qualifier) ->
              Qualifier :: binary()| undefined,
              Config    :: aws_config()) -> return_val().
 invoke(FunctionName, Payload, Options, Qualifier, Config = #aws_config{}) ->
-    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName) ++ "/invocations",
+    URLFunctionName = erlcloud_http:url_encode(binary_to_list(FunctionName)),
+    Path = base_path() ++ "functions/" ++ URLFunctionName ++ "/invocations",
     QParams = filter_undef([{"Qualifier", Qualifier}]),
     lambda_request(Config, post, Path, Payload, QParams, Options).
 

--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -107,7 +107,7 @@ create_alias(FunctionName, FunctionVersion,
                          Options         :: proplist(),
                          Config          :: aws_config()) -> return_val().
 create_alias(FunctionName, FunctionVersion, AliasName, Options, Config) ->
-    Path = base_path() ++ "functions/" ++  binary_to_list(FunctionName) ++ "/aliases",
+    Path = base_path() ++ "functions/" ++  url_parameter(FunctionName) ++ "/aliases",
     Json = [{<<"FunctionVersion">>, FunctionVersion},
             {<<"Name">>, AliasName}
             | Options],
@@ -212,7 +212,7 @@ delete_event_source_mapping(Uuid) ->
 -spec delete_event_source_mapping(Uuid   :: binary(),
                                         Config :: aws_config()) -> return_val().
 delete_event_source_mapping(Uuid, Config) ->
-    Path = base_path() ++ "event-source-mappings/" ++ binary_to_list(Uuid),
+    Path = base_path() ++ "event-source-mappings/" ++ url_parameter(Uuid),
     lambda_request(Config, delete, Path, undefined).
 
 
@@ -239,7 +239,7 @@ get_alias(FunctionName, Name) ->
                 Config       :: aws_config()) -> return_val().
 get_alias(FunctionName, Name, Config) ->
     Path = base_path() ++ "functions/"
-        ++ binary_to_list(FunctionName) ++ "/aliases/" ++ binary_to_list(Name),
+        ++ url_parameter(FunctionName) ++ "/aliases/" ++ url_parameter(Name),
     lambda_request(Config, get, Path, undefined).
 
 %%------------------------------------------------------------------------------
@@ -262,7 +262,7 @@ get_event_source_mapping(Uuid) ->
 -spec get_event_source_mapping(Uuid   :: binary(),
                                Config :: aws_config()) -> return_val().
 get_event_source_mapping(Uuid, Config) ->
-    Path = base_path() ++ "event-source-mappings/" ++ binary_to_list(Uuid),
+    Path = base_path() ++ "event-source-mappings/" ++ url_parameter(Uuid),
     lambda_request(Config, get, Path, undefined).
 
 %%------------------------------------------------------------------------------
@@ -291,7 +291,7 @@ get_function(FunctionName, Config) ->
                    Qualifier    :: undefined | binary(),
                    Config       :: aws_config()) -> return_val().
 get_function(FunctionName, Qualifier, Config) ->
-    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName),
+    Path = base_path() ++ "functions/" ++ url_parameter(FunctionName),
     QParams = filter_undef([{"Qualifier", Qualifier}]),
     lambda_request(Config, get, Path, undefined, QParams).
 
@@ -317,7 +317,7 @@ get_function_configuration(FunctionName, Config) ->
     get_function_configuration(FunctionName, undefined, Config).
 
 get_function_configuration(Function, Qualifier, Config) ->
-    Path = base_path() ++ "functions/" ++ binary_to_list(Function) ++ "/configuration",
+    Path = base_path() ++ "functions/" ++ url_parameter(Function) ++ "/configuration",
     QParams = filter_undef([{"Qualifier", Qualifier}]),
     lambda_request(Config, get, Path, undefined, QParams).
 
@@ -377,8 +377,7 @@ invoke(FunctionName, Payload, Options, Qualifier) when is_binary(Qualifier) ->
              Qualifier :: binary()| undefined,
              Config    :: aws_config()) -> return_val().
 invoke(FunctionName, Payload, Options, Qualifier, Config = #aws_config{}) ->
-    URLFunctionName = erlcloud_http:url_encode(binary_to_list(FunctionName)),
-    Path = base_path() ++ "functions/" ++ URLFunctionName ++ "/invocations",
+    Path = base_path() ++ "functions/" ++ url_parameter(FunctionName) ++ "/invocations",
     QParams = filter_undef([{"Qualifier", Qualifier}]),
     lambda_request(Config, post, Path, Payload, QParams, Options).
 
@@ -419,7 +418,7 @@ list_aliases(FunctionName, FunctionVersion, Marker, MaxItems) ->
                    Config          :: aws_config()) -> return_val().
 list_aliases(FunctionName, FunctionVersion, Marker, MaxItems, Config) ->
     Path = base_path() ++ "functions/"
-        ++ binary_to_list(FunctionName) ++ "/aliases",
+        ++ url_parameter(FunctionName) ++ "/aliases",
     QParams = filter_undef([{"Marker", Marker},
                             {"MaxItems", MaxItems},
                             {"FunctionVersion", FunctionVersion}]),
@@ -521,7 +520,7 @@ list_versions_by_function(Function, Marker, MaxItems) ->
                                 MaxItems     :: integer() | undefined,
                                 Config       :: aws_config()) -> return_val().
 list_versions_by_function(Function, Marker, MaxItems, Config) ->
-    Path = base_path() ++ "functions/" ++ binary_to_list(Function) ++ "/versions",
+    Path = base_path() ++ "functions/" ++ url_parameter(Function) ++ "/versions",
     QParams = filter_undef([{"Marker", Marker},
                             {"MaxItems", MaxItems}]),
     lambda_request(Config, get, Path, undefined, QParams).
@@ -554,7 +553,7 @@ publish_version(FunctionName, CodeSha, Description) ->
                       Description  :: binary() | undefined,
                       Config       :: aws_config()) -> return_val().
 publish_version(FunctionName, CodeSha, Description, Config) ->
-    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName) ++ "/versions",
+    Path = base_path() ++ "functions/" ++ url_parameter(FunctionName) ++ "/versions",
     Json = filter_undef([{<<"CodeSha">>, CodeSha},
                          {<<"Description">>, Description}]),
     lambda_request(Config, post, Path, Json).
@@ -591,7 +590,7 @@ update_alias(FunctionName, AliasName, Description, FunctionVersion) ->
                    Config          :: aws_config()) -> return_val().
 update_alias(FunctionName, AliasName, Description, FunctionVersion, Config) ->
     Path = base_path() ++ "functions/"
-        ++ binary_to_list(FunctionName) ++ "/aliases/" ++ binary_to_list(AliasName),
+        ++ url_parameter(FunctionName) ++ "/aliases/" ++ url_parameter(AliasName),
     Json = filter_undef([{"Description", Description},
                          {"FunctionVersion", FunctionVersion}]),
     lambda_request(Config, put, Path, Json).
@@ -623,7 +622,7 @@ update_event_source_mapping(Uuid, BatchSize, Enabled, FunctionName) ->
                                   FunctionName :: binary() | undefined,
                                   Config       :: aws_config()) -> return_val().
 update_event_source_mapping(Uuid, BatchSize, Enabled, FunctionName, Config) ->
-    Path = base_path() ++ "event-source-mappings/" ++ binary_to_list(Uuid),
+    Path = base_path() ++ "event-source-mappings/" ++ url_parameter(Uuid),
     Json = filter_undef([{<<"BatchSize">>, BatchSize},
                          {<<"Enabled">>, Enabled},
                          {<<"FunctionName">>, FunctionName}]),
@@ -653,7 +652,7 @@ update_function_code(FunctionName, Publish, Code) ->
                            Code         :: erlcloud_lambda_code(),
                            Config       :: aws_config()) -> return_val().
 update_function_code(FunctionName, Publish, Code, Config) ->
-    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName) ++ "/code",
+    Path = base_path() ++ "functions/" ++ url_parameter(FunctionName) ++ "/code",
     Json = [{<<"Publish">>, Publish} | from_record(Code)],
     lambda_request(Config, put, Path, Json).
 
@@ -701,7 +700,7 @@ update_function_configuration(FunctionName, Description, Handler,
     Configuration :: list(tuple()), % JSX json object
     Config       :: aws_config()) -> return_val().
 update_function_configuration(FunctionName, Configuration, Config) when is_list(Configuration) ->
-    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName) ++ "/configuration",
+    Path = base_path() ++ "functions/" ++ url_parameter(FunctionName) ++ "/configuration",
     Json = filter_undef(Configuration),
     lambda_request(Config, put, Path, Json).
 
@@ -718,6 +717,9 @@ from_record(#erlcloud_lambda_code{s3Bucket        = S3Bucket,
             {<<"S3ObjectVersion">>, S3ObjectVersion},
             {<<"ZipFile">>, ZipFile}],
     filter_undef(List).
+
+url_parameter(Param) ->
+    erlcloud_http:url_encode(binary_to_list(Param)).
 
 base_path() ->
     "/" ++ ?API_VERSION ++ "/".
@@ -775,5 +777,5 @@ headers(Method, Uri, Hdrs, Config, Body, QParams) ->
     Headers = [{"host", Config#aws_config.lambda_host},
                {"content-type", "application/json"} | Hdrs],
     Region = erlcloud_aws:aws_region_from_host(Config#aws_config.lambda_host),
-    erlcloud_aws:sign_v4(Method, Uri, Config,
+    erlcloud_aws:sign_v4(Method, erlcloud_http:url_encode_loose(Uri), Config,
                          Headers, Body, Region, "lambda", QParams).

--- a/src/erlcloud_mes.erl
+++ b/src/erlcloud_mes.erl
@@ -169,7 +169,7 @@ mes_request(Config, Operation, Json) ->
 mes_request_no_update(#aws_config{mes_scheme = Scheme, mes_host = Host, mes_port = Port} = Config, Operation, Json) ->
     Body = jsx:encode(Json),
     Headers = headers(Config, Operation, Body),
-    case erlcloud_aws:aws_request_form_raw(post, Scheme, Host, Port, "/", Body, Headers, Config) of
+    case erlcloud_aws:aws_request_form_raw(post, Scheme, Host, Port, "/", Body, Headers, [], Config) of
         {ok, Response} ->
             {ok, jsx:decode(Response, [{return_maps, false}])};
         {error, Reason} ->

--- a/src/erlcloud_mms.erl
+++ b/src/erlcloud_mms.erl
@@ -168,7 +168,7 @@ mms_request(Config, Operation, Json) ->
 mms_request_no_update(#aws_config{mms_scheme = Scheme, mms_host = Host, mms_port = Port} = Config, Operation, Json) ->
     Body = jsx:encode(Json),
     Headers = headers(Config, Operation, Body),
-    case erlcloud_aws:aws_request_form_raw(post, Scheme, Host, Port, "/", Body, Headers, Config) of
+    case erlcloud_aws:aws_request_form_raw(post, Scheme, Host, Port, "/", Body, Headers, [], Config) of
         {ok, Response} ->
             {ok, jsx:decode(Response, [{return_maps, false}])};
         {error, Reason} ->

--- a/test/erlcloud_lambda_tests.erl
+++ b/test/erlcloud_lambda_tests.erl
@@ -25,6 +25,7 @@ mocks() ->
      mocked_get_function(),
      mocked_get_function_configuration(),
      mocked_invoke(),
+     mocked_invoke_alias(),
      mocked_invoke_qualifier(),
      mocked_list_aliases(),
      mocked_list_event_source_mappings(),
@@ -158,6 +159,13 @@ mocked_invoke() ->
     [?BASE_URL ++ "functions/name/invocations", post, '_', <<"{}">>, '_', '_'],
     make_response(<<"{\"message\":\"Hello World!\"}">>)
   }.
+
+mocked_invoke_alias() ->
+  {
+    [?BASE_URL ++ "functions/name%3Aalias/invocations", post, '_', <<"{}">>, '_', '_'],
+    make_response(<<"{\"message\":\"Hello World!\"}">>)
+  }.
+
 
 mocked_invoke_qualifier() ->
   {
@@ -647,6 +655,11 @@ api_tests(_) ->
      end,
      fun() ->
              Result = erlcloud_lambda:invoke(<<"name">>, [], [raw_response_body], #aws_config{}),
+             Expected = {ok, <<"{\"message\":\"Hello World!\"}">>},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:invoke(<<"name:alias">>, [], [raw_response_body], #aws_config{}),
              Expected = {ok, <<"{\"message\":\"Hello World!\"}">>},
              ?assertEqual(Expected, Result)
      end,

--- a/test/erlcloud_lambda_tests.erl
+++ b/test/erlcloud_lambda_tests.erl
@@ -25,6 +25,7 @@ mocks() ->
      mocked_get_function(),
      mocked_get_function_configuration(),
      mocked_invoke(),
+     mocked_invoke_qualifier(),
      mocked_list_aliases(),
      mocked_list_event_source_mappings(),
      mocked_list_function(),
@@ -87,7 +88,7 @@ mocked_create_function() ->
     }.
 mocked_delete_event_source_mapping() ->
     {
-      [?BASE_URL ++ "event-source-mappings/6554f300-551b-46a6-829c-41b6af6022c6?",
+      [?BASE_URL ++ "event-source-mappings/6554f300-551b-46a6-829c-41b6af6022c6",
        delete, '_', <<>>, '_', '_'],
       make_response(<<"{\"BatchSize\":100,\"EventSourceArn\":\"arn:aws:kinesi"
 "s:us-east-1:352283894008:stream/eholland-test\",\"FunctionArn\":\"arn:aws:lam"
@@ -98,7 +99,7 @@ mocked_delete_event_source_mapping() ->
     }.
 mocked_get_alias() ->
         {
-      [?BASE_URL ++ "functions/name/aliases/aliasName?",
+      [?BASE_URL ++ "functions/name/aliases/aliasName",
        get, '_', <<>>, '_', '_'],
       make_response(<<"{\"AliasArn\":\"arn:aws:lambda:us-east-1:352283894008:"
 "function:name:aliasName\",\"Description\":\"\",\"FunctionVersion\":\"$LATEST\"
@@ -106,7 +107,7 @@ mocked_get_alias() ->
     }.
 mocked_get_event_source_mapping() ->
         {
-      [?BASE_URL ++ "event-source-mappings/a45b58ec-a539-4c47-929e-174b4dd2d963?",
+      [?BASE_URL ++ "event-source-mappings/a45b58ec-a539-4c47-929e-174b4dd2d963",
        get, '_', <<>>, '_', '_'],
       make_response(<<"{\"BatchSize\":100,\"EventSourceArn\":\"arn:aws:kinesi"
 "s:us-east-1:352283894008:stream/eholland-test\",\"FunctionArn\":\"arn:aws:lam"
@@ -117,7 +118,7 @@ mocked_get_event_source_mapping() ->
     }.
 mocked_get_function() ->
     {
-      [?BASE_URL ++ "functions/name?",
+      [?BASE_URL ++ "functions/name",
        get, '_', <<>>, '_', '_'],
       make_response(<<"{\"Code\":{\"Location\":\"https://awslambda-us-east-1-"
 "tasks.s3-us-east-1.amazonaws.com/snapshots/352283894008/name-69237aec-bae9-40"
@@ -142,7 +143,7 @@ mocked_get_function() ->
     }.
 mocked_get_function_configuration() ->
     {
-      [?BASE_URL ++ "functions/name/configuration?", get, '_', <<>>, '_', '_'],
+      [?BASE_URL ++ "functions/name/configuration", get, '_', <<>>, '_', '_'],
       make_response(<<"{\"CodeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4Ic"
 "piPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"FunctionArn\":\"arn:aws:la"
 "mbda:us-east-1:352283894008:function:name\",\"FunctionName\":\"name\",\"Handl"
@@ -158,10 +159,17 @@ mocked_invoke() ->
     make_response(<<"{\"message\":\"Hello World!\"}">>)
   }.
 
+mocked_invoke_qualifier() ->
+  {
+    [?BASE_URL ++ "functions/name_qualifier/invocations?Qualifier=123", post,
+     '_', <<"{}">>, '_', '_'],
+    make_response(<<"{\"message\":\"Hello World!\"}">>)
+  }.
+
 
 mocked_list_aliases() ->
     {
-      [?BASE_URL ++ "functions/name/aliases?", get, '_', <<>>, '_', '_'],
+      [?BASE_URL ++ "functions/name/aliases", get, '_', <<>>, '_', '_'],
       make_response(<<"{\"Aliases\":[{\"AliasArn\":\"arn:aws:lambda:us-east-1"
 ":352283894008:function:name:aliasName\",\"Description\":\"\",\"FunctionVersio"
 "n\":\"$LATEST\",\"Name\":\"aliasName\"},{\"AliasArn\":\"arn:aws:lambda:us-eas"
@@ -184,7 +192,7 @@ mocked_list_event_source_mappings() ->
 
 mocked_list_function() ->
     {
-      [?BASE_URL ++ "functions/?",
+      [?BASE_URL ++ "functions/",
        get, '_', <<>>, '_', '_'],
       make_response(<<"{\"Functions\":[{\"CodeSha256\":\"XmLDAZXEkl5KbA8ezZpw"
 "FU+bjgTXBehUmWGOScl4F2A=\",\"CodeSize\":5561,\"Description\":\"\",\"FunctionA"
@@ -265,7 +273,7 @@ mocked_list_function() ->
 
 mocked_list_versions_by_function() ->
     {
-      [?BASE_URL ++ "functions/name/versions?", get, '_', <<>>, '_', '_'],
+      [?BASE_URL ++ "functions/name/versions", get, '_', <<>>, '_', '_'],
       make_response(<<"{\"NextMarker\":null,\"Versions\":[{\"CodeSha256\":\"z"
 "eoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=\",\"CodeSize\":848,\"Description"
 "\":\"\",\"FunctionArn\":\"arn:aws:lambda:us-east-1:352283894008:function:name:"
@@ -640,6 +648,11 @@ api_tests(_) ->
      fun() ->
              Result = erlcloud_lambda:invoke(<<"name">>, [], [raw_response_body], #aws_config{}),
              Expected = {ok, <<"{\"message\":\"Hello World!\"}">>},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:invoke(<<"name_qualifier">>, [], [], <<"123">>),
+             Expected = {ok, [{<<"message">>, <<"Hello World!">>}]},
              ?assertEqual(Expected, Result)
      end,
      fun() ->


### PR DESCRIPTION
Fixes #690.

Refactors `erlcloud_aws:[do_]_aws_request_form_raw` function to take a QueryString distinctly from the Form and _always_ use that as the query string fragment of the URI, never in form body. This allows callers to explicitly force values to go into the query string on POST/PUT method calls where the Form gets stored in the body.

Also fixes the logic of `erlcloud_lambda:lambda_request_no_update` to explicitly encode the Body (Form) and QParams to be fully separate, so that QParams, which for lambda always must go in the query string fragment of the URI, is always explicitly passed there. This makes it so that the `erlcloud_lambda:invoke` call, which is a POST call, will pass its `Qualifier` parameter as a query string.