### PR TITLE
Return ipv6 range(s) for security group rules

### DIFF
--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -2088,7 +2088,8 @@ extract_ip_permissions(Node) ->
      {users, get_list("groups/item/userId", Node)},
      {groups,
       [extract_user_id_group_pair(Item) || Item <- xmerl_xpath:string("groups/item", Node)]},
-     {ip_ranges, get_list("ipRanges/item/cidrIp", Node)}
+     {ip_ranges, get_list("ipRanges/item/cidrIp", Node)},
+     {ipv6_ranges, get_list("ipv6Ranges/item/cidrIpv6", Node)}
     ].
 
 extract_user_id_group_pair(Node) ->


### PR DESCRIPTION
Previously we didn't return IPv6 CIDR ranges when security group rules contained IPv6 ranges for either the source or destination. This change remedies that.

Also added small amount of test coverage for the describe_security_groups functionality.