### PR TITLE
Delete function API

### DIFF
--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -241,7 +241,7 @@ delete_function(FunctionName, Config) ->
     Qualifier    :: undefined | binary(),
     Config       :: aws_config()) -> return_val().
 delete_function(FunctionName, Qualifier, Config) ->
-    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName),
+    Path = base_path() ++ "functions/" ++ url_parameter(FunctionName),
     QParams = filter_undef([{"Qualifier", Qualifier}]),
     lambda_request(Config, delete, Path, undefined, QParams).
 

--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -14,6 +14,7 @@
          create_event_source_mapping/4, create_event_source_mapping/5,
          create_function/6, create_function/7,
          delete_event_source_mapping/1, delete_event_source_mapping/2,
+         delete_function/1, delete_function/2, delete_function/3,
          get_alias/2, get_alias/3,
          get_event_source_mapping/1, get_event_source_mapping/2,
          get_function/1, get_function/2, get_function/3,
@@ -215,6 +216,34 @@ delete_event_source_mapping(Uuid, Config) ->
     Path = base_path() ++ "event-source-mappings/" ++ url_parameter(Uuid),
     lambda_request(Config, delete, Path, undefined).
 
+%%------------------------------------------------------------------------------
+%% DeleteFunction
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteFunction.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+-spec delete_function(FunctionName :: binary()) -> return_val().
+delete_function(FunctionName) ->
+    delete_function(FunctionName, default_config()).
+
+-spec delete_function(FunctionName :: binary(),
+    Config       :: aws_config()) -> return_val().
+delete_function(FunctionName, Config) ->
+    delete_function(FunctionName, undefined, Config).
+
+-spec delete_function(FunctionName :: binary(),
+    Qualifier    :: undefined | binary(),
+    Config       :: aws_config()) -> return_val().
+delete_function(FunctionName, Qualifier, Config) ->
+    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName),
+    QParams = filter_undef([{"Qualifier", Qualifier}]),
+    lambda_request(Config, delete, Path, undefined, QParams).
 
 %%------------------------------------------------------------------------------
 %% GetAlias

--- a/test/erlcloud_lambda_tests.erl
+++ b/test/erlcloud_lambda_tests.erl
@@ -20,6 +20,8 @@ mocks() ->
      mocked_create_event_source_mapping(),
      mocked_create_function(),
      mocked_delete_event_source_mapping(),
+     mocked_delete_function(),
+     mocked_delete_function_qualifier(),
      mocked_get_alias(),
      mocked_get_event_source_mapping(),
      mocked_get_function(),
@@ -97,6 +99,18 @@ mocked_delete_event_source_mapping() ->
 "stProcessingResult\":\"No records processed\",\"State\":\"Deleting\",\"StateT"
 "ransitionReason\":\"User action\",\"UUID\":\"a45b58ec-a539-4c47-929e-174b4dd2"
 "d963\"}">>)
+    }.
+mocked_delete_function() ->
+    {
+        [?BASE_URL ++ "functions/name",
+            delete, '_', <<>>, '_', '_'],
+        make_response({204,"No Content"}, <<"">>)
+    }.
+mocked_delete_function_qualifier() ->
+    {
+        [?BASE_URL ++ "functions/name_qualifier?Qualifier=123",
+            delete, '_', <<>>, '_', '_'],
+        make_response({204,"No Content"}, <<"">>)
     }.
 mocked_get_alias() ->
         {
@@ -582,6 +596,18 @@ api_tests(_) ->
              ?assertEqual(Expected, Result)
      end,
      fun() ->
+             Result = erlcloud_lambda:delete_function(
+                        <<"name">>),
+             Expected = {ok, []},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:delete_function(
+                        <<"name_qualifier">>, <<"123">>, #aws_config{}),
+             Expected = {ok, []},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
              Result = erlcloud_lambda:get_alias(<<"name">>, <<"aliasName">>),
              Expected = {ok, [{<<"AliasArn">>,
                                <<"arn:aws:lambda:us-east-1:352283894008:function:name:aliasName">>},
@@ -826,4 +852,7 @@ api_tests(_) ->
     ].
 
 make_response(Value) ->
-    {ok, {{200, <<"OK">>}, [], Value}}.
+    make_response({200, <<"OK">>}, Value).
+
+make_response(Status, Value) ->
+    {ok, {Status, [], Value}}.


### PR DESCRIPTION
While working with lambda versions and aliases found that there is no delete function api that can be useful (for example to delete old lambda versions). Maybe it will make sense to add it?
cc @motobob 