### PR TITLE
Add functions to read server certificates stored in IAM

### DIFF
--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -72,6 +72,11 @@ iam_api_test_() ->
       fun list_role_policies_input_tests/1,
       fun list_role_policies_output_tests/1,
       fun list_role_policies_all_output_tests/1,
+      fun get_server_certificate_input_tests/1,
+      fun get_server_certificate_output_tests/1,
+      fun list_server_certificates_input_tests/1,
+      fun list_server_certificates_output_tests/1,
+      fun list_server_certificates_all_output_tests/1,
       fun list_instance_profiles_input_tests/1,
       fun list_instance_profiles_output_tests/1,
       fun list_instance_profiles_all_output_tests/1,
@@ -1717,6 +1722,190 @@ list_role_policies_all_output_tests(_) ->
              })
             ],
     output_tests_seq(?_f(erlcloud_iam:list_role_policies_all("S3Access")), Tests).
+
+-define(SERVER_CERTIFICATE_BODY,
+"-----BEGIN CERTIFICATE-----
+MIICdzCCAeCgAwIBAgIGANc+Ha2wMA0GCSqGSIb3DQEBBQUAMFMxCzAJBgNVBAYT
+AlVTMRMwEQYDVQQKEwpBbWF6b24uY29tMQwwCgYDVQQLEwNBV1MxITAfBgNVBAMT
+GEFXUyBMaW1pdGVkLUFzc3VyYW5jZSBDQTAeFw0wOTAyMDQxNzE5MjdaFw0xMDAy
+MDQxNzE5MjdaMFIxCzAJBgNVBAYTAlVTMRMwEQYDVQQKEwpBbWF6b24uY29tMRcw
+FQYDVQQLEw5BV1MtRGV2ZWxvcGVyczEVMBMGA1UEAxMMNTdxNDl0c3ZwYjRtMIGf
+MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCpB/vsOwmT/O0td1RqzKjttSBaPjbr
+dqwNe9BrOyB08fw2+Ch5oonZYXfGUrT6mkYXH5fQot9HvASrzAKHO596FdJA6DmL
+ywdWe1Oggk7zFSXO1Xv+3vPrJtaYxYo3eRIp7w80PMkiOv6M0XK8ubcTouODeJbf
+suDqcLnLDxwsvwIDAQABo1cwVTAOBgNVHQ8BAf8EBAMCBaAwFgYDVR0lAQH/BAww
+CgYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQULGNaBphBumaKbDRK
+CAi0mH8B3mowDQYJKoZIhvcNAQEFBQADgYEAuKxhkXaCLGcqDuweKtO/AEw9ZePH
+wr0XqsaIK2HZboqruebXEGsojK4Ks0WzwgrEynuHJwTn760xe39rSqXWIOGrOBaX
+wFpWHVjTFMKk+tSDG1lssLHyYWWdFFU4AnejRGORJYNaRHgVTKjHphc5jEhHm0BX
+AEaHzTpmEXAMPLE=
+-----END CERTIFICATE-----").
+
+-define(GET_SERVER_CERTIFICATE_RESP,
+"<GetServerCertificateResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+  <GetServerCertificateResult>
+    <ServerCertificate>
+      <ServerCertificateMetadata>
+        <ServerCertificateName>ProdServerCert</ServerCertificateName>
+        <Path>/company/servercerts/</Path>
+        <Arn>arn:aws:iam::123456789012:server-certificate/company/servercerts/ProdServerCert</Arn>
+        <UploadDate>2010-05-08T01:02:03.004Z</UploadDate>
+        <ServerCertificateId>ASCACKCEVSQ6C2EXAMPLE</ServerCertificateId>
+        <Expiration>2012-05-08T01:02:03.004Z</Expiration>
+      </ServerCertificateMetadata>
+      <CertificateBody>"
+        ++ ?SERVER_CERTIFICATE_BODY ++
+      "</CertificateBody>
+    </ServerCertificate>
+  </GetServerCertificateResult>
+  <ResponseMetadata>
+    <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+  </ResponseMetadata>
+</GetServerCertificateResponse>").
+
+get_server_certificate_input_tests(_) ->
+    Tests = [
+        ?_iam_test({
+            "Test returning a server certificate.",
+            ?_f(erlcloud_iam:get_server_certificate("test")),
+            [{"Action", "GetServerCertificate"}, {"ServerCertificateName", "test"}]
+        })
+    ],
+    input_tests(?GET_SERVER_CERTIFICATE_RESP, Tests).
+
+get_server_certificate_output_tests(_) ->
+    Tests = [
+        ?_iam_test({
+            "This returns the server certificate",
+            ?GET_SERVER_CERTIFICATE_RESP,
+            {ok, [
+                {server_certificate_metadata, [
+                    {server_certificate_name, "ProdServerCert"},
+                    {server_certificate_id, "ASCACKCEVSQ6C2EXAMPLE"},
+                    {path, "/company/servercerts/"},
+                    {arn, "arn:aws:iam::123456789012:server-certificate/company/servercerts/ProdServerCert"},
+                    {upload_date, {{2010,5,8}, {1,2,3}}},
+                    {expiration, {{2012,5,8}, {1,2,3}}}
+                ]},
+                {certificate_body, ?SERVER_CERTIFICATE_BODY}
+            ]}
+        })
+    ],
+    output_tests(?_f(erlcloud_iam:get_server_certificate("test")), Tests).
+
+-define(LIST_SERVER_CERTIFICATES_RESP,
+"<ListServerCertificatesResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+  <ListServerCertificatesResult>
+    <IsTruncated>false</IsTruncated>
+    <ServerCertificateMetadataList>
+      <member>
+        <ServerCertificateName>ProdServerCert</ServerCertificateName>
+        <Path>/company/servercerts/</Path>
+        <Arn>arn:aws:iam::123456789012:server-certificate/company/servercerts/ProdServerCert</Arn>
+        <UploadDate>2010-05-08T01:02:03.004Z</UploadDate>
+        <ServerCertificateId>ASCACKCEVSQ6C2EXAMPLE</ServerCertificateId>
+        <Expiration>2012-05-08T01:02:03.004Z</Expiration>
+      </member>
+    </ServerCertificateMetadataList>
+  </ListServerCertificatesResult>
+  <ResponseMetadata>
+    <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+  </ResponseMetadata>
+</ListServerCertificatesResponse>").
+
+list_server_certificates_input_tests(_) ->
+    Tests = [
+        ?_iam_test({
+            "Test returning a list of server certificates.",
+            ?_f(erlcloud_iam:list_server_certificates("test")),
+            [{"Action", "ListServerCertificates"}, {"PathPrefix", "test"}]
+        })
+    ],
+    input_tests(?LIST_SERVER_CERTIFICATES_RESP, Tests).
+
+list_server_certificates_output_tests(_) ->
+    Tests = [
+        ?_iam_test({
+            "Test returning a list of server certificates.",
+            ?LIST_SERVER_CERTIFICATES_RESP,
+            {ok, [
+                [
+                    {server_certificate_name, "ProdServerCert"},
+                    {server_certificate_id, "ASCACKCEVSQ6C2EXAMPLE"},
+                    {path, "/company/servercerts/"},
+                    {arn, "arn:aws:iam::123456789012:server-certificate/company/servercerts/ProdServerCert"},
+                    {upload_date, {{2010,5,8}, {1,2,3}}},
+                    {expiration, {{2012,5,8}, {1,2,3}}}
+                ]
+            ]}
+        })
+    ],
+    output_tests(?_f(erlcloud_iam:list_server_certificates("test")), Tests).
+
+list_server_certificates_all_output_tests(_) ->
+    Tests = [
+        ?_iam_test({
+            "Test returning all server certificates",
+            [
+                "<ListServerCertificatesResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+                <ListServerCertificatesResult>
+                  <IsTruncated>true</IsTruncated>
+                  <Marker>marker</Marker>
+                  <ServerCertificateMetadataList>
+                    <member>
+                      <ServerCertificateName>ProdServerCert</ServerCertificateName>
+                      <Path>/company/servercerts/</Path>
+                      <Arn>arn:aws:iam::123456789012:server-certificate/company/servercerts/ProdServerCert</Arn>
+                      <UploadDate>2010-05-08T01:02:03.004Z</UploadDate>
+                      <ServerCertificateId>ASCACKCEVSQ6CEXAMPLE1</ServerCertificateId>
+                      <Expiration>2012-05-08T01:02:03.004Z</Expiration>
+                    </member>
+                  </ServerCertificateMetadataList>
+                </ListServerCertificatesResult>
+                <ResponseMetadata>
+                  <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+                </ResponseMetadata>
+              </ListServerCertificatesResponse>",
+              "<ListServerCertificatesResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+                <ListServerCertificatesResult>
+                  <IsTruncated>false</IsTruncated>
+                  <ServerCertificateMetadataList>
+                    <member>
+                      <ServerCertificateName>TestServerCert</ServerCertificateName>
+                      <Path>/company/servercerts/</Path>
+                      <Arn>arn:aws:iam::123456789012:server-certificate/company/servercerts/TestServerCert</Arn>
+                      <UploadDate>2010-05-08T03:01:02.004Z</UploadDate>
+                      <ServerCertificateId>ASCACKCEVSQ6CEXAMPLE2</ServerCertificateId>
+                      <Expiration>2012-05-08T03:01:02.004Z</Expiration>
+                    </member>
+                  </ServerCertificateMetadataList>
+                </ListServerCertificatesResult>
+                <ResponseMetadata>
+                  <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+                </ResponseMetadata>
+              </ListServerCertificatesResponse>"
+            ],
+            {ok, [
+                [
+                    {server_certificate_name, "ProdServerCert"},
+                    {server_certificate_id, "ASCACKCEVSQ6CEXAMPLE1"},
+                    {path, "/company/servercerts/"},
+                    {arn, "arn:aws:iam::123456789012:server-certificate/company/servercerts/ProdServerCert"},
+                    {upload_date, {{2010,5,8}, {1,2,3}}},
+                    {expiration, {{2012,5,8}, {1,2,3}}}
+                ],
+                [
+                    {server_certificate_name, "TestServerCert"},
+                    {server_certificate_id, "ASCACKCEVSQ6CEXAMPLE2"},
+                    {path, "/company/servercerts/"},
+                    {arn, "arn:aws:iam::123456789012:server-certificate/company/servercerts/TestServerCert"},
+                    {upload_date, {{2010,5,8}, {3,1,2}}},
+                    {expiration, {{2012,5,8}, {3,1,2}}}
+                ]       
+            ]}
+        })
+    ],
+    output_tests_seq(?_f(erlcloud_iam:list_server_certificates_all("test")), Tests).
 
 -define(LIST_INSTANCE_PROFILES_RESP,
         "<ListInstanceProfilesResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">


### PR DESCRIPTION
The following functions have been added to `erlcloud_iam` to read server certificates stored in IAM:
1. get_server_certificate/1,2 based on [API Reference/GetServerCertificate](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetServerCertificate.html)
2. list_server_certificates(_all)/0,1,2 based on [API Reference/ListServerCertificates](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListServerCertificates.html)