### PR TITLE
Add functionality for retrieval of IAM server certificate tags

### DIFF
--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -52,6 +52,8 @@
     get_server_certificate/1, get_server_certificate/2,
     list_server_certificates/0, list_server_certificates/1, list_server_certificates/2,
     list_server_certificates_all/0, list_server_certificates_all/1, list_server_certificates_all/2,
+    list_server_certificate_tags/1, list_server_certificate_tags/2,
+    list_server_certificate_tags_all/1, list_server_certificate_tags_all/2,
     list_instance_profiles/0, list_instance_profiles/1, list_instance_profiles/2,
     list_instance_profiles_all/0, list_instance_profiles_all/1, list_instance_profiles_all/2,
     get_instance_profile/1, get_instance_profile/2,
@@ -690,6 +692,34 @@ list_server_certificates_all(PathPrefix, #aws_config{} = Config)
     DataTypeDef = data_type("ServerCertificateMetadataList"),
     iam_query_all(Config, Action, Params, ItemPath, DataTypeDef).
 
+-spec list_server_certificate_tags(string()) -> {ok, [proplist()]} | {error, any()}.
+list_server_certificate_tags(ServerCertificateName)
+  when is_list(ServerCertificateName) ->
+    list_server_certificate_tags(ServerCertificateName, default_config()).
+
+-spec list_server_certificate_tags(string(), aws_config()) -> {ok, [proplist()]} | {error, any()}.
+list_server_certificate_tags(ServerCertificateName, #aws_config{} = Config)
+  when is_list(ServerCertificateName) ->
+    Action = "ListServerCertificateTags",
+    Params = [{"ServerCertificateName", ServerCertificateName}],
+    ItemPath = "/ListServerCertificateTagsResponse/ListServerCertificateTagsResult/Tags/member",
+    DataTypeDef = data_type("ServerCertificateTags"),
+    iam_query(Config, Action, Params, ItemPath, DataTypeDef).
+
+-spec list_server_certificate_tags_all(string()) -> {ok, [proplist()]} | {error, any()}.
+list_server_certificate_tags_all(ServerCertificateName)
+  when is_list(ServerCertificateName) ->
+    list_server_certificate_tags_all(ServerCertificateName, default_config()).
+
+-spec list_server_certificate_tags_all(string(), aws_config()) -> {ok, [proplist()]} | {error, any()}.
+list_server_certificate_tags_all(ServerCertificateName, #aws_config{} = Config)
+  when is_list(ServerCertificateName) ->
+    Action = "ListServerCertificateTags",
+    Params = [{"ServerCertificateName", ServerCertificateName}],
+    ItemPath = "/ListServerCertificateTagsResponse/ListServerCertificateTagsResult/Tags/member",
+    DataTypeDef = data_type("ServerCertificateTags"),
+    iam_query_all(Config, Action, Params, ItemPath, DataTypeDef).
+
 %
 % InstanceProfile
 %
@@ -1148,7 +1178,10 @@ data_type("ServerCertificateMetadataList") ->
      {"Arn", arn, "String"},
      {"Path", path, "String"},
      {"ServerCertificateId", server_certificate_id, "String"},
-     {"ServerCertificateName", server_certificate_name, "String"}].
+     {"ServerCertificateName", server_certificate_name, "String"}];
+data_type("ServerCertificateTags") ->
+    [{"Value", value, "String"},
+     {"Key", key, "String"}].
 
 data_fun("String") -> {erlcloud_xml, get_text};
 data_fun("DateTime") -> {erlcloud_xml, get_time};

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -77,6 +77,9 @@ iam_api_test_() ->
       fun list_server_certificates_input_tests/1,
       fun list_server_certificates_output_tests/1,
       fun list_server_certificates_all_output_tests/1,
+      fun list_server_certificate_tags_input_tests/1,
+      fun list_server_certificate_tags_output_tests/1,
+      fun list_server_certificate_tags_all_output_tests/1,
       fun list_instance_profiles_input_tests/1,
       fun list_instance_profiles_output_tests/1,
       fun list_instance_profiles_all_output_tests/1,
@@ -1906,6 +1909,111 @@ list_server_certificates_all_output_tests(_) ->
         })
     ],
     output_tests_seq(?_f(erlcloud_iam:list_server_certificates_all("test")), Tests).
+
+-define(SERVER_CERTIFICATE_TAGS_RESP,
+    "<ListServerCertificateTagsResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+      <ListServerCertificateTagsResult>
+        <IsTruncated>false</IsTruncated>
+        <Tags>
+          <member>
+            <Key>Dept</Key>
+            <Value>12345</Value>
+          </member>
+          <member>
+            <Key>Team</Key>
+            <Value>Accounting</Value>
+          </member>
+        </Tags>
+      </ListServerCertificateTagsResult>
+      <ResponseMetadata>
+        <RequestId>EXAMPLE8-90ab-cdef-fedc-ba987EXAMPLE</RequestId>
+      </ResponseMetadata>
+    </ListServerCertificateTagsResponse>"
+).
+
+list_server_certificate_tags_input_tests(_) ->
+  Tests = [
+    ?_iam_test({
+      "Test input for returning server certificate tags",
+      ?_f(erlcloud_iam:list_server_certificate_tags("test")),
+      [{"Action", "ListServerCertificateTags"}, {"ServerCertificateName", "test"}]
+    })
+  ],
+  input_tests(?SERVER_CERTIFICATE_TAGS_RESP, Tests).
+
+list_server_certificate_tags_output_tests(_) ->
+  Tests = [
+    ?_iam_test({
+      "Test returning server certificate tags",
+      ?SERVER_CERTIFICATE_TAGS_RESP,
+      {ok, [
+        [{key, "Dept"},
+        {value, "12345"}],
+        [{key, "Team"},
+        {value, "Accounting"}]
+      ]}
+    })
+  ],
+  output_tests(?_f(erlcloud_iam:list_server_certificate_tags("test")), Tests).
+
+-define(SERVER_CERTIFICATE_TAGS_ALL_RESP, [
+    "<ListServerCertificateTagsResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+      <ListServerCertificateTagsResult>
+        <IsTruncated>true</IsTruncated>
+        <Marker>marker</Marker>
+        <Tags>
+          <member>
+            <Key>Dept</Key>
+            <Value>12345</Value>
+          </member>
+          <member>
+            <Key>Team</Key>
+            <Value>Accounting</Value>
+          </member>
+        </Tags>
+      </ListServerCertificateTagsResult>
+      <ResponseMetadata>
+        <RequestId>EXAMPLE8-90ab-cdef-fedc-ba987EXAMPLE</RequestId>
+      </ResponseMetadata>
+    </ListServerCertificateTagsResponse>",
+    "<ListServerCertificateTagsResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+      <ListServerCertificateTagsResult>
+        <IsTruncated>false</IsTruncated>
+        <Tags>
+          <member>
+            <Key>Dept</Key>
+            <Value>00001</Value>
+          </member>
+          <member>
+            <Key>Team</Key>
+            <Value>Engineering</Value>
+          </member>
+        </Tags>
+      </ListServerCertificateTagsResult>
+      <ResponseMetadata>
+        <RequestId>EXAMPLE8-90ab-cdef-fedc-ba987EXAMPLE</RequestId>
+      </ResponseMetadata>
+    </ListServerCertificateTagsResponse>"
+]).
+
+list_server_certificate_tags_all_output_tests(_) ->
+  Tests = [
+    ?_iam_test({
+      "Test returning all pages of server certificate tags",
+      ?SERVER_CERTIFICATE_TAGS_ALL_RESP,
+      {ok, [
+        [{key, "Dept"},
+        {value, "12345"}],
+        [{key, "Team"},
+        {value, "Accounting"}],
+        [{key, "Dept"},
+        {value, "00001"}],
+        [{key, "Team"},
+        {value, "Engineering"}]
+      ]}
+    })
+  ],
+  output_tests_seq(?_f(erlcloud_iam:list_server_certificate_tags_all("test")), Tests).
 
 -define(LIST_INSTANCE_PROFILES_RESP,
         "<ListInstanceProfilesResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">


### PR DESCRIPTION
Add missing functionality to allow retrieval of any tags associated with IAM's Server Certificates.

https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListServerCertificateTags.html