### PR TITLE
Extension of AWS Secrets Manager module

### DIFF
--- a/src/erlcloud_sm.erl
+++ b/src/erlcloud_sm.erl
@@ -9,6 +9,8 @@
 
 %%% API
 -export([
+    create_secret_binary/3, create_secret_binary/4, create_secret_binary/5,
+    create_secret_string/3, create_secret_string/4, create_secret_string/5,
     get_secret_value/2, get_secret_value/3
 ]).
 
@@ -20,6 +22,21 @@
 
 -type get_secret_value_option() :: {version_id | version_stage, binary()}.
 -type get_secret_value_options() :: [get_secret_value_option()].
+
+%% replica region is expected to be a proplist of the following tuples:
+%% [{<<"KmsKeyId">>, binary()}, {<<"Region">>, binary()}]
+-type replica_region() :: [proplist()].
+-type replica_regions() :: [replica_region()].
+
+-type create_secret_option() :: {add_replica_regions, replica_regions()}
+                              | {client_request_token, binary()}
+                              | {description, binary()}
+                              | {force_overwrite_replica_secret, boolean()}
+                              | {kms_key_id, binary()}
+                              | {secret_binary, binary()}
+                              | {secret_string, binary()}
+                              | {tags, proplist()}.
+-type create_secret_options() :: [create_secret_option()].
 
 %%%------------------------------------------------------------------------------
 %%% Library initialization.
@@ -51,6 +68,99 @@ new(AccessKeyID, SecretAccessKey, Host, Port) ->
         sm_port = Port
     }.
 
+
+%%------------------------------------------------------------------------------
+%% CreateSecret - SecretBinary
+%%------------------------------------------------------------------------------
+%% @doc
+%% Creates a new secret binary. The function internally base64-encodes the binary
+%% as it is expected by the AWS SecretManager API, so raw blob is expected
+%% to be passed as an attribute.
+%%
+%% ClientRequestToken is used by AWS for secret versioning purposes.
+%% It is recommended to be a UUID type value, and is requred to be between
+%% 32 and 64 characters.
+%%
+%% To store a text secret use CreateSecret - SecretString version of the function
+%% instead.
+%%
+%% SM API:
+%% [https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_CreateSecret.html]
+%%
+%% Example:
+%% Name = <<"my-secret-binary">>,
+%% ClientRequestToken = <<"7537a353-0de0-4b98-bf55-f8365821ed36">>,
+%% %% some binary to store (say, an RSA private key's exponent)
+%% {[_E, _Pub], [_E, _N, Priv, _P1, _P2, _E1, _E2, _C]} = crypto:generate_key(rsa, {2048,65537}),
+%% erlcloud_sm:create_secret_binary(Name, ClientRequestToken, Priv).
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec create_secret_binary(Name :: binary(), ClientRequestToken :: binary(),
+                           SecretBinary :: binary()) -> sm_response().
+create_secret_binary(Name, ClientRequestToken, SecretBinary) ->
+    create_secret_binary(Name, ClientRequestToken, SecretBinary, []).
+
+-spec create_secret_binary(Name :: binary(), ClientRequestToken :: binary(),
+                           SecretBinary :: binary(),
+                           Opts :: create_secret_options()) -> sm_response().
+create_secret_binary(Name, ClientRequestToken, SecretBinary, Opts) ->
+    create_secret_binary(Name, ClientRequestToken, SecretBinary, Opts, erlcloud_aws:default_config()).
+
+-spec create_secret_binary(Name :: binary(), ClientRequestToken :: binary(),
+                           SecretBinary :: binary(), Opts :: create_secret_options(),
+                           Config :: aws_config()) -> sm_response().
+create_secret_binary(Name, ClientRequestToken, SecretBinary, Opts, Config) ->
+    Secret = {secret_binary, base64:encode(SecretBinary)},
+    create_secret(Name, ClientRequestToken, [Secret | Opts], Config).
+
+%%------------------------------------------------------------------------------
+%% CreateSecret - SecretString
+%%------------------------------------------------------------------------------
+%% @doc
+%% Creates a new secret string. The API expects SecretString is a text data to
+%% encrypt and store in the SecretManager. It is recommended a JSON structure
+%% of key/value pairs is used for the secret value.
+%%
+%% ClientRequestToken is used by AWS for secret versioning purposes.
+%% It is recommended to be a UUID type value, and is requred to be between
+%% 32 and 64 characters.
+%%
+%% To store a binary (which will be base64 encoded by the library, as it is
+%% expected by AWS SecretManager API), use CreateSecret - SecretBinary version
+%% of the function.
+%%
+%% SM API:
+%% [https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_CreateSecret.html]
+%%
+%% Example:
+%% Name = <<"my-secret-string">>,
+%% ClientRequestToken = <<"7537a353-0de0-4b98-bf55-f8365821ed37">>,
+%% %% some user/password json to store
+%% Secret = jsx:encode(#{<<"user">> => <<"my-user">>, <<"password">> => <<"superSecretPassword">>}),
+%% erlcloud_sm:create_secret_string(Name, ClientRequestToken, Secret).
+%%
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec create_secret_string(Name :: binary(), ClientRequestToken :: binary(),
+                           SecretString :: binary()) -> sm_response().
+create_secret_string(Name, ClientRequestToken, SecretString) ->
+    create_secret_string(Name, ClientRequestToken, SecretString, []).
+
+-spec create_secret_string(Name :: binary(), ClientRequestToken :: binary(),
+                           SecretString :: binary(), Opts :: create_secret_options()) -> sm_response().
+create_secret_string(Name, ClientRequestToken, SecretString, Opts) ->
+    create_secret_string(Name, ClientRequestToken, SecretString, Opts, erlcloud_aws:default_config()).
+
+
+-spec create_secret_string(Name :: binary(), ClientRequestToken :: binary(),
+                           SecretString :: binary(), Opts :: create_secret_options(),
+                           Config :: aws_config()) -> sm_response().
+create_secret_string(Name, ClientRequestToken, SecretString, Opts, Config) ->
+    Secret = {secret_string, SecretString},
+    create_secret(Name, ClientRequestToken, [Secret | Opts], Config).
+
 %%------------------------------------------------------------------------------
 %% GetSecretValue
 %%------------------------------------------------------------------------------
@@ -80,6 +190,12 @@ get_secret_value(SecretId, Opts, Config) ->
 %%%------------------------------------------------------------------------------
 %%% Internal Functions
 %%%------------------------------------------------------------------------------
+
+create_secret(SecretName, ClientRequestToken, Opts, Config) ->
+    Opts1 = [{client_request_token, ClientRequestToken} | Opts],
+    Json = create_secret_payload(SecretName, Opts1),
+    sm_request(Config, "secretsmanager.CreateSecret", Json).
+
 
 sm_request(Config, Operation, Body) ->
     case erlcloud_aws:update_config(Config) of
@@ -131,4 +247,20 @@ sm_result_fun(#aws_request{response_type = error,
     Request#aws_request{should_retry = true};
 sm_result_fun(#aws_request{response_type = error, error_type = aws} = Request) ->
     Request#aws_request{should_retry = false}.
+
+create_secret_payload(SecretName, Opts) ->
+    Json = lists:map(
+        fun
+            ({add_replica_regions, Val}) -> {<<"AddReplicaRegions">>, Val};
+            ({client_request_token, Val}) -> {<<"ClientRequestToken">>, Val};
+            ({description, Val}) -> {<<"Description">>, Val};
+            ({force_overwrite_replica_secret, Val}) -> {<<"ForceOverwriteReplicaSecret">>, Val};
+            ({kms_key_id, Val}) -> {<<"KmsKeyId">>, Val};
+            ({secret_binary, Val}) -> {<<"SecretBinary">>, Val}; %% note AWS accepts either SecretBinary or SecretString
+            ({secret_string, Val}) -> {<<"SecretString">>, Val}; %% not both at the same time
+            ({tags, Val}) -> {<<"Tags">>, Val};
+            (Other) -> Other
+        end,
+        [{<<"Name">>, SecretName} | Opts]),
+    Json.
 


### PR DESCRIPTION
Extends the module with the following functions:
 - create_secret_string
 - create_secret_binary
 - delete_resource_policy
 - delete_secret
 - describe_secret
 - get_resource_policy
 - put_resource_policy


Reference: 
https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_Operations.html