### PR TITLE
Allow consumer-defined lhttpc_types -less lhttpc fork to compile without issues

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -29,7 +29,6 @@
 
 -include("erlcloud.hrl").
 -include("erlcloud_aws.hrl").
--include_lib("lhttpc/include/lhttpc_types.hrl").
 
 -define(ERLCLOUD_RETRY_TIMEOUT, 10000).
 -define(GREGORIAN_EPOCH_OFFSET, 62167219200).
@@ -43,7 +42,7 @@
 -define(AWS_REGION,  ["AWS_DEFAULT_REGION", "AWS_REGION"]).
 
 %% types
--type http_client_result() :: result(). % from lhttpc_types.hrl
+-type http_client_result() :: erlcloud_httpc:result().
 -type http_client_headers() :: [{string(), string()}].
 -type httpc_result_ok() :: {http_client_headers(), binary()}.
 -type httpc_result_error() :: {http_error, Status :: pos_integer(), StatusLine :: string(), Body :: binary()}
@@ -1059,11 +1058,11 @@ request_to_return(#aws_request{response_type = error,
     {error, {http_error, Status, StatusLine, Body, Headers}}.
 
 %% http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
--spec sign_v4_headers(aws_config(), headers(), string() | binary(), string(), string()) -> headers().
+-spec sign_v4_headers(aws_config(), erlcloud_httpc:headers(), string() | binary(), string(), string()) -> erlcloud_httpc:headers().
 sign_v4_headers(Config, Headers, Payload, Region, Service) ->
     sign_v4(post, "/", Config, Headers, Payload, Region, Service, []).
 
--spec sign_v4(atom(), list(), aws_config(), headers(), string() | binary(), string(), string(), list()) -> headers().
+-spec sign_v4(atom(), list(), aws_config(), erlcloud_httpc:headers(), string() | binary(), string(), string(), list()) -> erlcloud_httpc:headers().
 sign_v4(Method, Uri, Config, Headers, Payload, Region, Service, QueryParams) ->
     Date = iso_8601_basic_time(),
     {PayloadHash, Headers1} =

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -25,6 +25,19 @@
         {error, any()}).
 -export_type([request_fun/0]).
 
+% Imported from lhttpc_types.hrl
+-type body() :: binary()
+              | undefined % HEAD request.
+              | pid(). % When partial_download option is used.
+
+-type headers() :: [{atom() | string(), iodata()}]. % atom is of type 'Cache-Control' | 'Connection' | 'Date' | ...
+-export_type([headers/0]).
+
+-type result() :: {ok, {{StatusCode :: pos_integer(), StatusMsg :: string()}, headers(), body()}}
+                | {ok, {pid(), WindowSize :: non_neg_integer() | infinity}}
+                | {error, atom()}.
+-export_type([result/0]).
+
 request(URL, Method, Hdrs, Body, Timeout,
         #aws_config{http_client = lhttpc} = Config) ->
     request_lhttpc(URL, Method, Hdrs, Body, Timeout, Config);


### PR DESCRIPTION
Closes #692.

As discussed, in the linked issue, I present an alternative to importing `lhttpc_types.hrl` that allows consumers with a `lhttpc_types.hrl`less fork to continue compiling `erlcloud` without issues.