### PR TITLE
Add missing set types for (un)dynamize_type

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -429,7 +429,13 @@ dynamize_type(s) ->
 dynamize_type(n) ->
     <<"N">>;
 dynamize_type(b) ->
-    <<"B">>.
+    <<"B">>;
+dynamize_type(ss) ->
+    <<"SS">>;
+dynamize_type(ns) ->
+    <<"NS">>;
+dynamize_type(bs) ->
+    <<"BS">>.
 
 -spec dynamize_string(in_string_value()) -> binary().
 dynamize_string(Value) when is_binary(Value) ->
@@ -727,7 +733,13 @@ undynamize_type(<<"S">>, _) ->
 undynamize_type(<<"N">>, _) ->
     n;
 undynamize_type(<<"B">>, _) ->
-    b.
+    b;
+undynamize_type(<<"SS">>, _) ->
+    ss;
+undynamize_type(<<"NS">>, _) ->
+    ns;
+undynamize_type(<<"BS">>, _) ->
+    bs.
 
 -spec undynamize_number(binary(), undynamize_opts()) -> number().
 undynamize_number(Value, _) ->

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -1094,7 +1094,8 @@ create_table_input_tests(_) ->
                    <<"Thread">>,
                    [{<<"ForumName">>, s},
                     {<<"Subject">>, s},
-                    {<<"LastPostDateTime">>, s}],
+                    {<<"LastPostDateTime">>, s},
+                    {<<"Posters">>, ss}],
                    {<<"ForumName">>, <<"Subject">>},
                    5,
                    5,
@@ -1116,6 +1117,10 @@ create_table_input_tests(_) ->
         {
             \"AttributeName\": \"LastPostDateTime\",
             \"AttributeType\": \"S\"
+        },
+        {
+            \"AttributeName\": \"Posters\",
+            \"AttributeType\": \"SS\"
         }
     ],
     \"GlobalSecondaryIndexes\": [


### PR DESCRIPTION
SS, NS and BS are supported elsewhere, but not in these two functions
and that makes it impossible to create tables using any of the set
types.
Only SS has been tested, but given the similarity of these types one
might consider that enough.