### PR TITLE
Fix Hex.pm license to match COPYRIGHT

### DIFF
--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -24,7 +24,7 @@
       {services_vpc_endpoints, []},
       {ec2_meta_host_port, "169.254.169.254:80"} % allows for an alternative instance metadata service
   ]},
-  {licenses, ["MIT"]},
+  {licenses, ["BSD-2-Clause"]},
   {links, [{"Github", "https://github.com/erlcloud/erlcloud"}]}
  ]
 }.


### PR DESCRIPTION
Fixes https://github.com/erlcloud/erlcloud/issues/715.

Erlcloud never used the MIT license, and has always been the BSD 2-clause license. It looks like this mistake in the Hex application properties was present from when hex publishing was implemented initially. Following https://hex.pm/docs/publish, we are amending the `licenses` from `["MIT"]` to `["BSD-2-Clause"]`, the [SPDX License identifier](https://spdx.org/licenses/) for [BSD 2-Clause](https://spdx.org/licenses/BSD-2-Clause.html).