### PR TITLE
Support access-analyzer service

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -19,6 +19,7 @@
 -type(hackney_client_options() :: #hackney_client_options{}).
 
 -record(aws_config, {
+          access_analyzer_host="access-analyzer.us-east-1.amazonaws.com"::string(),
           as_host="autoscaling.amazonaws.com"::string(),
           ec2_protocol="https"::string(),
           ec2_host="ec2.amazonaws.com"::string(),

--- a/src/erlcloud_access_analyzer.erl
+++ b/src/erlcloud_access_analyzer.erl
@@ -1,0 +1,240 @@
+-module(erlcloud_access_analyzer).
+
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
+
+%% API
+-export([
+    list_analyzers/1,
+    list_analyzers/2,
+    list_analyzers_all/1,
+    list_analyzers_all/2,
+    get_analyzer/2,
+    create_analyzer/2,
+    delete_analyzer/2
+]).
+
+-type param_name() :: binary() | string() | atom().
+-type param_value() :: binary() | string() | atom() | integer(). 
+-type params() :: [param_name() | {param_name(), param_value()}].
+
+-type analyzer() :: proplist().
+-type analyzers() :: [analyzer()].
+-type token() :: binary().
+
+-type create_analyzer_spec() :: proplist().
+
+%% -----------------------------------------------------------------------------
+%% Exported functions
+%% -----------------------------------------------------------------------------
+
+-spec list_analyzers(AwsConfig) -> Result
+when AwsConfig :: aws_config(),
+     Result :: {ok, analyzers()} | {ok, analyzers(), token()} | {error, term()}.
+list_analyzers(AwsConfig)
+  when is_record(AwsConfig, aws_config) ->
+    list_analyzers(AwsConfig, _Params = []);
+list_analyzers(Params) ->
+    AwsConfig = erlcloud_aws:default_config(),
+    list_analyzers(AwsConfig, Params).
+
+-spec list_analyzers(AwsConfig, Params) -> Result
+when AwsConfig :: aws_config(),
+     Params :: params(),
+     Result :: {ok, analyzers()} | {ok, analyzers(), token()} | {error, term()}.
+list_analyzers(AwsConfig, Params) ->
+    Path = ["analyzer"],
+    case request(AwsConfig, _Method = get, Path, Params) of
+        {ok, Response} ->
+            Analyzers = proplists:get_value(<<"analyzers">>, Response),
+            case proplists:get_value(<<"nextToken">>, Response) of
+                undefined ->
+                    {ok, Analyzers};
+                Token ->
+                    {ok, Analyzers, Token}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec list_analyzers_all(AwsConfig) -> Result
+when AwsConfig :: aws_config(),
+     Result :: {ok, analyzers()} | {ok, analyzers(), token()} | {error, term()}.
+list_analyzers_all(AwsConfig)
+  when is_record(AwsConfig, aws_config) ->
+    list_analyzers_all(AwsConfig, _Params = []);
+list_analyzers_all(Params) ->
+    AwsConfig = erlcloud_aws:default_config(),
+    list_analyzers(AwsConfig, Params).
+
+-spec list_analyzers_all(AwsConfig, Params) -> Result
+when AwsConfig :: aws_config(),
+     Params :: params(),
+     Result :: {ok, analyzers()} | {ok, analyzers(), token()} | {error, term()}.
+list_analyzers_all(AwsConfig, Params) ->
+    case list_analyzers(AwsConfig, Params) of
+        {ok, Analyzers} ->
+            {ok, Analyzers};
+        {ok, Analyzers, Token} ->
+            list_analyzers_next(AwsConfig, Params, Token, Analyzers);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec get_analyzer(AwsConfig, AnalyzerName) -> Result
+when AwsConfig :: aws_config(),
+     AnalyzerName :: binary() | string(),
+     Result :: {ok, analyzer()} | {error, not_found} | {error, term()}.
+get_analyzer(AwsConfig, AnalyzerName) ->
+    Path = ["analyzer", AnalyzerName],
+    case request(AwsConfig, _Method = get, Path) of
+        {ok, Response} ->
+            Analyzer = proplists:get_value(<<"analyzer">>, Response),
+            {ok, Analyzer};
+        {error, {<<"ResourceNotFoundException">>, _Message}} ->
+            {error, not_found};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec create_analyzer(AwsConfig, Spec) -> Result
+when AwsConfig :: aws_config(),
+     Spec :: create_analyzer_spec(),
+     Result :: {ok, Arn :: binary()} | {error, term()}.
+create_analyzer(AwsConfig, Spec) ->
+    Path = ["analyzer"],
+    RequestBody = jsx:encode(Spec),
+    case request(AwsConfig, _Method = put, Path, _Params = [], RequestBody) of
+        {ok, Response} ->
+            Arn = proplists:get_value(<<"arn">>, Response),
+            {ok, Arn};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec delete_analyzer(AwsConfig, AnalyzerName) -> Result
+when AwsConfig :: aws_config(),
+     AnalyzerName :: binary() | string(),
+     Result :: ok | {error, not_found} | {error, term()}.
+delete_analyzer(AwsConfig, AnalyzerName) ->
+    delete_analyser(AwsConfig, AnalyzerName, _Params = []).
+
+-spec delete_analyser(AwsConfig, AnalyzerName, Params) -> Result
+when AwsConfig :: aws_config(),
+     AnalyzerName :: binary() | string(),
+     Params :: params(),
+     Result :: ok | {error, not_found} | {error, term()}.
+delete_analyser(AwsConfig, AnalyzerName, Params) ->
+    Path = ["analyzer", AnalyzerName],
+    case request(AwsConfig, _Method = delete, Path, Params) of
+        ok ->
+            ok;
+        {error, {<<"ResourceNotFoundException">>, _Message}} ->
+            {error, not_found};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% -----------------------------------------------------------------------------
+%% Local functions
+%% -----------------------------------------------------------------------------
+
+list_analyzers_next(AwsConfig, Params, Token0, Analyzers0) ->
+    case list_analyzers(AwsConfig, [{<<"nextToken">>, Token0} | Params]) of
+        {ok, Analyzers} ->
+            Analyzers1 = lists:append(Analyzers0, Analyzers),
+            {ok, Analyzers1};
+        {ok, Analyzers, Token1} ->
+            Analyzers1 = lists:append(Analyzers0, Analyzers),
+            list_analyzers_next(AwsConfig, Params, Token1, Analyzers1);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+request(AwsConfig, Method, Path) ->
+    request(AwsConfig, Method, Path, _Params = []).
+
+request(AwsConfig, Method, Path, Params) ->
+    request(AwsConfig, Method, Path, Params, _RequestBody = <<>>).
+
+request(AwsConfig0, Method, Path, Params, RequestBody) ->
+    case erlcloud_aws:update_config(AwsConfig0) of
+        {ok, AwsConfig1} ->
+            AwsRequest0 = init_request(AwsConfig1, Method, Path, Params, RequestBody),
+            AwsRequest1 = erlcloud_retry:request(AwsConfig1, AwsRequest0, fun should_retry/1),
+            case AwsRequest1#aws_request.response_type of
+                ok ->
+                    decode_response(AwsRequest1);
+                error ->
+                    decode_error(AwsRequest1)
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+init_request(AwsConfig, Method, Path, Params, Payload) ->
+    Host = AwsConfig#aws_config.access_analyzer_host,
+    Service = "access-analyzer",
+    NormPath = norm_path(Path),
+    NormParams = norm_params(Params),
+    Region = erlcloud_aws:aws_region_from_host(Host),
+    Headers = [{"host", Host}, {"content-type", "application/json"}],
+    SignedHeaders = erlcloud_aws:sign_v4(Method, NormPath, AwsConfig, Headers, Payload, Region, Service, Params),
+    #aws_request{
+        service = access_analyzer,
+        method = Method,
+        uri = "https://" ++ Host ++ NormPath ++ NormParams,
+        request_headers = SignedHeaders,
+        request_body = Payload
+    }.
+
+norm_path(Path) ->
+    binary_to_list(iolist_to_binary(["/" | lists:join("/", Path)])).
+
+norm_params([] = _Params) ->
+    "";
+norm_params(Params) ->
+    "?" ++ erlcloud_aws:canonical_query_string(Params).
+
+should_retry(Request)
+  when Request#aws_request.response_type == ok ->
+    Request;
+should_retry(Request)
+  when Request#aws_request.response_type == error,
+       Request#aws_request.response_status == 429 ->
+    Request#aws_request{should_retry = true};
+should_retry(Request)
+  when Request#aws_request.response_type == error,
+       Request#aws_request.response_status >= 500 ->
+    Request#aws_request{should_retry = true};
+should_retry(Request) ->
+    Request#aws_request{should_retry = false}.
+
+decode_response(AwsRequest) ->
+    case AwsRequest#aws_request.response_body of
+        <<>> ->
+            ok;
+        ResponseBody ->
+            Json = jsx:decode(ResponseBody, [{return_maps, false}]),
+            {ok, Json}
+    end.
+
+decode_error(AwsRequest) ->
+    case AwsRequest#aws_request.error_type of
+        aws ->
+            Type = extract_error_type(AwsRequest),
+            Message = extract_error_message(AwsRequest),
+            {error, {Type, Message}};
+        _ ->
+            erlcloud_aws:request_to_return(AwsRequest)
+    end.
+
+extract_error_type(AwsRequest) ->
+    Headers = AwsRequest#aws_request.response_headers,
+    Value = proplists:get_value("x-amzn-errortype", Headers),
+    iolist_to_binary(Value).
+
+extract_error_message(AwsRequest) ->
+    ResponseBody = AwsRequest#aws_request.response_body,
+    Object = jsx:decode(ResponseBody, [{return_maps, false}]),
+    proplists:get_value(<<"message">>, Object, <<>>).

--- a/test/erlcloud_access_analyzer_tests.erl
+++ b/test/erlcloud_access_analyzer_tests.erl
@@ -1,0 +1,299 @@
+-module(erlcloud_access_analyzer_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("erlcloud_aws.hrl").
+
+-define(TEST_AWS_CONFIG,
+    #aws_config{
+        access_key_id = "TEST_ACCESS_KEY_ID",
+        secret_access_key = "TEST_ACCESS_KEY",
+        security_token = "TEST_SECURITY_TOKEN"
+    }
+).
+
+api_test_() ->
+    {
+        foreach,
+        fun() -> meck:new(erlcloud_httpc) end,
+        fun(_) -> meck:unload() end,
+        [
+            fun list_analyzers_tests/1,
+            fun get_analyzer_tests/1,
+            fun create_analyzer_tests/1,
+            fun delete_analyzer_tests/1
+        ]
+    }.
+
+list_analyzers_tests(_) ->
+    [
+        {
+            "ListAnalyzers",
+            fun() ->
+                AwsConfig = ?TEST_AWS_CONFIG,
+                meck:expect(
+                    erlcloud_httpc, request,
+                    fun(A1, A2, A3, A4, A5, A6) ->
+                        Url = "https://access-analyzer.us-east-1.amazonaws.com/analyzer?maxResults=10",
+                        Method = get,
+                        RequestContent = <<>>,
+                        case [A1, A2, A3, A4, A5, A6] of
+                            [Url, Method, _Headers, RequestContent, _Timeout, AwsConfig] ->
+                                ResponseContent = <<
+                                    "{"
+                                        "\"analyzers\":["
+                                            "{"
+                                                "\"arn\":\"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-1\","
+                                                "\"name\":\"test-1\","
+                                                "\"type\":\"ACCOUNT\","
+                                                "\"createdAt\":\"2022-01-01T01:02:03Z\","
+                                                "\"status\":\"ACTIVE\""
+                                            "},"
+                                            "{"
+                                                "\"arn\":\"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-2\","
+                                                "\"name\":\"test-2\","
+                                                "\"type\":\"ACCOUNT\","
+                                                "\"createdAt\":\"2022-02-02T01:02:03Z\","
+                                                "\"status\":\"ACTIVE\""
+                                            "}"
+                                        "]"
+                                    "}"
+                                >>,
+                                {ok, {{200, "OK"}, [], ResponseContent}}
+                        end
+                    end
+                ),
+                Params = [{"maxResults", 10}],
+                Result = erlcloud_access_analyzer:list_analyzers(AwsConfig, Params),
+                Analyzers = [
+                    [
+                        {<<"arn">>, <<"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-1">>},
+                        {<<"name">>, <<"test-1">>},
+                        {<<"type">>, <<"ACCOUNT">>},
+                        {<<"createdAt">>, <<"2022-01-01T01:02:03Z">>},
+                        {<<"status">>, <<"ACTIVE">>}
+                    ],
+                    [
+                        {<<"arn">>, <<"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-2">>},
+                        {<<"name">>, <<"test-2">>},
+                        {<<"type">>, <<"ACCOUNT">>},
+                        {<<"createdAt">>, <<"2022-02-02T01:02:03Z">>},
+                        {<<"status">>, <<"ACTIVE">>}
+                    ]
+                ],
+                ?assertEqual({ok, Analyzers}, Result)
+            end
+        },
+        {
+            "ListAnalyzers [all]",
+            fun() ->
+                AwsConfig = ?TEST_AWS_CONFIG,
+                meck:expect(
+                    erlcloud_httpc, request,
+                    fun(A1, A2, A3, A4, A5, A6) ->
+                        Url1 = "https://access-analyzer.us-east-1.amazonaws.com/analyzer?maxResults=1&type=ACCOUNT",
+                        Url2 = "https://access-analyzer.us-east-1.amazonaws.com/analyzer?maxResults=1&nextToken=TEST_NEXT_TOKEN&type=ACCOUNT",
+                        Method = get,
+                        RequestContent = <<>>,
+                        case [A1, A2, A3, A4, A5, A6] of
+                            [Url1, Method, _Headers, RequestContent, _Timeout, AwsConfig] ->
+                                ResponseContent = <<
+                                    "{"
+                                        "\"analyzers\":["
+                                            "{"
+                                                "\"arn\":\"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-1\","
+                                                "\"name\":\"test-1\","
+                                                "\"type\":\"ACCOUNT\","
+                                                "\"createdAt\":\"2022-01-01T01:02:03Z\","
+                                                "\"status\":\"ACTIVE\""
+                                            "}"
+                                        "],"
+                                        "\"nextToken\":\"TEST_NEXT_TOKEN\""
+                                    "}"
+                                >>,
+                                {ok, {{200, "OK"}, [], ResponseContent}};
+                            [Url2, Method, _Headers, RequestContent, _Timeout, AwsConfig] ->
+                                ResponseContent = <<
+                                    "{"
+                                        "\"analyzers\":["
+                                            "{"
+                                                "\"arn\":\"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-2\","
+                                                "\"name\":\"test-2\","
+                                                "\"type\":\"ACCOUNT\","
+                                                "\"createdAt\":\"2022-02-02T01:02:03Z\","
+                                                "\"status\":\"ACTIVE\""
+                                            "}"
+                                        "]"
+                                    "}"
+                                >>,
+                                {ok, {{200, "OK"}, [], ResponseContent}}
+                        end
+                    end
+                ),
+                Params = [{"type", "ACCOUNT"}, {"maxResults", 1}],
+                Result = erlcloud_access_analyzer:list_analyzers_all(AwsConfig, Params),
+                Analyzers = [
+                    [
+                        {<<"arn">>, <<"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-1">>},
+                        {<<"name">>, <<"test-1">>},
+                        {<<"type">>, <<"ACCOUNT">>},
+                        {<<"createdAt">>, <<"2022-01-01T01:02:03Z">>},
+                        {<<"status">>, <<"ACTIVE">>}
+                    ],
+                    [
+                        {<<"arn">>, <<"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-2">>},
+                        {<<"name">>, <<"test-2">>},
+                        {<<"type">>, <<"ACCOUNT">>},
+                        {<<"createdAt">>, <<"2022-02-02T01:02:03Z">>},
+                        {<<"status">>, <<"ACTIVE">>}
+                    ]
+                ],
+                ?assertEqual({ok, Analyzers}, Result)
+            end
+        }
+    ].
+
+get_analyzer_tests(_) ->
+    [
+        {
+            "GetAnalyzer",
+            fun() ->
+                AwsConfig = ?TEST_AWS_CONFIG,
+                meck:expect(
+                    erlcloud_httpc, request,
+                    fun(A1, A2, A3, A4, A5, A6) ->
+                        Url = "https://access-analyzer.us-east-1.amazonaws.com/analyzer/test-1",
+                        Method = get,
+                        RequestContent = <<>>,
+                        case [A1, A2, A3, A4, A5, A6] of
+                            [Url, Method, _Headers, RequestContent, _Timeout, AwsConfig] ->
+                                ResponseContent = <<
+                                    "{"
+                                        "\"analyzer\":{"
+                                            "\"arn\":\"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-1\","
+                                            "\"name\":\"test-1\","
+                                            "\"type\":\"ACCOUNT\","
+                                            "\"createdAt\":\"2022-01-01T01:02:03Z\","
+                                            "\"status\":\"ACTIVE\""
+                                        "}"
+                                    "}"
+                                >>,
+                                {ok, {{200, "OK"}, [], ResponseContent}}
+                        end
+                    end
+                ),
+                Result = erlcloud_access_analyzer:get_analyzer(AwsConfig, _AnalyzerName = "test-1"),
+                Analyzer = [
+                    {<<"arn">>, <<"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-1">>},
+                    {<<"name">>, <<"test-1">>},
+                    {<<"type">>, <<"ACCOUNT">>},
+                    {<<"createdAt">>, <<"2022-01-01T01:02:03Z">>},
+                    {<<"status">>, <<"ACTIVE">>}
+                ],
+                ?assertEqual({ok, Analyzer}, Result)
+            end
+        },
+        {
+            "GetAnalyzer -> not_found",
+            fun() ->
+                AwsConfig = ?TEST_AWS_CONFIG,
+                meck:expect(
+                    erlcloud_httpc, request,
+                    fun(A1, A2, A3, A4, A5, A6) ->
+                        Url = "https://access-analyzer.us-east-1.amazonaws.com/analyzer/test-2",
+                        Method = get,
+                        RequestContent = <<>>,
+                        case [A1, A2, A3, A4, A5, A6] of
+                            [Url, Method, _Headers, RequestContent, _Timeout, AwsConfig] ->
+                                ResponseHeaders = [{"x-amzn-errortype", "ResourceNotFoundException"}],
+                                ResponseContent = <<"{\"message\": \"Analyzer not found\"}">>,
+                                {ok, {{404, "NotFound"}, ResponseHeaders, ResponseContent}}
+                        end
+                    end
+                ),
+                Result = erlcloud_access_analyzer:get_analyzer(AwsConfig, _AnalyzerName = "test-2"),
+                ?assertEqual({error, not_found}, Result)
+            end
+        }
+    ].
+
+create_analyzer_tests(_) ->
+    [
+        {
+            "CreateAnalyzer",
+            fun() ->
+                AwsConfig = ?TEST_AWS_CONFIG,
+                meck:expect(
+                    erlcloud_httpc, request,
+                    fun(A1, A2, A3, A4, A5, A6) ->
+                        Url = "https://access-analyzer.us-east-1.amazonaws.com/analyzer",
+                        Method = put,
+                        RequestContent = <<
+                            "{"
+                                "\"analyzerName\":\"test-1\","
+                                "\"type\":\"ACCOUNT\""
+                            "}"
+                        >>,
+                        case [A1, A2, A3, A4, A5, A6] of
+                            [Url, Method, _Headers, RequestContent, _Timeout, AwsConfig] ->
+                                ResponseContent = <<"{\"arn\":\"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-1\"}">>,
+                                {ok, {{200, "OK"}, [], ResponseContent}}
+                        end
+                    end
+                ),
+                AnalyzerSpec = [
+                    {<<"analyzerName">>, <<"test-1">>},
+                    {<<"type">>, <<"ACCOUNT">>}
+                ],
+                Result = erlcloud_access_analyzer:create_analyzer(AwsConfig, AnalyzerSpec),
+                Arn = <<"arn:aws:access-analyzer:us-east-1:123456789012:analyzer/test-1">>,
+                ?assertEqual({ok, Arn}, Result)
+            end
+        }
+    ].
+
+delete_analyzer_tests(_) ->
+    [
+        {
+            "DeleteAnalyzer",
+            fun() ->
+                AwsConfig = ?TEST_AWS_CONFIG,
+                meck:expect(
+                    erlcloud_httpc, request,
+                    fun(A1, A2, A3, A4, A5, A6) ->
+                        Url = "https://access-analyzer.us-east-1.amazonaws.com/analyzer/test-1",
+                        Method = delete,
+                        RequestContent = <<>>,
+                        case [A1, A2, A3, A4, A5, A6] of
+                            [Url, Method, _Headers, RequestContent, _Timeout, AwsConfig] ->
+                                ResponseContent = <<>>,
+                                {ok, {{200, "OK"}, [], ResponseContent}}
+                        end
+                    end
+                ),
+                Result = erlcloud_access_analyzer:delete_analyzer(AwsConfig, _AnalyzerName = "test-1"),
+                ?assertEqual(ok, Result)
+            end
+        },
+        {
+            "DeleteAnalyzer -> not_found",
+            fun() ->
+                AwsConfig = ?TEST_AWS_CONFIG,
+                meck:expect(
+                    erlcloud_httpc, request,
+                    fun(A1, A2, A3, A4, A5, A6) ->
+                        Url = "https://access-analyzer.us-east-1.amazonaws.com/analyzer/test-1",
+                        Method = delete,
+                        RequestContent = <<>>,
+                        case [A1, A2, A3, A4, A5, A6] of
+                            [Url, Method, _Headers, RequestContent, _Timeout, AwsConfig] ->
+                                ResponseHeaders = [{"x-amzn-errortype", "ResourceNotFoundException"}],
+                                ResponseContent = <<"{\"message\": \"Analyzer not found\"}">>,
+                                {ok, {{404, "NotFound"}, ResponseHeaders, ResponseContent}}
+                        end
+                    end
+                ),
+                Result = erlcloud_access_analyzer:delete_analyzer(AwsConfig, _AnalyzerName = "test-1"),
+                ?assertEqual({error, not_found}, Result)
+            end
+        }
+    ].


### PR DESCRIPTION
A new module is added to support basic operations to manipulate access analyzers.

See https://docs.aws.amazon.com/access-analyzer/latest/APIReference/Welcome.html