### PR TITLE
Token tuple wrapped in call to conver_param/2

### DIFF
--- a/src/erlcloud_cloudformation.erl
+++ b/src/erlcloud_cloudformation.erl
@@ -491,8 +491,9 @@ list_all(Fun, Params, Config, Acc) ->
                 undefined ->
                     lists:foldl(fun erlang:'++'/2, [], [Data | Acc]);
                 _ ->
-                    list_all(Fun, [{next_token, NextToken} | Params],
-                        Config, [Data | Acc])
+                    list_all(Fun, 
+			     [convert_param({next_token, NextToken}) | Params],
+			     Config, [Data | Acc])
             end;
         {error, Reason} ->
             {error, Reason}


### PR DESCRIPTION
Fix for https://github.com/erlcloud/erlcloud/issues/721; solved by @ghost.
@motobob, could you have a look?