### PR TITLE
Removed self-references

### DIFF
--- a/src/erlcloud_ddb.erl
+++ b/src/erlcloud_ddb.erl
@@ -664,7 +664,7 @@ batch_get_item_record() ->
        end}
      ]}.
 
--type batch_get_item_return() :: ddb_return(#ddb_batch_get_item{}, [erlcloud_ddb:out_item()]).
+-type batch_get_item_return() :: ddb_return(#ddb_batch_get_item{}, [out_item()]).
 
 -spec batch_get_item(batch_get_item_request_items()) -> batch_get_item_return().
 batch_get_item(RequestItems) ->

--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -969,7 +969,7 @@ list_all_tags_pagination_test_() ->
     meck:sequence(EK, request, 3,
                   [{ok, [{<<"HasMoreTags">>, true},  {<<"Tags">>, Tags1}]},
                    {ok, [{<<"HasMoreTags">>, false}, {<<"Tags">>, Tags2}]}]),
-    Result = erlcloud_kinesis:list_all_tags_for_stream(<<"stream">>),
+    Result = list_all_tags_for_stream(<<"stream">>),
     meck:unload(EK),
     ?_assertEqual({ok, [{<<"k1">>, <<"v1">>},
                         {<<"k2">>, <<"v2">>},


### PR DESCRIPTION
Found with this command:
```shell
git grep -n ':' | perl -nE 'print if m;/([\w_]+)\.erl:.*[^\w_]\g1:[\w_]+\(; && !/%/'
```