### PR TITLE
Fallback on unknown attribute names

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -46,7 +46,7 @@
                                     kms_master_key_id | kms_data_key_reuse_period_seconds |
                                     approximate_number_of_messages_not_visible | visibility_timeout |
                                     created_timestamp | last_modified_timestamp | policy |
-                                    queue_arn | deduplication_scope | fifo_throughput_limit).
+                                    queue_arn | deduplication_scope | fifo_throughput_limit | sqs_managed_sse_enabled).
 
 -type(batch_entry() ::   {string(), string()}
                        | {string(), string(), [message_attribute()]}
@@ -240,7 +240,8 @@ encode_attribute_name(kms_master_key_id) -> "KmsMasterKeyId";
 encode_attribute_name(kms_data_key_reuse_period_seconds) -> "KmsDataKeyReusePeriodSeconds";
 encode_attribute_name(all) -> "All";
 encode_attribute_name(deduplication_scope) -> "DeduplicationScope";
-encode_attribute_name(fifo_throughput_limit) -> "FifoThroughputLimit".
+encode_attribute_name(fifo_throughput_limit) -> "FifoThroughputLimit";
+encode_attribute_name(sqs_managed_sse_enabled) -> "SqsManagedSseEnabled".
 
 
 decode_attribute_name("MessageRetentionPeriod") -> message_retention_period;
@@ -261,7 +262,9 @@ decode_attribute_name("KmsMasterKeyId") -> kms_master_key_id;
 decode_attribute_name("KmsDataKeyReusePeriodSeconds") -> kms_data_key_reuse_period_seconds;
 decode_attribute_name("FifoQueue") -> fifo_queue;
 decode_attribute_name("DeduplicationScope") -> deduplication_scope;
-decode_attribute_name("FifoThroughputLimit") -> fifo_throughput_limit.
+decode_attribute_name("FifoThroughputLimit") -> fifo_throughput_limit;
+decode_attribute_name("SqsManagedSseEnabled") -> sqs_managed_sse_enabled;
+decode_attribute_name(Name) -> Name.
 
 
 decode_attribute_value("Policy", Value) -> Value;


### PR DESCRIPTION
AWS rolled-out a new field and clients started to fail with `{function_clause ,[{erlcloud_sqs,decode_attribute_name,["SqsManagedSseEnabled"]...`