### PR TITLE
Handle invalid xml response in erlcloud_sns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ ercloud.iml
 *[#]*[#]
 *[#]*
 .dialyzer_plt
+eunit.log

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ifeq ($(REBAR_VSN),2)
 	$(MAKE) compile
 	@$(REBAR) eunit skip_deps=true
 else
-	@$(REBAR) eunit
+	@ERL_FLAGS="-config $(PWD)/eunit" $(REBAR) eunit
 endif
 
 .dialyzer_plt:

--- a/eunit.config
+++ b/eunit.config
@@ -1,0 +1,1 @@
+[{kernel, [{error_logger, {file, "eunit.log"}}]}].

--- a/rebar.config
+++ b/rebar.config
@@ -37,3 +37,5 @@
            ]}.
 
 {post_hooks, [{clean, "rm -f .dialyzer_plt"}]}.
+
+{pre_hooks, [{clean, "rm -rf erl_crash.dump *.log *.coverage.xml"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -38,4 +38,4 @@
 
 {post_hooks, [{clean, "rm -f .dialyzer_plt"}]}.
 
-{pre_hooks, [{clean, "rm -rf erl_crash.dump *.log *.coverage.xml"}]}.
+{pre_hooks, [{clean, "rm -rf erl_crash.dump *.log"}]}.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -73,23 +73,23 @@
 
 aws_request_xml(Method, Host, Path, Params, #aws_config{} = Config) ->
     Body = aws_request(Method, Host, Path, Params, Config),
-    element(1, xmerl_scan:string(binary_to_list(Body))).
+    raw_xml_response(Body).
 aws_request_xml(Method, Host, Path, Params, AccessKeyID, SecretAccessKey) ->
     Body = aws_request(Method, Host, Path, Params, AccessKeyID, SecretAccessKey),
-    element(1, xmerl_scan:string(binary_to_list(Body))).
+    raw_xml_response(Body).
 aws_request_xml(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Config) ->
     Body = aws_request(Method, Protocol, Host, Port, Path, Params, Config),
-    element(1, xmerl_scan:string(binary_to_list(Body))).
+    raw_xml_response(Body).
 aws_request_xml(Method, Protocol, Host, Port, Path, Params, AccessKeyID, SecretAccessKey) ->
     Body = aws_request(Method, Protocol, Host, Port, Path, Params, AccessKeyID, SecretAccessKey),
-    element(1, xmerl_scan:string(binary_to_list(Body))).
+    raw_xml_response(Body).
 
 aws_request_xml2(Method, Host, Path, Params, #aws_config{} = Config) ->
     aws_request_xml2(Method, undefined, Host, undefined, Path, Params, Config).
 aws_request_xml2(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Config) ->
     case aws_request2(Method, Protocol, Host, Port, Path, Params, Config) of
         {ok, Body} ->
-            {ok, element(1, xmerl_scan:string(binary_to_list(Body)))};
+            format_xml_response(Body);
         {error, Reason} ->
             {error, Reason}
     end.
@@ -99,7 +99,7 @@ aws_request_xml4(Method, Host, Path, Params, Service, #aws_config{} = Config) ->
 aws_request_xml4(Method, Protocol, Host, Port, Path, Params, Service, #aws_config{} = Config) ->
     case aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) of
         {ok, Body} ->
-            {ok, element(1, xmerl_scan:string(binary_to_list(Body)))};
+            format_xml_response(Body);
         {error, Reason} ->
             {error, Reason}
     end.
@@ -330,6 +330,20 @@ encode_params(Params, Headers) ->
     ?DEFAULT_CONTENT_TYPE -> {erlcloud_http:make_query_string(Params), LowerCaseHeaders};
     _ContentType -> {Params, LowerCaseHeaders}
   end.
+
+raw_xml_response(Body) ->
+    case format_xml_response(Body) of
+        {ok, XML} -> XML;
+        Error -> Error
+    end.
+
+format_xml_response(Body) ->
+    try element(1, xmerl_scan:string(binary_to_list(Body))) of
+        XML -> {ok, XML}
+    catch
+        exit:{fatal,{expected_element_start_tag, _, _, _}} ->
+            {aws_error, {invalid_xml_response_document, Body}}
+    end.
 
 %%%---------------------------------------------------------------------------
 -spec default_config() -> aws_config().

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -89,7 +89,10 @@ aws_request_xml2(Method, Host, Path, Params, #aws_config{} = Config) ->
 aws_request_xml2(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Config) ->
     case aws_request2(Method, Protocol, Host, Port, Path, Params, Config) of
         {ok, Body} ->
-            format_xml_response(Body);
+            case format_xml_response(Body) of
+                {ok, XML} -> {ok, XML};
+                Error -> {error, Error}
+            end;
         {error, Reason} ->
             {error, Reason}
     end.
@@ -99,7 +102,10 @@ aws_request_xml4(Method, Host, Path, Params, Service, #aws_config{} = Config) ->
 aws_request_xml4(Method, Protocol, Host, Port, Path, Params, Service, #aws_config{} = Config) ->
     case aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) of
         {ok, Body} ->
-            format_xml_response(Body);
+            case format_xml_response(Body) of
+                {ok, XML} -> {ok, XML};
+                Error -> {error, Error}
+            end;
         {error, Reason} ->
             {error, Reason}
     end.
@@ -334,7 +340,7 @@ encode_params(Params, Headers) ->
 raw_xml_response(Body) ->
     case format_xml_response(Body) of
         {ok, XML} -> XML;
-        Error -> Error
+        Error -> erlang:error(Error)
     end.
 
 format_xml_response(Body) ->

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -344,13 +344,12 @@ raw_xml_response(Body) ->
     end.
 
 format_xml_response(Body) ->
-    XML = try 
-        element(1, xmerl_scan:string(binary_to_list(Body)))
+    try 
+        {ok, element(1, xmerl_scan:string(binary_to_list(Body)))}
     catch
         _:_ ->
             {aws_error, {invalid_xml_response_document, Body}}
-    end,
-    {ok, XML}.
+    end.
 
 %%%---------------------------------------------------------------------------
 -spec default_config() -> aws_config().

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -344,12 +344,13 @@ raw_xml_response(Body) ->
     end.
 
 format_xml_response(Body) ->
-    try element(1, xmerl_scan:string(binary_to_list(Body))) of
-        XML -> {ok, XML}
+    XML = try 
+        element(1, xmerl_scan:string(binary_to_list(Body)))
     catch
-        exit:{fatal,{expected_element_start_tag, _, _, _}} ->
+        _:_ ->
             {aws_error, {invalid_xml_response_document, Body}}
-    end.
+    end,
+    {ok, XML}.
 
 %%%---------------------------------------------------------------------------
 -spec default_config() -> aws_config().

--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -820,8 +820,7 @@ sns_xml_request(Config, Action, Params) ->
             ErrMsg = erlcloud_xml:get_text("Error/Message", XML),
             erlang:error({sns_error, ErrCode, ErrMsg});
         {error, Reason} ->
-            erlang:error({sns_error, Reason});
-        Otherwise -> Otherwise
+            erlang:error({sns_error, Reason})
     end.
 
 sns_request(Config, Action, Params) ->

--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -586,7 +586,7 @@ publish(Type, RecipientArn, Message, Subject, Attributes, Config) ->
         Doc ->
             erlcloud_xml:get_text("PublishResult/MessageId", Doc)
     catch
-        exit:{fatal,{expected_element_start_tag, _, _, _}}:_Stack ->
+        exit:{fatal,{expected_element_start_tag, _, _, _}} ->
             erlang:error({sns_error, invalid_xml_response_document})
     end.
 

--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -580,13 +580,12 @@ publish(Type, RecipientArn, Message, Subject, Attributes, Config) ->
             Subject -> [{"Subject", Subject}]
         end,
     AttributesParam = message_attributes(Attributes),
-    case sns_xml_request(
+    Doc =
+        sns_xml_request(
             Config, "Publish",
-            RecipientParam ++ MessageParams ++ SubjectParam ++ AttributesParam) of
-        {ok, Doc} ->
-            erlcloud_xml:get_text("PublishResult/MessageId", Doc);
-        Error -> Error
-    end.
+            RecipientParam ++ MessageParams ++ SubjectParam ++ AttributesParam),
+    erlcloud_xml:get_text(
+        "PublishResult/MessageId", Doc).
 
 -spec parse_event(iodata()) -> sns_event().
 parse_event(EventSource) ->

--- a/test/erlcloud_sns_tests.erl
+++ b/test/erlcloud_sns_tests.erl
@@ -172,7 +172,7 @@ output_test(Fun, {Line, {Description, Response, Result}}) ->
               Actual = try
                   Fun()
                 catch
-                  _Class:Error:_Stack ->
+                  _Class:Error ->
                     Error
                 end,
               ?assertEqual(Result, Actual)

--- a/test/erlcloud_sns_tests.erl
+++ b/test/erlcloud_sns_tests.erl
@@ -882,7 +882,7 @@ publish_invalid_xml_response_output_tests(_) ->
     [?_sns_test(
       {"Test PublishTopic invalid XML return",
         "",
-        {sns_error, invalid_xml_response_document}})
+        {aws_error, {invalid_xml_response_document, <<>>}}})
     ]).
 
 

--- a/test/erlcloud_sns_tests.erl
+++ b/test/erlcloud_sns_tests.erl
@@ -122,11 +122,7 @@ validate_params(Body, Expected) ->
 %% Validates the query body and responds with the provided response.
 -spec input_expect(string(), [expected_param()]) -> fun().
 input_expect(Response, Expected) ->
-    fun
-        (_Url, post, _Headers, "test message" = Body, _Timeout, _Config) ->
-            validate_params(Body, Expected),
-            {ok, {{200, "OK"}, [], <<"">>}};
-        (_Url, post, _Headers, Body, _Timeout, _Config) ->
+    fun(_Url, post, _Headers, Body, _Timeout, _Config) ->
             validate_params(Body, Expected),
             {ok, {{200, "OK"}, [], list_to_binary(Response)}}
     end.

--- a/test/erlcloud_sns_tests.erl
+++ b/test/erlcloud_sns_tests.erl
@@ -882,7 +882,7 @@ publish_invalid_xml_response_output_tests(_) ->
     [?_sns_test(
       {"Test PublishTopic invalid XML return",
         "",
-        {aws_error, {invalid_xml_response_document, <<>>}}})
+        {sns_error, {aws_error, {invalid_xml_response_document, <<>>}}}})
     ]).
 
 


### PR DESCRIPTION
During an AWS incident of increased error rates on SNS, Topic Publish operations were disobeying API response format defined by [AWS Docs](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html). Instead of well formed XML responses with required elements included, the response body for Publish calls was empty. In this period, errors were being generated from xmerl https://github.com/erlang/otp/blob/master/lib/xmerl/src/xmerl_scan.erl#L575 . Errors were of the form :
```
** exception exit: {fatal,{expected_element_start_tag,{file,file_name_unknown},
                                                              {line,1},
                                                              {col,1}}}
             in function  xmerl_scan:fatal/2 (xmerl_scan.erl, line 4124)
             in call from xmerl_scan:scan_document/2 (xmerl_scan.erl, line 572)
             in call from xmerl_scan:string/2 (xmerl_scan.erl, line 291)
```

This PR intends to handle an error of this form from xmerl and transform it into an sns error with form `{sns_error, invalid_xml_response_document}` . 

Additionally this PR introduces an `eunit.config` which redirects error reports from a terminal output into an `eunit.log` file to prevent error reports from cluttering the terminal at each test invocation.