### PR TITLE
Fix reading error message from failed DDB requests

### DIFF
--- a/src/erlcloud_ddb_impl.erl
+++ b/src/erlcloud_ddb_impl.erl
@@ -248,7 +248,7 @@ client_error(Body, DDBError) ->
                 undefined ->
                     DDBError#ddb2_error{error_type = http, should_retry = false};
                 FullType ->
-                    Message = proplists:get_value(<<"Message">>, Json, <<>>),
+                    Message = proplists:get_value(<<"message">>, Json, <<>>),
                     case binary:split(FullType, <<"#">>) of
                         [_, Type] when
                               Type =:= <<"ProvisionedThroughputExceededException">> orelse

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -273,7 +273,7 @@ error_handling_tests(_) ->
             {"Test retry after ProvisionedThroughputExceededException",
              [httpc_response(400, "
 {\"__type\":\"com.amazonaws.dynamodb.v20111205#ProvisionedThroughputExceededException\",
-\"Message\":\"The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API\"}"
+\"message\":\"The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API\"}"
                             ),
               OkResponse],
              OkResult}),
@@ -281,7 +281,7 @@ error_handling_tests(_) ->
             {"Test ConditionalCheckFailed error",
              [httpc_response(400, "
 {\"__type\":\"com.amazonaws.dynamodb.v20111205#ConditionalCheckFailedException\",
-\"Message\":\"The expected value did not match what was stored in the system.\"}"
+\"message\":\"The expected value did not match what was stored in the system.\"}"
                             )],
              {error, {<<"ConditionalCheckFailedException">>, <<"The expected value did not match what was stored in the system.">>}}}),
          ?_ddb_test(
@@ -315,7 +315,7 @@ error_handling_tests(_) ->
             \"Message\":\"The conditional request failed\",
         }
     ],
-    \"Message\":\"Transaction cancelled, please refer cancellation reasons for specific reasons [None, ConditionalCheckFailed]\"
+    \"message\":\"Transaction cancelled, please refer cancellation reasons for specific reasons [None, ConditionalCheckFailed]\"
 }"
                             )],
               TransactionErrorResult}),
@@ -333,7 +333,7 @@ error_handling_tests(_) ->
             \"Message\":\"The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API\",
         }
     ],
-    \"Message\":\"Transaction cancelled, please refer cancellation reasons for specific reasons [None, ProvisionedThroughputExceeded]\"
+    \"message\":\"Transaction cancelled, please refer cancellation reasons for specific reasons [None, ProvisionedThroughputExceeded]\"
 }"
                             ),
               TransactOkResponse],

--- a/test/erlcloud_ddb_tests.erl
+++ b/test/erlcloud_ddb_tests.erl
@@ -211,7 +211,7 @@ error_handling_tests(_) ->
             {"Test retry after ProvisionedThroughputExceededException",
              [httpc_response(400, "
 {\"__type\":\"com.amazonaws.dynamodb.v20111205#ProvisionedThroughputExceededException\",
-\"Message\":\"The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API\"}"
+\"message\":\"The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API\"}"
                             ),
               OkResponse],
              OkResult}),
@@ -219,7 +219,7 @@ error_handling_tests(_) ->
             {"Test ConditionalCheckFailed error",
              [httpc_response(400, "
 {\"__type\":\"com.amazonaws.dynamodb.v20111205#ConditionalCheckFailedException\",
-\"Message\":\"The expected value did not match what was stored in the system.\"}"
+\"message\":\"The expected value did not match what was stored in the system.\"}"
                             )],
              {error, {<<"ConditionalCheckFailedException">>, <<"The expected value did not match what was stored in the system.">>}}}),
          ?_ddb_test(


### PR DESCRIPTION
I noticed when trying to handle specific errors that reading the message from the DDB error body wasn't correct resulting in an empty message.
This fixes such that we will get this message.
For example:
```
(infranet@127.0.0.1)42> erlcloud_ddb2:put_item(<<"a_table">>, [{<<"id">>, <<"dummy">>}, {<<"some_attr">>, Data}]).
{error,{<<"ValidationException">>,<<>>}}
```
with this fix the result is:
```
(infranet@127.0.0.1)45> erlcloud_ddb2:put_item(<<"a_table">>, [{<<"id">>, <<"dummy">>}, {<<"some_attr">>, Data}]).
{error,{<<"ValidationException">>,
        <<"Item size has exceeded the maximum allowed size">>}}
```
