### PR TITLE
Issue 773: allow to skip content-type header for all empty-body requests

### DIFF
--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -68,14 +68,7 @@ request_lhttpc(URL, Method, Hdrs, Body, Timeout, #aws_config{lhttpc_pool = Pool,
     LHttpcOpts = [{pool, Pool}, {pool_ensure, true}, {proxy, HttpProxy}],
     lhttpc:request(URL, Method, Hdrs, Body, Timeout, LHttpcOpts).
 
-%% Guard clause protects against empty bodied requests from being
-%% unable to find a matching httpc:request call.
-request_httpc(URL, Method, Hdrs, <<>>, Timeout, _Config) 
-    when (Method =:= options) orelse 
-         (Method =:= get) orelse 
-         (Method =:= head) orelse 
-         (Method =:= delete) orelse 
-         (Method =:= trace) ->
+request_httpc(URL, Method, Hdrs, <<>>, Timeout, _Config) ->
     HdrsStr = [{to_list_string(K), to_list_string(V)} || {K, V} <- Hdrs],
     response_httpc(httpc:request(Method, {URL, HdrsStr},
                                  [{timeout, Timeout}],


### PR DESCRIPTION
https://github.com/erlcloud/erlcloud/issues/773

Enables creation of session token with httpc.