### PR TITLE
add workgroup option to start, create, list query API calls

### DIFF
--- a/src/erlcloud_athena.erl
+++ b/src/erlcloud_athena.erl
@@ -437,7 +437,7 @@ list_query_executions(Config) when is_record(Config, aws_config) ->
 list_query_executions(PaginationMap) when is_map(PaginationMap) ->
     list_query_executions(PaginationMap, [], default_config()).
 
--spec list_query_executions(map(), aws_config()) ->
+-spec list_query_executions(map(), aws_config() | list_query_executions_opts()) ->
     {ok, map()} | {error, any()}.
 list_query_executions(PaginationMap, Config) when is_record(Config, aws_config) ->
     list_query_executions(PaginationMap, [], Config);

--- a/src/erlcloud_athena.erl
+++ b/src/erlcloud_athena.erl
@@ -19,6 +19,7 @@
     create_named_query/4,
     create_named_query/5,
     create_named_query/6,
+    create_named_query/7,
 
     create_prepared_statement/3,
     create_prepared_statement/4,
@@ -46,6 +47,7 @@
     list_named_queries/0,
     list_named_queries/1,
     list_named_queries/2,
+    list_named_queries/3,
 
     list_prepared_statements/1,
     list_prepared_statements/2,
@@ -54,11 +56,13 @@
     list_query_executions/0,
     list_query_executions/1,
     list_query_executions/2,
+    list_query_executions/3,
 
     start_query_execution/4,
     start_query_execution/5,
     start_query_execution/6,
     start_query_execution/7,
+    start_query_execution/8,
 
     stop_query_execution/1,
     stop_query_execution/2,
@@ -170,38 +174,53 @@ batch_get_query_execution(QueryExecutionIds, Config) ->
 %%                            <<"db-name">>,
 %%                            <<"query-name">>,
 %%                            <<"select * from some-tbl">>,
-%%                            <<"optional-query-description">>
+%%                            <<"optional-query-description">>,
+%%                            <<"optional-some-workgroup">>
 %% ).
 %% '
 %%
+-type create_named_query_opts() :: [create_named_query_opt()].
+-type create_named_query_opt()  :: {workgroup, binary()}.
+
 -spec create_named_query(binary(), binary(), binary(), binary()) ->
     {ok, binary()} | {error, any()}.
 create_named_query(ClientReqToken, Db, Name, Query) ->
     Config = default_config(),
-    create_named_query(ClientReqToken, Db, Name, Query, undefined, Config).
+    create_named_query(ClientReqToken, Db, Name, Query, undefined, [], Config).
 
 -spec create_named_query(binary(), binary(), binary(), binary(),
                          aws_config() | binary()) ->
     {ok, binary()} | {error, any()}.
 create_named_query(ClientReqToken, Db, Name, Query, Config)
   when is_record(Config, aws_config) ->
-    create_named_query(ClientReqToken, Db, Name, Query, undefined, Config);
+    create_named_query(ClientReqToken, Db, Name, Query, undefined, [], Config);
 create_named_query(ClientReqToken, Db, Name, Query, Description)
   when is_binary(Description) ->
     Config = default_config(),
-    create_named_query(ClientReqToken, Db, Name, Query, Description, Config).
+    create_named_query(ClientReqToken, Db, Name, Query, Description, [], Config).
+
+-spec create_named_query(binary(), binary(), binary(), binary(),
+                         binary(), aws_config() | create_named_query_opts()) ->
+    {ok, binary()} | {error, any()}.
+create_named_query(ClientReqToken, Db, Name, Query, Description, Config)
+  when is_record(Config, aws_config) ->
+    create_named_query(ClientReqToken, Db, Name, Query, Description, [], Config);
+create_named_query(ClientReqToken, Db, Name, Query, Description, Options)
+  when is_list(Options) ->
+    create_named_query(ClientReqToken, Db, Name, Query, Description, Options, default_config()).
 
 -spec create_named_query(binary(), binary(), binary(), binary(),
                          binary() | undefined,
+                         create_named_query_opts(),
                          aws_config()) ->
     {ok, binary()} | {error, any()}.
-create_named_query(ClientReqToken, Db, Name, Query, Description, Config) ->
-    Request0 = #{<<"ClientRequestToken">> => ClientReqToken,
-                  <<"Database">>          => Db,
-                  <<"Name">>              => Name,
-                  <<"QueryString">>       => Query},
-    Request1 = update_description(Request0, Description),
-    case request(Config, "CreateNamedQuery", Request1) of
+create_named_query(ClientReqToken, Db, Name, Query, Description, Options, Config) ->
+    Params  = encode_params([{description, Description} | Options]),
+    Request = Params#{<<"ClientRequestToken">> => ClientReqToken,
+                      <<"Database">>           => Db,
+                      <<"Name">>               => Name,
+                      <<"QueryString">>        => Query},
+    case request(Config, "CreateNamedQuery", Request) of
         {ok, Res} -> {ok, maps:get(<<"NamedQueryId">>, Res)};
         Error     -> Error
     end.
@@ -222,10 +241,10 @@ create_prepared_statement(WorkGroup, StatementName, QueryStatement, Description)
 
 -spec create_prepared_statement(binary(), binary(), binary(), binary() | undefined, aws_config()) -> ok | {error, any()}.
 create_prepared_statement(WorkGroup, StatementName, QueryStatement, Description, Config) ->
-    Request0 = #{<<"WorkGroup">>      => WorkGroup,
-                 <<"StatementName">>  => StatementName,
-                 <<"QueryStatement">> => QueryStatement},
-    Request = update_description(Request0, Description),
+    Params  = encode_params([{description, Description}]),
+    Request = Params#{<<"WorkGroup">>      => WorkGroup,
+                      <<"StatementName">>  => StatementName,
+                      <<"QueryStatement">> => QueryStatement},
     case request(Config, "CreatePreparedStatement", Request) of
         {ok, _} -> ok;
         Error   -> Error
@@ -339,22 +358,36 @@ get_query_results(QueryExecutionId, PaginationMap, Config) ->
 %%
 %% `
 %% erlcloud_athena:list_named_queries(#{<<"MaxResults">> => 1,
-%%                                      <<"NextToken">>  => <<"some-token">>}).
+%%                                      <<"NextToken">>  => <<"some-token">>,
+%%                                      <<"WorkGroup">>  => <<"some-workgroup">>}).
 %% '
 %%
+-type list_named_queries_opts() :: [list_named_queries_opt()].
+-type list_named_queries_opt()  :: {workgroup, binary()}.
+
 -spec list_named_queries() -> {ok, map()} | {error, any()}.
 list_named_queries() ->
-    list_named_queries(#{}, default_config()).
+    list_named_queries(#{}, undefined, default_config()).
 
--spec list_named_queries(map() | aws_config()) -> {ok, map()} | {error, any()}.
+-spec list_named_queries(map() | aws_config()) ->
+    {ok, map()} | {error, any()}.
 list_named_queries(Config) when is_record(Config, aws_config) ->
-    list_named_queries(#{}, Config);
+    list_named_queries(#{}, undefined, Config);
 list_named_queries(PaginationMap) when is_map(PaginationMap) ->
-    list_named_queries(PaginationMap, default_config()).
+    list_named_queries(PaginationMap, [], default_config()).
 
--spec list_named_queries(map(), aws_config()) -> {ok, map} | {error, any()}.
-list_named_queries(PaginationMap, Config) ->
-    request(Config, "ListNamedQueries", PaginationMap).
+-spec list_named_queries(map(), aws_config() | list_named_queries_opts()) ->
+    {ok, map} | {error, any()}.
+list_named_queries(PaginationMap, Config) when is_record(Config, aws_config) ->
+    list_named_queries(PaginationMap, [], Config);
+list_named_queries(PaginationMap, Options) when is_list(Options) ->
+    list_named_queries(PaginationMap, Options, default_config()).
+
+-spec list_named_queries(map(), list_named_queries_opts(), aws_config()) ->
+    {ok, map} | {error, any()}.
+list_named_queries(PaginationMap, Options, Config) ->
+    Params = encode_params(Options),
+    request(Config, "ListNamedQueries", maps:merge(PaginationMap, Params)).
 
 %% @doc
 %% Athena API:
@@ -390,21 +423,32 @@ list_prepared_statements(WorkGroup, PaginationMap, Config) ->
 %%                                         <<"NextToken">>  => <<"some-token">>}).
 %% '
 %%
+-type list_query_executions_opts() :: [list_query_executions_opt()].
+-type list_query_executions_opt() :: {workgroup, binary()}.
+
 -spec list_query_executions() -> {ok, map()} | {error, any()}.
 list_query_executions() ->
-    list_query_executions(#{}, default_config()).
+    list_query_executions(#{}, [], default_config()).
 
 -spec list_query_executions(map() | aws_config()) ->
     {ok, map()} | {error, any()}.
 list_query_executions(Config) when is_record(Config, aws_config) ->
-    list_query_executions(#{}, Config);
+    list_query_executions(#{}, [], Config);
 list_query_executions(PaginationMap) when is_map(PaginationMap) ->
-    list_query_executions(PaginationMap, default_config()).
+    list_query_executions(PaginationMap, [], default_config()).
 
 -spec list_query_executions(map(), aws_config()) ->
     {ok, map()} | {error, any()}.
-list_query_executions(PaginationMap, Config) ->
-    request(Config, "ListQueryExecutions", PaginationMap).
+list_query_executions(PaginationMap, Config) when is_record(Config, aws_config) ->
+    list_query_executions(PaginationMap, [], Config);
+list_query_executions(PaginationMap, Options) when is_list(Options) ->
+    list_query_executions(PaginationMap, Options, default_config()).
+
+-spec list_query_executions(map(), list_query_executions_opts(), aws_config()) ->
+    {ok, map()} | {error, any()}.
+list_query_executions(PaginationMap, Options, Config) ->
+    Params = encode_params(Options),
+    request(Config, "ListQueryExecutions", maps:merge(PaginationMap, Params)).
 
 %% @doc
 %% Athena API:
@@ -417,15 +461,19 @@ list_query_executions(PaginationMap, Config) ->
 %%                              <<"select * from some-tbl">>,
 %%                              <<"s3://some-bucket">>,
 %%                              <<"SSE_KMS">>,
-%%                              <<"some-kms-key-id">>}]
+%%                              <<"some-kms-key-id">>,
+%%                              <<"optional-some-workgroup">>}]
 %% ).
 %% '
 %%
+-type start_query_execution_opts() :: [start_query_execution_opt()].
+-type start_query_execution_opt()  :: {workgroup, binary()}.
+
 -spec start_query_execution(binary(), binary(), binary(), binary()) ->
     {ok, binary()} | {error, any()}.
 start_query_execution(ClientReqToken, Db, Query, OutputLocation) ->
     start_query_execution(ClientReqToken, Db, Query, OutputLocation, undefined,
-                          undefined, default_config()).
+                          undefined, [], default_config()).
 
 -spec start_query_execution(binary(), binary(), binary(), binary(),
                             aws_config()) ->
@@ -433,7 +481,7 @@ start_query_execution(ClientReqToken, Db, Query, OutputLocation) ->
 start_query_execution(ClientReqToken, Db, Query, OutputLocation, Config)
   when is_record(Config, aws_config) ->
     start_query_execution(ClientReqToken, Db, Query, OutputLocation, undefined,
-                          undefined, Config).
+                          undefined, [], Config).
 
 -spec start_query_execution(binary(), binary(), binary(), binary(),
                             binary() | undefined,
@@ -442,22 +490,40 @@ start_query_execution(ClientReqToken, Db, Query, OutputLocation, Config)
 start_query_execution(ClientReqToken, Db, Query, OutputLocation,
                       EncryptionOption, KmsKey) ->
     start_query_execution(ClientReqToken, Db, Query, OutputLocation,
-                          EncryptionOption, KmsKey, default_config()).
+                          EncryptionOption, KmsKey, [], default_config()).
 
 -spec start_query_execution(binary(), binary(), binary(), binary(),
                             binary() | undefined,
                             binary() | undefined,
-                            aws_config()) ->
+                            aws_config() | start_query_execution_opts()) ->
     {ok, binary()} | {error, any()}.
 start_query_execution(ClientReqToken, Db, Query, OutputLocation,
-                      EncryptionOption, KmsKey, Config) ->
+                      EncryptionOption, KmsKey, Config)
+  when is_record(Config, aws_config)  ->
+    start_query_execution(ClientReqToken, Db, Query, OutputLocation,
+                          EncryptionOption, KmsKey, [], Config);
+start_query_execution(ClientReqToken, Db, Query, OutputLocation,
+                      EncryptionOption, KmsKey, Opts)
+  when is_list(Opts) ->
+    start_query_execution(ClientReqToken, Db, Query, OutputLocation,
+                          EncryptionOption, KmsKey, Opts, default_config()).
+
+-spec start_query_execution(binary(), binary(), binary(), binary(),
+                            binary() | undefined,
+                            binary() | undefined,
+                            map(),
+                            aws_config() | start_query_execution_opts()) ->
+    {ok, binary()} | {error, any()}.
+start_query_execution(ClientReqToken, Db, Query, OutputLocation,
+                      EncryptionOption, KmsKey, Options, Config) ->
+    Params        = encode_params(Options),
     EncryptConfig = get_encrypt_config(EncryptionOption, KmsKey),
     ResultConfig  = EncryptConfig#{<<"OutputLocation">> => OutputLocation},
     QueryExecCtxt = #{<<"Database">> => Db},
-    Request       = #{<<"ClientRequestToken">>    => ClientReqToken,
-                      <<"QueryExecutionContext">> => QueryExecCtxt,
-                      <<"QueryString">>           => Query,
-                      <<"ResultConfiguration">>   => ResultConfig},
+    Request       = Params#{<<"ClientRequestToken">>    => ClientReqToken,
+                            <<"QueryExecutionContext">> => QueryExecCtxt,
+                            <<"QueryString">>           => Query,
+                            <<"ResultConfiguration">>   => ResultConfig},
     case request(Config, "StartQueryExecution", Request) of
         {ok, Res} -> {ok, maps:get(<<"QueryExecutionId">>, Res)};
         Error     -> Error
@@ -489,10 +555,10 @@ update_prepared_statement(WorkGroup, StatementName, QueryStatement, Description)
 
 -spec update_prepared_statement(binary(), binary(), binary(), binary() | undefined, aws_config()) -> ok | {error, any()}.
 update_prepared_statement(WorkGroup, StatementName, QueryStatement, Description, Config) ->
-    Request0 = #{<<"WorkGroup">>      => WorkGroup,
-                 <<"StatementName">>  => StatementName,
-                 <<"QueryStatement">> => QueryStatement},
-    Request = update_description(Request0, Description),
+    Params = encode_params([{description, Description}]),
+    Request = Params#{<<"WorkGroup">>      => WorkGroup,
+                      <<"StatementName">>  => StatementName,
+                      <<"QueryStatement">> => QueryStatement},
     case request(Config, "UpdatePreparedStatement", Request) of
         {ok, _} -> ok;
         Error   -> Error
@@ -566,6 +632,16 @@ get_url(#aws_config{athena_scheme = Scheme,
                     athena_port   = Port}) ->
     Scheme ++ Host ++ ":" ++ integer_to_list(Port).
 
-update_description(Request, undefined)   -> Request;
-update_description(Request, Description) ->
-    maps:put(<<"Description">>, Description, Request).
+encode_params(Params) ->
+  encode_params(Params, []).
+
+encode_params([], Acc) ->
+  maps:from_list(Acc);
+encode_params([{_, undefined} | T], Acc) ->
+  encode_params(T, Acc);
+encode_params([{description, Description} | T], Acc) when is_binary(Description) ->
+  encode_params(T, [{<<"Description">>, Description} | Acc]);
+encode_params([{workgroup, WorkGroup} | T], Acc) when is_binary(WorkGroup) ->
+  encode_params(T, [{<<"WorkGroup">>, WorkGroup} | Acc]);
+encode_params([Option | _], _Acc) ->
+  error({erlcloud_athena, {invalid_parameter, Option}}).

--- a/src/erlcloud_athena.erl
+++ b/src/erlcloud_athena.erl
@@ -367,12 +367,12 @@ get_query_results(QueryExecutionId, PaginationMap, Config) ->
 
 -spec list_named_queries() -> {ok, map()} | {error, any()}.
 list_named_queries() ->
-    list_named_queries(#{}, undefined, default_config()).
+    list_named_queries(#{}, [], default_config()).
 
 -spec list_named_queries(map() | aws_config()) ->
     {ok, map()} | {error, any()}.
 list_named_queries(Config) when is_record(Config, aws_config) ->
-    list_named_queries(#{}, undefined, Config);
+    list_named_queries(#{}, [], Config);
 list_named_queries(PaginationMap) when is_map(PaginationMap) ->
     list_named_queries(PaginationMap, [], default_config()).
 

--- a/src/erlcloud_athena.erl
+++ b/src/erlcloud_athena.erl
@@ -511,8 +511,8 @@ start_query_execution(ClientReqToken, Db, Query, OutputLocation,
 -spec start_query_execution(binary(), binary(), binary(), binary(),
                             binary() | undefined,
                             binary() | undefined,
-                            map(),
-                            aws_config() | start_query_execution_opts()) ->
+                            start_query_execution_opts(),
+                            aws_config()) ->
     {ok, binary()} | {error, any()}.
 start_query_execution(ClientReqToken, Db, Query, OutputLocation,
                       EncryptionOption, KmsKey, Options, Config) ->


### PR DESCRIPTION
Add workgroup option to start_query_execution, create_named_query, list_named_queries and list_query_executions API calls.