### PR TITLE
Handle ipv6 destination cidr block for Route table discovery.

### DIFF
--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -2005,6 +2005,7 @@ extract_route(Node) ->
 extract_route_set(Node) ->
     [
      {destination_cidr_block, get_text("destinationCidrBlock", Node)},
+     {destination_ipv6_cidr_block, get_text("destinationIpv6CidrBlock", Node)},
      {gateway_id, get_text("gatewayId", Node)},
      {nat_gateway_id, get_text("natGatewayId", Node)},
      {instance_id, get_text("instanceId", Node)},


### PR DESCRIPTION
Problem Description
When discovering route tables in AWS, the IPv6 destination CIDR blocks are not being correctly included in the asset description or empty value with wrong tag and the asset key format may not be correctly structured.

Solution Description
Add that "destinationIpv6CidrBlock" tag to handle Ipv6 destination CIDR blocks for Route-table.