### PR TITLE
erlcloud_sqs: get_queue_attributes improvement, test

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -275,7 +275,13 @@ decode_attribute_value("DeduplicationScope", Value) -> Value;
 decode_attribute_value("FifoThroughputLimit", Value) -> Value;
 decode_attribute_value(_, "true") -> true;
 decode_attribute_value(_, "false") -> false;
-decode_attribute_value(_, Value) -> list_to_integer(Value).
+decode_attribute_value(_, Value) ->
+    try
+        list_to_integer(Value)
+    catch
+        error:badarg ->
+            Value
+    end.
 
 
 -spec list_queues() -> [string()].

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -42,11 +42,14 @@
                                   approximate_first_receive_timestamp |
                                   wait_time_seconds |
                                   receive_message_wait_time_seconds).
--type(sqs_queue_attribute_name() :: all | approximate_number_of_messages |
-                                    kms_master_key_id | kms_data_key_reuse_period_seconds |
-                                    approximate_number_of_messages_not_visible | visibility_timeout |
-                                    created_timestamp | last_modified_timestamp | policy |
-                                    queue_arn | deduplication_scope | fifo_throughput_limit | sqs_managed_sse_enabled).
+
+-type(sqs_queue_attribute_name() :: all | approximate_number_of_messages | approximate_number_of_messages_not_visible |
+                                    approximate_number_of_messages_delayed | created_timestamp | delay_seconds |
+                                    last_modified_timestamp | maximum_message_size | message_retention_period |
+                                    policy | queue_arn | receive_message_wait_time_seconds | redrive_policy |
+                                    visibility_timeout | kms_master_key_id | kms_data_key_reuse_period_seconds |
+                                    sqs_managed_sse_enabled | fifo_queue | content_cased_deduplication |
+                                    deduplication_scope | fifo_throughput_limit).
 
 -type(batch_entry() ::   {string(), string()}
                        | {string(), string(), [message_attribute()]}
@@ -223,47 +226,53 @@ get_queue_attributes(QueueName, AttributeNames, Config)
     [{decode_attribute_name(Name), decode_attribute_value(Name, Value)} || {Name, Value} <- Attrs].
 
 
-encode_attribute_name(message_retention_period) -> "MessageRetentionPeriod";
-encode_attribute_name(queue_arn) -> "QueueArn";
-encode_attribute_name(maximum_message_size) -> "MaximumMessageSize";
-encode_attribute_name(visibility_timeout) -> "VisibilityTimeout";
+encode_attribute_name(all) -> "All";
 encode_attribute_name(approximate_number_of_messages) -> "ApproximateNumberOfMessages";
 encode_attribute_name(approximate_number_of_messages_not_visible) -> "ApproximateNumberOfMessagesNotVisible";
 encode_attribute_name(approximate_number_of_messages_delayed) -> "ApproximateNumberOfMessagesDelayed";
-encode_attribute_name(last_modified_timestamp) -> "LastModifiedTimestamp";
 encode_attribute_name(created_timestamp) -> "CreatedTimestamp";
 encode_attribute_name(delay_seconds) -> "DelaySeconds";
-encode_attribute_name(receive_message_wait_time_seconds) -> "ReceiveMessageWaitTimeSeconds";
+encode_attribute_name(last_modified_timestamp) -> "LastModifiedTimestamp";
+encode_attribute_name(maximum_message_size) -> "MaximumMessageSize";
+encode_attribute_name(message_retention_period) -> "MessageRetentionPeriod";
 encode_attribute_name(policy) -> "Policy";
+encode_attribute_name(queue_arn) -> "QueueArn";
+encode_attribute_name(receive_message_wait_time_seconds) -> "ReceiveMessageWaitTimeSeconds";
 encode_attribute_name(redrive_policy) -> "RedrivePolicy";
+encode_attribute_name(visibility_timeout) -> "VisibilityTimeout";
+%% The following attributes apply only to server-side-encryption
 encode_attribute_name(kms_master_key_id) -> "KmsMasterKeyId";
 encode_attribute_name(kms_data_key_reuse_period_seconds) -> "KmsDataKeyReusePeriodSeconds";
-encode_attribute_name(all) -> "All";
+encode_attribute_name(sqs_managed_sse_enabled) -> "SqsManagedSseEnabled";
+%% The following attributes apply only to FIFO (first-in-first-out) queues
+encode_attribute_name(fifo_queue) -> "FifoQueue";
+encode_attribute_name(content_cased_deduplication) -> "ContentBasedDeduplication";
 encode_attribute_name(deduplication_scope) -> "DeduplicationScope";
-encode_attribute_name(fifo_throughput_limit) -> "FifoThroughputLimit";
-encode_attribute_name(sqs_managed_sse_enabled) -> "SqsManagedSseEnabled".
+encode_attribute_name(fifo_throughput_limit) -> "FifoThroughputLimit".
 
 
-decode_attribute_name("MessageRetentionPeriod") -> message_retention_period;
-decode_attribute_name("QueueArn") -> queue_arn;
-decode_attribute_name("MaximumMessageSize") -> maximum_message_size;
-decode_attribute_name("VisibilityTimeout") -> visibility_timeout;
 decode_attribute_name("ApproximateNumberOfMessages") -> approximate_number_of_messages;
 decode_attribute_name("ApproximateNumberOfMessagesNotVisible") -> approximate_number_of_messages_not_visible;
 decode_attribute_name("ApproximateNumberOfMessagesDelayed") -> approximate_number_of_messages_delayed;
-decode_attribute_name("LastModifiedTimestamp") -> last_modified_timestamp;
 decode_attribute_name("CreatedTimestamp") -> created_timestamp;
 decode_attribute_name("DelaySeconds") -> delay_seconds;
-decode_attribute_name("ReceiveMessageWaitTimeSeconds") -> receive_message_wait_time_seconds;
+decode_attribute_name("LastModifiedTimestamp") -> last_modified_timestamp;
+decode_attribute_name("MaximumMessageSize") -> maximum_message_size;
+decode_attribute_name("MessageRetentionPeriod") -> message_retention_period;
 decode_attribute_name("Policy") -> policy;
+decode_attribute_name("QueueArn") -> queue_arn;
+decode_attribute_name("ReceiveMessageWaitTimeSeconds") -> receive_message_wait_time_seconds;
 decode_attribute_name("RedrivePolicy") -> redrive_policy;
-decode_attribute_name("ContentBasedDeduplication") -> content_based_deduplication;
+decode_attribute_name("VisibilityTimeout") -> visibility_timeout;
+%% The following attributes apply only to server-side-encryption
 decode_attribute_name("KmsMasterKeyId") -> kms_master_key_id;
 decode_attribute_name("KmsDataKeyReusePeriodSeconds") -> kms_data_key_reuse_period_seconds;
+decode_attribute_name("SqsManagedSseEnabled") -> sqs_managed_sse_enabled;
+%% The following attributes apply only to FIFO (first-in-first-out) queues
 decode_attribute_name("FifoQueue") -> fifo_queue;
+decode_attribute_name("ContentBasedDeduplication") -> content_cased_deduplication;
 decode_attribute_name("DeduplicationScope") -> deduplication_scope;
 decode_attribute_name("FifoThroughputLimit") -> fifo_throughput_limit;
-decode_attribute_name("SqsManagedSseEnabled") -> sqs_managed_sse_enabled;
 decode_attribute_name(Name) -> Name.
 
 

--- a/test/erlcloud_sqs_tests.erl
+++ b/test/erlcloud_sqs_tests.erl
@@ -18,6 +18,10 @@ erlcloud_api_test_() ->
      fun stop/1,
      [
       fun set_queue_attributes/1,
+      fun get_queue_attributes_all_output/1,
+      fun get_queue_attributes_all_unknown_output/1,
+      fun get_queue_attributes_all_input/1,
+      fun get_queue_attributes_specific_input/1,
       fun get_queue_url/1,
       fun send_message_with_message_opts/1,
       fun send_message_with_message_attributes/1,
@@ -161,6 +165,194 @@ set_queue_attributes(_) ->
       <RequestId>40945605-b328-53b5-aed4-1cc24a7240e8</RequestId>
    </ResponseMetadata>
 </SetQueueAttributesResponse>",
+    input_tests(Response, Tests).
+
+get_queue_attributes_all_output(_) ->
+    GetQueueAttributesResponse = "
+<GetQueueAttributesResponse>
+    <GetQueueAttributesResult>
+        <Attribute>
+            <Name>ReceiveMessageWaitTimeSeconds</Name>
+            <Value>2</Value>
+        </Attribute>
+        <Attribute>
+            <Name>VisibilityTimeout</Name>
+            <Value>30</Value>
+        </Attribute>
+        <Attribute>
+            <Name>ApproximateNumberOfMessages</Name>
+            <Value>0</Value>
+        </Attribute>
+        <Attribute>
+            <Name>ApproximateNumberOfMessagesNotVisible</Name>
+            <Value>0</Value>
+        </Attribute>
+        <Attribute>
+            <Name>CreatedTimestamp</Name>
+            <Value>1286771522</Value>
+        </Attribute>
+        <Attribute>
+            <Name>LastModifiedTimestamp</Name>
+            <Value>1286771522</Value>
+        </Attribute>
+        <Attribute>
+            <Name>QueueArn</Name>
+            <Value>arn:aws:sqs:us-east-2:123456789012:MyQueue</Value>
+        </Attribute>
+        <Attribute>
+            <Name>MaximumMessageSize</Name>
+            <Value>8192</Value>
+        </Attribute>
+        <Attribute>
+            <Name>MessageRetentionPeriod</Name>
+            <Value>345600</Value>
+        </Attribute>
+    </GetQueueAttributesResult>
+    <ResponseMetadata>
+        <RequestId>1ea71be5-b5a2-4f9d-b85a-945d8d08cd0b</RequestId>
+    </ResponseMetadata>
+</GetQueueAttributesResponse>",
+
+    Expected = [{receive_message_wait_time_seconds, 2},
+                {visibility_timeout, 30},
+                {approximate_number_of_messages, 0},
+                {approximate_number_of_messages_not_visible, 0},
+                {created_timestamp, 1286771522},
+                {last_modified_timestamp, 1286771522},
+                {queue_arn, "arn:aws:sqs:us-east-2:123456789012:MyQueue"},
+                {maximum_message_size, 8192},
+                {message_retention_period, 345600}],
+    Tests =
+        [?_sqs_test(
+            {"Test receives a get queue attributes result with all attributes (default).",
+             GetQueueAttributesResponse, Expected})],
+
+    output_tests(?_f(erlcloud_sqs:get_queue_attributes("MyQueue")), Tests).
+
+get_queue_attributes_all_unknown_output(_) ->
+        GetQueueAttributesResponse = "
+<GetQueueAttributesResponse>
+    <GetQueueAttributesResult>
+        <Attribute>
+            <Name>ReceiveMessageWaitTimeSeconds</Name>
+            <Value>2</Value>
+        </Attribute>
+        <Attribute>
+            <Name>VisibilityTimeout</Name>
+            <Value>30</Value>
+        </Attribute>
+        <Attribute>
+            <Name>ApproximateNumberOfMessages</Name>
+            <Value>0</Value>
+        </Attribute>
+        <Attribute>
+            <Name>ApproximateNumberOfMessagesNotVisible</Name>
+            <Value>0</Value>
+        </Attribute>
+        <Attribute>
+            <Name>CreatedTimestamp</Name>
+            <Value>1286771522</Value>
+        </Attribute>
+        <Attribute>
+            <Name>LastModifiedTimestamp</Name>
+            <Value>1286771522</Value>
+        </Attribute>
+        <Attribute>
+            <Name>QueueArn</Name>
+            <Value>arn:aws:sqs:us-east-2:123456789012:MyQueue</Value>
+        </Attribute>
+        <Attribute>
+            <Name>MaximumMessageSize</Name>
+            <Value>8192</Value>
+        </Attribute>
+        <Attribute>
+            <Name>MessageRetentionPeriod</Name>
+            <Value>345600</Value>
+        </Attribute>
+        <Attribute>
+            <Name>UnrecognizedAttribute</Name>
+            <Value>UnrecognizedValue</Value>
+        </Attribute>
+    </GetQueueAttributesResult>
+    <ResponseMetadata>
+        <RequestId>1ea71be5-b5a2-4f9d-b85a-945d8d08cd0b</RequestId>
+    </ResponseMetadata>
+</GetQueueAttributesResponse>",
+    Expected = [{receive_message_wait_time_seconds,2},
+                {visibility_timeout, 30},
+                {approximate_number_of_messages, 0},
+                {approximate_number_of_messages_not_visible, 0},
+                {created_timestamp, 1286771522},
+                {last_modified_timestamp, 1286771522},
+                {queue_arn, "arn:aws:sqs:us-east-2:123456789012:MyQueue"},
+                {maximum_message_size, 8192},
+                {message_retention_period, 345600},
+                {"UnrecognizedAttribute", "UnrecognizedValue"}],
+    Tests =
+        [?_sqs_test(
+            {"Test receives a get queue attributes result with all attributes (default).",
+             GetQueueAttributesResponse, Expected})],
+
+    output_tests(?_f(erlcloud_sqs:get_queue_attributes("MyQueue")), Tests).
+
+get_queue_attributes_all_input(_) ->
+    Expected = [
+        {"Action", "GetQueueAttributes"},
+        {"AttributeName.1", "All"}
+    ],
+    Tests =
+        [?_sqs_test(
+            {"Test getting queue attributes (specific).",
+             ?_f(erlcloud_sqs:get_queue_attributes("MyQueue")),
+             Expected})],
+    Response = "
+<GetQueueAttributesResponse>
+    <GetQueueAttributesResult>
+        <Attribute>
+            <Name>QueueArn</Name>
+            <Value>arn:aws:sqs:us-east-2:123456789012:MyQueue</Value>
+        </Attribute>
+    </GetQueueAttributesResult>
+    <ResponseMetadata>
+        <RequestId>1ea71be5-b5a2-4f9d-b85a-945d8d08cd0b</RequestId>
+    </ResponseMetadata>
+</GetQueueAttributesResponse>",
+    input_tests(Response, Tests).
+
+get_queue_attributes_specific_input(_) ->
+    Expected = [
+        {"Action", "GetQueueAttributes"},
+        {"AttributeName.1", "VisibilityTimeout"},
+        {"AttributeName.2", "DelaySeconds"},
+        {"AttributeName.3", "ReceiveMessageWaitTimeSeconds"}
+    ],
+    Tests =
+        [?_sqs_test(
+            {"Test getting queue attributes (specific).",
+             ?_f(erlcloud_sqs:get_queue_attributes("MyQueue", [visibility_timeout,
+                                                               delay_seconds,
+                                                               receive_message_wait_time_seconds])),
+             Expected})],
+    Response = "
+<GetQueueAttributesResponse>
+    <GetQueueAttributesResult>
+        <Attribute>
+            <Name>VisibilityTimeout</Name>
+            <Value>30</Value>
+        </Attribute>
+        <Attribute>
+            <Name>DelaySeconds</Name>
+            <Value>0</Value>
+        </Attribute>
+        <Attribute>
+            <Name>ReceiveMessageWaitTimeSeconds</Name>
+            <Value>2</Value>
+        </Attribute>
+    </GetQueueAttributesResult>
+    <ResponseMetadata>
+        <RequestId>1ea71be5-b5a2-4f9d-b85a-945d8d08cd0b</RequestId>
+    </ResponseMetadata>
+</GetQueueAttributesResponse>",
     input_tests(Response, Tests).
 
 get_queue_url(_) ->


### PR DESCRIPTION
Follow-up to https://github.com/erlcloud/erlcloud/pull/713.

When AWS added `SqsManagedSseEnabled`, we were lucky that it was a Boolean value, so it didn't break `erlcloud_sqs:decode_attribute_value/1`, which assumes that all attribute values that aren't specifically known are Boolean or integer values. This change anticipates a future when they add a string attribute value (like `QueueArn` or `KmsMasterKeyId `), so that we don't crash decoding THAT.

Finally, adding some `get_queue_attributes` testing to `erlcloud_sqs_tests` to cover this functionality.

Edit: also added these enhancements to get tests to pass:

> erlcloud_sqs: extend sqs_queue_attribute_names 
> * Reorder `encode_attribute_name` and `decode_attribute_name` to use the ordering from [GetQueueAttributes API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html) `AttributeName.N` definition (alphabetical, with common params first, then SSE & FIFO specific attribute names in sections below).
> * Add `FifoQueue` and `ContentBasedDeduplication` to `encode_attribute_name` and `decode_attribute_name`, previously missed FIFO parameters that should be supported.
> * Refactor `sqs_queue_attribute_name` type to include all known types.