### PR TITLE
Prevent consumers from having to -include a whole .hrl for a single type

### DIFF
--- a/src/erlcloud.erl
+++ b/src/erlcloud.erl
@@ -5,6 +5,8 @@
 -include("erlcloud_aws.hrl").
 -define(APP, erlcloud).
 
+-export_type([aws_config/0]).
+
 start() ->
     application:load(?APP),
     {ok, Apps} = application:get_key(?APP, applications),


### PR DESCRIPTION
(others may follow suite, in the future)

Closes #698.

`erlcloud` is a nice lib. to build more complex lib.s/app.s around, but sometimes its scope just gets in their way, especially when structures are passed around without the consumer having to know the internals.

This presents a (redundant) albeit useful type for referring to ~opaque~ type `aws_config()`.