### PR TITLE
typo in s3 mfa_delete attribute

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -621,7 +621,7 @@ get_bucket_attribute(BucketName, AttributeName, Config)
                     [{enabled, true}|erlcloud_xml:decode(Attributes, LoggingEnabled)]
             end;
         mfa_delete ->
-            case erlcloud_xml:get_text("/VersioningConfiguration/MFADelete", Doc) of
+            case erlcloud_xml:get_text("/VersioningConfiguration/MfaDelete", Doc) of
                 "Enabled"   -> enabled;
                 _           -> disabled
             end;


### PR DESCRIPTION
Inconsistent documentation caused a bit of a nuisance, but after verification it is indeed `MfaDelete`

![image](https://user-images.githubusercontent.com/18538056/228934613-6569aba0-cd06-4cf4-83a1-6b2b57fcf9e3.png)
