### PR TITLE
Instead of SHA-1, sign_get/4 uses SHA256; solves #705

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1076,7 +1076,7 @@ sign_get(Expire_time, BucketName, Key, Config)
         SecurityToken -> "x-amz-security-token:" ++ SecurityToken ++ "\n"
     end,
     To_sign = lists:flatten(["GET\n\n\n", Expires, "\n", SecurityTokenToSign, "/", BucketName, "/", Key]),
-    Sig = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, To_sign)),
+    Sig = base64:encode(erlcloud_util:sha256_mac(Config#aws_config.secret_access_key, To_sign)),
     {Sig, Expires}.
 
 -spec make_link(integer(), string(), string()) -> {integer(), string(), string()}.


### PR DESCRIPTION
In #705, error seems matching AWS recommendations, https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html

- `make_get_url/3` & `make_get_url/4` use `sign_get/4`
- `sign_get/4` used `sha_mac/2`
- instead, the PR uses `sha256_mac/2`.