### PR TITLE
Small Cleanup - Apply fixes

### DIFF
--- a/src/erlcloud_as.erl
+++ b/src/erlcloud_as.erl
@@ -357,7 +357,6 @@ create_launch_config(#aws_launch_config{
           ++ when_defined(Monitoring, [{"InstanceMonitoring.Enabled", atom_to_list(Monitoring)}], [])
           ++ member_params("SecurityGroups.member.", SGroups)
           ++ when_defined(KeyPair, [{"KeyName", KeyPair}], []),
-    io:format("~p ~n", [Params]),
     create_launch_config(Params, Config);
 
 create_launch_config(Params, Config) ->

--- a/src/erlcloud_as.erl
+++ b/src/erlcloud_as.erl
@@ -29,7 +29,9 @@
 
          describe_lifecycle_hooks/1, describe_lifecycle_hooks/2, describe_lifecycle_hooks/3,
          complete_lifecycle_action/4, complete_lifecycle_action/5,
-         record_lifecycle_action_heartbeat/3, record_lifecycle_action_heartbeat/4
+         record_lifecycle_action_heartbeat/3, record_lifecycle_action_heartbeat/4,
+
+         query/4,prepare_action_params/1
 ]).
 
 -define(API_VERSION, "2011-01-01").
@@ -82,6 +84,12 @@
 -define(RECORD_LIFECYCLE_ACTION_HEARTBEAT_ACTIVITY, 
         "/RecordLifecycleActionHeartbeatResponse/ResponseMetadata/RequestId").
 
+    
+-type ok_error() :: ok | {error, term()}.
+-type query_opts() :: #{
+    api_version => string(),
+    response_format => map | none
+}.
 
 %% --------------------------------------------------------------------
 %% @doc Calls describe_groups([], default_configuration())
@@ -763,15 +771,8 @@ extract_as_activity(A) ->
 get_text(Label, Doc) ->
     erlcloud_xml:get_text(Label, Doc).
 
-%% @TODO:  spec is too general with terms I think
--spec as_query(aws_config(), string(), list({string(), term()}), string()) -> {ok, #xmlElement{}} | {error, term()}.
-as_query(Config, Action, Params, ApiVersion) ->
-    QParams = [{"Action", Action}, {"Version", ApiVersion}|Params],
-    erlcloud_aws:aws_request_xml4(post, Config#aws_config.as_host,
-                                  "/", QParams, "autoscaling", Config).
-
-
 when_defined(Value, Return, DefaultReturn) ->
+
     case Value of 
         undefined ->
             DefaultReturn;
@@ -795,3 +796,32 @@ tag_to_member_param(#aws_autoscaling_tag{
       when_defined(ResourceId, {Prefix ++ "ResourceId", ResourceId}, []),
       when_defined(ResourceType, {Prefix ++ "ResourceType", ResourceType}, [])
     ].
+
+%% @TODO:  spec is too general with terms I think
+-spec as_query(aws_config(), string(), list({string(), term()}), string()) -> {ok, #xmlElement{}} | {error, term()}.
+as_query(Config, Action, Params, ApiVersion) ->
+    QParams = [{"Action", Action}, {"Version", ApiVersion}|Params],
+    erlcloud_aws:aws_request_xml4(post, Config#aws_config.as_host,
+                                  "/", QParams, "autoscaling", Config).
+
+-spec query(aws_config(), string(), map(), query_opts()) -> ok_error().
+query(Config, Action, Params, Opts) ->
+    ApiVersion= maps:get(version, Opts, ?API_VERSION),
+    ResponseFormat = maps:get(response_format, Opts, none),
+    erlcloud_aws:parse_response(do_query(Config, Action, Params, ApiVersion), ResponseFormat).
+
+prepare_action_params(ParamsMap) when is_map(ParamsMap) ->
+    erlcloud_aws:process_params(ParamsMap, <<>>, <<"member">>).
+
+do_query(Config, Action, MapParams, ApiVersion) -> 
+    Params = prepare_action_params(MapParams),
+    case as_query(Config, Action, Params, ApiVersion) of
+        {ok, Results} ->
+            {ok, Results};
+        % AWS will return a 412 if a dry run is performed and is successful
+        {error, {http_error, 412, _, _}} -> 
+            {ok, dry_run_success};
+        {error, _} = E -> E
+    end.
+
+

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -25,7 +25,10 @@
          get_service_status/1,
          is_throttling_error_response/1,
          get_timeout/1,
-         profile/0, profile/1, profile/2
+         profile/0, profile/1, profile/2,
+         concat_key/2,
+         to_bitstring/1,value_to_string/1,
+         parse_response/2, process_params/1, process_params/2, process_params/3
 ]).
 
 -include("erlcloud.hrl").
@@ -285,7 +288,6 @@ do_aws_request_form_raw(Method, Scheme, Host, Port, Path, Form, Headers, QuerySt
     %%       Many timeout related failures is observed at prod env
     %%       when library is used in 24/7 manner
     Response = erlcloud_retry:request(Config, AwsRequest, ResultFun),
-
     show_headers(ShowRespHeaders, request_to_return(Response)).
 
 show_headers(true, {ok, {Headers, Body}}) ->
@@ -1522,15 +1524,11 @@ profiles_assume( Credential, Role, ExternalId,
         erlcloud_sts:assume_role( Config, Role, Name, Duration, ExtId ),
     {ok, AssumedConfig}.
 
-
 config_credential({Id, Secret}, Config) ->
     Config#aws_config{ access_key_id = Id, secret_access_key = Secret };
 config_credential({Id, Secret, Token}, Config) ->
     Config#aws_config{ access_key_id = Id, secret_access_key = Secret, security_token = Token };
 config_credential(#aws_config{} = Config, _) -> Config.
-
-
-
 
 error_msg( Message ) ->
     Error = iolist_to_binary( Message ),
@@ -1572,3 +1570,50 @@ maybe_imdsv2_session_token(Config) ->
         {ok, Token} -> Token;
         _Error -> undefined
     end.
+
+%%%%%%%%%%%%%%%%%
+
+% Takes the query response and turns it into a map if desired
+parse_response({ok, Response}, map) ->
+    {ok, _Res} = erlcloud_xml:xml_to_map(Response);
+parse_response({ok, Response}, _) ->
+    {ok, Response};
+parse_response({error, _} = ErrRes, _Format) -> 
+    ErrRes.
+
+concat_key(<<>>, Key) when is_bitstring(Key); is_atom(Key)  ->
+    to_bitstring(Key);
+concat_key(<<>>, Key) when is_list(Key) -> 
+    list_to_bitstring(Key);
+concat_key(ParentKey, Key) ->
+    BiParentKey = to_bitstring(ParentKey),
+    BiKey = to_bitstring(Key),
+    <<BiParentKey/binary, ".", BiKey/binary>>.
+
+%%% Conversions
+to_bitstring(In) when is_bitstring(In) ->
+    In;
+to_bitstring(In) when is_list(In) ->
+    list_to_binary(In);
+to_bitstring(In) when is_atom(In) ->
+    erlang:atom_to_binary(In, utf8).
+
+process_params(Params) ->
+    process_params(Params, <<>>, <<>>).
+process_params(Params, ParentKey) ->
+    process_params(Params, ParentKey, <<>>).
+process_params(Params, ParentKey, ListPrependStr) when is_map(Params) ->
+    process_params2(maps:to_list(Params), ParentKey, ListPrependStr);
+    
+process_params(Params, ParentKey, ListPrependStr) when is_list(Params) ->
+    Indexes = lists:seq(1, length(Params)),
+    BinIndexes = [ erlcloud_aws:concat_key(ListPrependStr, integer_to_binary(Index)) || Index <- Indexes],
+    process_params2(lists:zip(BinIndexes, Params), ParentKey, ListPrependStr);
+    
+process_params(Value, ParentKey, _)  ->
+    [{ParentKey, Value}].
+    
+process_params2(KV, ParentKey, ListPrependStr) ->
+    [ Result || {Key, Param} <- KV,
+        Result <- process_params(Param, erlcloud_aws:concat_key(ParentKey, Key), ListPrependStr)].
+

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -1574,6 +1574,8 @@ maybe_imdsv2_session_token(Config) ->
 %%%%%%%%%%%%%%%%%
 
 % Takes the query response and turns it into a map if desired
+parse_response({ok, Response}, _) when is_atom(Response) ->
+    {ok, Response};
 parse_response({ok, Response}, map) ->
     {ok, _Res} = erlcloud_xml:xml_to_map(Response);
 parse_response({ok, Response}, _) ->

--- a/test/erlcloud_xml_tests.erl
+++ b/test/erlcloud_xml_tests.erl
@@ -1,0 +1,67 @@
+-module(erlcloud_xml_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include("erlcloud.hrl").
+
+start() ->
+    ok.
+
+stop(_) ->
+    ok.
+
+xml_test_() ->
+    {foreach, 
+    fun start/0, 
+    fun stop/1, 
+    [
+        fun parse_xml_test/0
+    ]}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% 
+
+parse_xml_test() ->
+    Xml = 
+    "<DescribeInstancesResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\">
+        <requestId>8f7724cf-496f-496e-8fe3-example</requestId>
+        <reservationSet>
+            <item>
+                <reservationId>r-1234567890abcdef0</reservationId>
+                <ownerId>123456789012</ownerId>
+                <groupSet/>
+                <instancesSet>
+                    <item>
+                        <instanceId>i-1234567890abcdef0</instanceId>
+                        <imageId>ami-bff32ccc</imageId>
+                    </item>
+                </instancesSet>
+            </item>
+            <item>
+                <reservationId>r-abc</reservationId>
+                <ownerId>123456789012</ownerId>
+                <groupSet/>
+                <instancesSet>
+                    <item>
+                        <instanceId>i-abc</instanceId>
+                        <imageId>ami-bff32ccc</imageId>
+                    </item>
+                </instancesSet>
+            </item>
+        </reservationSet>
+    </DescribeInstancesResponse>", 
+    XmerlRaw = xmerl_scan:string(Xml), % Parse into xmerl structure
+    Xmerl = element(1,XmerlRaw),
+    Result = erlcloud_xml:xml_to_map(Xmerl),
+    Expected = {ok,#{'DescribeInstancesResponse' =>
+                  #{requestId => <<"8f7724cf-496f-496e-8fe3-example">>,
+                    reservationSet =>
+                        [#{ownerId => <<"123456789012">>,groupSet => [],
+                           reservationId => <<"r-1234567890abcdef0">>,
+                           instancesSet =>
+                               [#{instanceId => <<"i-1234567890abcdef0">>,
+                                  imageId => <<"ami-bff32ccc">>}]},
+                         #{ownerId => <<"123456789012">>,groupSet => [],
+                           reservationId => <<"r-abc">>,
+                           instancesSet =>
+                               [#{instanceId => <<"i-abc">>,
+                                  imageId => <<"ami-bff32ccc">>}]}]}}},
+    ?assertEqual(Expected, Result).


### PR DESCRIPTION
There were a couple of small issues identified in testing by @nkrylov

This PR applies these changes:

1. Remove redundant logging
2. Update `parse_response` to catch when the response is an atom - which is the case for dry runs.