### PR TITLE
Add support for DeletionProtectionEnabled in erlcloud_ddb2

### DIFF
--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -156,6 +156,7 @@
         {attribute_definitions :: undefined | erlcloud_ddb2:attr_defs(),
          billing_mode_summary :: undefined | #ddb2_billing_mode_summary{},
          creation_date_time :: undefined | number(),
+         deletion_protection_enabled :: undefined | boolean(),
          global_secondary_indexes :: undefined | [#ddb2_global_secondary_index_description{}],
          global_table_version :: undefined | binary(),
          item_count :: undefined | integer(),

--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -168,6 +168,7 @@
     delete_item_opts/0,
     delete_item_return/0,
     delete_table_return/0,
+    deletion_protection_enabled/0,
     describe_global_table_return/0,
     describe_global_table_settings_return/0,
     describe_table_return/0,
@@ -381,6 +382,8 @@ default_config() -> erlcloud_aws:default_config().
                      {attr_name(), {in_attr_value(), in_attr_value()}, between} |
                      {attr_name(), [in_attr_value(),...], in}.
 -type conditions() :: maybe_list(condition()).
+
+-type deletion_protection_enabled() :: boolean_opt(deletion_protection_enabled).
 
 -type select() :: all_attributes | all_projected_attributes | count | specific_attributes.
 
@@ -1439,6 +1442,7 @@ table_description_record() ->
      [{<<"AttributeDefinitions">>, #ddb2_table_description.attribute_definitions, fun undynamize_attr_defs/2},
       {<<"BillingModeSummary">>, #ddb2_table_description.billing_mode_summary, fun undynamize_billing_mode_summary/2},
       {<<"CreationDateTime">>, #ddb2_table_description.creation_date_time, fun id/2},
+      {<<"DeletionProtectionEnabled">>, #ddb2_table_description.deletion_protection_enabled, fun id/2},
       {<<"GlobalSecondaryIndexes">>, #ddb2_table_description.global_secondary_indexes,
        fun(V, Opts) -> [undynamize_record(global_secondary_index_description_record(), I, Opts) || I <- V] end},
       {<<"GlobalTableVersion">>, #ddb2_table_description.global_table_version, fun id/2},
@@ -1892,7 +1896,8 @@ dynamize_sse_specification({enabled, Enabled}) when is_boolean(Enabled) ->
                             {global_secondary_indexes, global_secondary_indexes()} |
                             {provisioned_throughput, {read_units(), write_units()}} |
                             {sse_specification, sse_specification()} |
-                            {stream_specification, stream_specification()}.
+                            {stream_specification, stream_specification()} |
+                            boolean_opt(deletion_protection_enabled).
 -type create_table_opts() :: [create_table_opt()].
 
 -spec create_table_opts(key_schema()) -> opt_table().
@@ -1904,7 +1909,8 @@ create_table_opts(KeySchema) ->
       fun dynamize_global_secondary_indexes/1},
      {provisioned_throughput, <<"ProvisionedThroughput">>, fun dynamize_provisioned_throughput/1},
      {sse_specification, <<"SSESpecification">>, fun dynamize_sse_specification/1},
-     {stream_specification, <<"StreamSpecification">>, fun dynamize_stream_specification/1}].
+     {stream_specification, <<"StreamSpecification">>, fun dynamize_stream_specification/1},
+     {deletion_protection_enabled, <<"DeletionProtectionEnabled">>, fun id/1}].
 
 -spec create_table_record() -> record_desc().
 create_table_record() ->
@@ -4271,6 +4277,7 @@ dynamize_replication_group_updates(Updates) ->
                             {attribute_definitions, attr_defs()} |
                             {global_secondary_index_updates, global_secondary_index_updates()} |
                             {stream_specification, stream_specification()} |
+                            boolean_opt(deletion_protection_enabled) |
                             out_opt().
 -type update_table_opts() :: [update_table_opt()].
 
@@ -4282,7 +4289,8 @@ update_table_opts() ->
      {global_secondary_index_updates, <<"GlobalSecondaryIndexUpdates">>,
       fun dynamize_global_secondary_index_updates/1},
      {stream_specification, <<"StreamSpecification">>, fun dynamize_stream_specification/1},
-     {replica_updates, <<"ReplicaUpdates">>, fun dynamize_replication_group_updates/1}].
+     {replica_updates, <<"ReplicaUpdates">>, fun dynamize_replication_group_updates/1},
+     {deletion_protection_enabled, <<"DeletionProtectionEnabled">>, fun id/1}].
 
 -spec update_table_record() -> record_desc().
 update_table_record() ->

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -1372,6 +1372,95 @@ create_table_input_tests(_) ->
         }
     ]
 }"
+            }),
+         ?_ddb_test(
+            {"CreateTable with deletion_protection_enabled = true",
+             ?_f(erlcloud_ddb2:create_table(
+                   <<"Thread">>,
+                   [{<<"ForumName">>, s},
+                    {<<"Subject">>, s},
+                    {<<"LastPostDateTime">>, s}],
+                   {<<"ForumName">>, <<"Subject">>},
+                   5,
+                   5,
+                   [{local_secondary_indexes,
+                     [{<<"LastPostIndex">>, <<"LastPostDateTime">>, keys_only}]},
+                    {global_secondary_indexes,
+                     [{<<"SubjectIndex">>, {<<"Subject">>, <<"LastPostDateTime">>}, keys_only, 10, 5}]},
+                    {deletion_protection_enabled, true}]
+                  )), "
+{
+    \"AttributeDefinitions\": [
+        {
+            \"AttributeName\": \"ForumName\",
+            \"AttributeType\": \"S\"
+        },
+        {
+            \"AttributeName\": \"Subject\",
+            \"AttributeType\": \"S\"
+        },
+        {
+            \"AttributeName\": \"LastPostDateTime\",
+            \"AttributeType\": \"S\"
+        }
+    ],
+    \"GlobalSecondaryIndexes\": [
+        {
+            \"IndexName\": \"SubjectIndex\",
+            \"KeySchema\": [
+                {
+                    \"AttributeName\": \"Subject\",
+                    \"KeyType\": \"HASH\"
+                },
+                {
+                    \"AttributeName\": \"LastPostDateTime\",
+                    \"KeyType\": \"RANGE\"
+                }
+            ],
+            \"Projection\": {
+                \"ProjectionType\": \"KEYS_ONLY\"
+            },
+            \"ProvisionedThroughput\": {
+                \"ReadCapacityUnits\": 10,
+                \"WriteCapacityUnits\": 5
+            }
+        }
+    ],
+    \"DeletionProtectionEnabled\": true,
+    \"TableName\": \"Thread\",
+    \"KeySchema\": [
+        {
+            \"AttributeName\": \"ForumName\",
+            \"KeyType\": \"HASH\"
+        },
+        {
+            \"AttributeName\": \"Subject\",
+            \"KeyType\": \"RANGE\"
+        }
+    ],
+    \"LocalSecondaryIndexes\": [
+        {
+            \"IndexName\": \"LastPostIndex\",
+            \"KeySchema\": [
+                {
+                    \"AttributeName\": \"ForumName\",
+                    \"KeyType\": \"HASH\"
+                },
+                {
+                    \"AttributeName\": \"LastPostDateTime\",
+                    \"KeyType\": \"RANGE\"
+                }
+            ],
+            \"Projection\": {
+                \"ProjectionType\": \"KEYS_ONLY\"
+            }
+        }
+    ],
+    \"ProvisionedThroughput\": {
+        \"ReadCapacityUnits\": 5,
+        \"WriteCapacityUnits\": 5
+    }
+}"
             })
         ],
 
@@ -3086,7 +3175,8 @@ describe_table_output_tests(_) ->
         },
         \"TableName\": \"Thread\",
         \"TableSizeBytes\": 0,
-        \"TableStatus\": \"ACTIVE\"
+        \"TableStatus\": \"ACTIVE\",
+        \"DeletionProtectionEnabled\": true
     }
 }",
              {ok, #ddb2_table_description
@@ -3132,7 +3222,8 @@ describe_table_output_tests(_) ->
                                                      replica_status = active}],
                table_name = <<"Thread">>,
                table_size_bytes = 0,
-               table_status = active}}})
+               table_status = active,
+               deletion_protection_enabled = true}}})
         ],
 
     output_tests(?_f(erlcloud_ddb2:describe_table(<<"name">>)), Tests).
@@ -6688,6 +6779,15 @@ update_table_input_tests(_) ->
 {
     \"TableName\": \"Thread\",
     \"BillingMode\": \"PAY_PER_REQUEST\"
+}"
+            }),
+        ?_ddb_test(
+            {"UpdateTable example request deletion_protection_enabled = false",
+             ?_f(erlcloud_ddb2:update_table(<<"Thread">>,
+                                            [{deletion_protection_enabled, false}])), "
+{
+    \"TableName\": \"Thread\",
+    \"DeletionProtectionEnabled\": false
 }"
             })
         ],


### PR DESCRIPTION
Enable setting deletion protection enabled for [Update](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html) and [Create](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html#DDB-CreateTable-request-DeletionProtectionEnabled) table. 